### PR TITLE
Make the Client's token_url completely configurable

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -42,7 +42,7 @@ Example
         client_secret="<your-client-secret>",
         scope=["<scopes>"],
         url="https://api.sphere.io",
-        token_url="https://auth.sphere.io",
+        token_url="https://auth.sphere.io/oauth/token",
     )
 
     product = client.products.get_by_id("00633d11-c5bb-434e-b132-73f7e130b4e3")

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -27,7 +27,7 @@ Example
         client_secret="<your-client-secret>",
         scope=["<scopes>"],
         url="https://api.sphere.io",
-        token_url="https://auth.sphere.io",
+        token_url="https://auth.sphere.io/oauth/token",
     )
 
     product = client.products.get_by_id("00633d11-c5bb-434e-b132-73f7e130b4e3")

--- a/src/commercetools/client.py
+++ b/src/commercetools/client.py
@@ -74,7 +74,7 @@ class Client:
         token = self._token_saver.get_token(
             self._config["client_id"], self._config["scope"]
         )
-        token_oauth_url = f"{self._config['token_url']}/oauth/token"
+        token_oauth_url = self._config['token_url']
 
         client = BackendApplicationClient(
             client_id=self._config["client_id"], scope=self._config["scope"]

--- a/src/commercetools/contrib/pytest.py
+++ b/src/commercetools/contrib/pytest.py
@@ -22,7 +22,7 @@ def commercetools_client(commercetools_api) -> typing.Generator[Client, None, No
         client_secret="client-secret",
         scope=[],
         url="https://api.sphere.io",
-        token_url="https://auth.sphere.io",
+        token_url="https://auth.sphere.io/oauth/token",
     )
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -13,7 +13,7 @@ def client_environment_settings(monkeypatch):
     monkeypatch.setenv("CTP_CLIENT_SECRET", "client_secret")
     monkeypatch.setenv("CTP_CLIENT_SCOPES", "some_scope")
     monkeypatch.setenv("CTP_API_URL", "https://api.shere.io")
-    monkeypatch.setenv("CTP_AUTH_URL", "https://auth.sphere.io")
+    monkeypatch.setenv("CTP_AUTH_URL", "https://auth.sphere.io/oauth/token")
 
 
 def test_client_with_environment_settings_is_setup(
@@ -31,7 +31,7 @@ def test_auto_refresh(commercetools_api):
         client_secret="mysecret",
         project_key="test",
         url="https://api.sphere.io",
-        token_url="https://auth.sphere.io",
+        token_url="https://auth.sphere.io/oauth/token",
     )
     client.products.query()
     time.sleep(1)
@@ -53,7 +53,7 @@ def test_cache_token(commercetools_api):
         client_secret="none",
         project_key="test",
         url="https://api.sphere.io",
-        token_url="https://auth.sphere.io",
+        token_url="https://auth.sphere.io/oauth/token",
     )
     assert len(commercetools_api.requests_mock.request_history) == 1
 
@@ -62,6 +62,6 @@ def test_cache_token(commercetools_api):
         client_secret="none",
         project_key="test",
         url="https://api.sphere.io",
-        token_url="https://auth.sphere.io",
+        token_url="https://auth.sphere.io/oauth/token",
     )
     assert len(commercetools_api.requests_mock.request_history) == 1


### PR DESCRIPTION
I have a specific use case where I want to point the client
class at a different implementation of the oauth token endpoint
than the standard one. I can't do this right now because the
`/oauth/token` part of the URL is hardcoded. This PR removes
that hardcoding and make the caller have to specify the entire
token URL.

Admittedly mine is not a very common use case and in
general, saving the user from having to specify `/oauth/token`
is a good thing so, happy to just close this if it's too 
disruptive but thought I'd suggest it anyway and see what the
maintainers thought.

Thanks for the great work on this library!

- Ratan