### PR TITLE
For testing use the products backend for projections

### DIFF
--- a/src/commercetools/services/product_projections.py
+++ b/src/commercetools/services/product_projections.py
@@ -16,7 +16,7 @@ class _ProductProjectionsBaseSchema(Schema, abstract.RemoveEmptyValuesMixin):
     limit = fields.Int()
     offset = fields.Int()
 
-    staged = fields.Bool(data_key="staged", required=False)
+    staged = fields.Bool(data_key="staged", required=False, missing=False)
     price_currency = fields.String(data_key="priceCurrency")
     price_country = fields.String(data_key="priceCountry")
     price_customer_group = fields.UUID(data_key="priceCustomerGroup")

--- a/src/commercetools/testing/__init__.py
+++ b/src/commercetools/testing/__init__.py
@@ -5,9 +5,9 @@ import wrapt
 
 from commercetools.testing.auth import AuthBackend
 from commercetools.testing.categories import CategoriesBackend
-from commercetools.testing.products import ProductsBackend
 from commercetools.testing.product_projections import ProductProjectionsBackend
 from commercetools.testing.product_types import ProductTypesBackend
+from commercetools.testing.products import ProductsBackend
 
 
 class BackendRepository:
@@ -15,7 +15,7 @@ class BackendRepository:
         self.auth = AuthBackend()
         self.categories = CategoriesBackend()
         self.products = ProductsBackend()
-        self.product_projections = ProductProjectionsBackend()
+        self.product_projections = ProductProjectionsBackend(model=self.products.model)
         self.product_types = ProductTypesBackend()
 
     def register(self, adapter):

--- a/src/commercetools/testing/abstract.py
+++ b/src/commercetools/testing/abstract.py
@@ -23,8 +23,8 @@ class BaseModel:
 class BaseBackend:
     path = None
 
-    def __init__(self):
-        self.model = self.model_class()
+    def __init__(self, model=None):
+        self.model = model if model is not None else self.model_class()
 
     def register(self, adapter):
         adapter.add_matcher(self._matcher)

--- a/src/commercetools/testing/products.py
+++ b/src/commercetools/testing/products.py
@@ -13,7 +13,15 @@ class ProductsModel(BaseModel):
         self.objects[obj.id] = obj
         return obj
 
-    def convert_product_draft(self, obj):
+    def convert_product_draft(self, obj: types.ProductDraft):
+        product = types.Product(
+            id=str(uuid.uuid4()),
+            key=obj.key,
+            version=1,
+            created_at=datetime.datetime.now(),
+            last_modified_at=datetime.datetime.now(),
+        )
+
         product_data = types.ProductData(
             name=obj.name,
             categories=obj.categories,
@@ -22,18 +30,15 @@ class ProductsModel(BaseModel):
             slug=obj.slug,
         )
 
-        product_catalog_data = types.ProductCatalogData(
-            staged=product_data, published=False
-        )
+        if obj.publish:
+            product.master_data = types.ProductCatalogData(
+                staged=None, current=product_data, published=True
+            )
+        else:
+            product.master_data = types.ProductCatalogData(
+                staged=product_data, current=None, published=False
+            )
 
-        product = types.Product(
-            id=str(uuid.uuid4()),
-            key=obj.key,
-            version=1,
-            created_at=datetime.datetime.now(),
-            last_modified_at=datetime.datetime.now(),
-            master_data=product_catalog_data,
-        )
         return product
 
 

--- a/tests/test_service_product_projections.py
+++ b/tests/test_service_product_projections.py
@@ -1,30 +1,48 @@
 import pytest
 from requests.exceptions import HTTPError
 
+from commercetools import types
+
 
 def test_product_projections_get_by_id(client):
-    product = client.product_projections.get_by_id("0001")
-    assert product.id == "0001"
-    assert product.key == "product-1"
+    product_create = client.products.create(
+        types.ProductDraft(key="test-product1", publish=False)
+    )
+    product = client.product_projections.get_by_id(product_create.id)
+    assert product.id == product_create.id
+    assert product.key == product_create.key
 
-    with pytest.raises(HTTPError) as e:
+
+def test_product_projections_get_by_id_not_found(client):
+    with pytest.raises(HTTPError):
         client.products.get_by_id("invalid")
 
 
 def test_product_projections_get_by_key(client):
-    product = client.product_projections.get_by_key("product-1")
-    assert product.id == "0001"
-    assert product.key == "product-1"
+    product_create = client.products.create(
+        types.ProductDraft(key="test-product1", publish=False)
+    )
+    product = client.product_projections.get_by_key(product_create.key)
+    assert product.id == product_create.id
+    assert product.key == product_create.key
 
-    with pytest.raises(HTTPError) as e:
+
+def test_product_projections_get_by_key_not_found(client):
+    with pytest.raises(HTTPError):
         client.products.get_by_key("invalid")
 
 
 def test_product_projections_query(client):
+    for key in ["product-1", "product-2"]:
+        client.products.create(types.ProductDraft(key=key, publish=True))
+    client.products.create(types.ProductDraft(key=key, publish=False))
+
     # single sort query
     result = client.product_projections.query(sort="id asc")
     assert len(result.results) == 2
     assert result.total == 2
+    assert result.results[0].key == "product-1"
+    assert result.results[1].key == "product-2"
 
     # multiple sort queries
     result = client.product_projections.query(sort=["id asc", "name asc"])

--- a/tests/test_service_products.py
+++ b/tests/test_service_products.py
@@ -1,7 +1,8 @@
 import pytest
 import requests_mock
-from commercetools import types
 from requests.exceptions import HTTPError
+
+from commercetools import types
 
 
 def test_products_get_by_id(client):
@@ -49,7 +50,7 @@ def test_product_query(client):
 
 def test_product_update(client):
     """Test the return value of the update methods.
-    
+
     It doesn't test the actual update itself.
     TODO: See if this is worth testing since we're using a mocking backend
     """


### PR DESCRIPTION
With this change it is now possible to manage the products via the
products api and search them via the product projections backend.