### PR TITLE
Removed /oauth/token path from token_url setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ deserialization steps.
         client_secret="<your-client-secret>",
         scope=["<scopes>"],
         url="https://api.sphere.io", 
-        token_url="https://auth.sphere.io/oauth/token",
+        token_url="https://auth.sphere.io",
     )
 
     product = client.products.get_by_id("00633d11-c5bb-434e-b132-73f7e130b4e3")

--- a/src/commercetools/client.py
+++ b/src/commercetools/client.py
@@ -58,6 +58,7 @@ class Client:
         token = self._token_saver.get_token(
             self._config["client_id"], self._config["scope"]
         )
+        token_oauth_url = f"{self._config['token_url']}/oauth/token"
 
         client = BackendApplicationClient(
             client_id=self._config["client_id"], scope=self._config["scope"]
@@ -65,7 +66,7 @@ class Client:
         self._http_client = OAuth2Session(
             client=client,
             scope=self._config["scope"],
-            auto_refresh_url=self._config["token_url"],
+            auto_refresh_url=token_oauth_url,
             auto_refresh_kwargs={
                 "client_id": self._config["client_id"],
                 "client_secret": self._config["client_secret"],
@@ -76,7 +77,7 @@ class Client:
             self._http_client.token = token
         else:
             token = self._http_client.fetch_token(
-                token_url=self._config["token_url"],
+                token_url=token_oauth_url,
                 scope=self._config["scope"],
                 client_id=self._config["client_id"],
                 client_secret=self._config["client_secret"],
@@ -153,8 +154,6 @@ class Client:
 
         if not config.get("token_url"):
             config["token_url"] = os.environ.get("CTP_AUTH_URL")
-            if config["token_url"]:
-                config["token_url"] += "/oauth/token"
 
         if not config["scope"]:
             config["scope"] = os.environ.get("CTP_SCOPES")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,5 +23,5 @@ def client():
             client_secret="client-secret",
             scope=[],
             url="https://api.sphere.io",
-            token_url="https://auth.sphere.io/oauth/token",
+            token_url="https://auth.sphere.io",
         )

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -28,7 +28,7 @@ def test_auto_refresh(commercetools_api):
             client_secret="mysecret",
             project_key="test",
             url="https://api.sphere.io",
-            token_url="https://auth.sphere.io/oauth/token",
+            token_url="https://auth.sphere.io",
         )
         client.products.query()
         with freeze_time("2018-11-01"):
@@ -52,7 +52,7 @@ def test_cache_token(commercetools_api):
         client_secret="none",
         project_key="test",
         url="https://api.sphere.io",
-        token_url="https://auth.sphere.io/oauth/token",
+        token_url="https://auth.sphere.io",
     )
     assert len(commercetools_api.requests_mock.request_history) == 1
 
@@ -61,6 +61,6 @@ def test_cache_token(commercetools_api):
         client_secret="none",
         project_key="test",
         url="https://api.sphere.io",
-        token_url="https://auth.sphere.io/oauth/token",
+        token_url="https://auth.sphere.io",
     )
     assert len(commercetools_api.requests_mock.request_history) == 1


### PR DESCRIPTION
Conform the commercetools-nodejs-sdk we shouldn't add /oauth/token to the sdk client setting.

From now the AUTH_URL should be `https://auth.sphere.io` instead of `https://auth.sphere.io/oauth/token`