### PR TITLE
Require full oauth2 token url when creating Client.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,6 @@
 2.0.0 (unreleased)
 ------------------
- - When creating the client the token url should now be a compete URL. When
+ - When creating the client the token url should now be a complete URL. When
    using environment variables it will automatically append /oauth/token if the
    url has no path specified. See #27
  - Add a changelog :-)

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,11 @@
+2.0.0 (unreleased)
+------------------
+ - When creating the client the token url should now be a compete URL. When
+   using environment variables it will automatically append /oauth/token if the
+   url has no path specified. See #27
+ - Add a changelog :-)
+
+
 1.5.0 (2018-12-11)
 ------------------
  - Add ability to run the mock server standalone using:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -27,7 +27,7 @@ Example
         client_secret="<your-client-secret>",
         scope=["<scopes>"],
         url="https://api.sphere.io",
-        token_url="https://auth.sphere.io",
+        token_url="https://auth.sphere.io/oauth/token",
     )
 
     product = client.products.get_by_id("00633d11-c5bb-434e-b132-73f7e130b4e3")

--- a/src/commercetools/contrib/pytest.py
+++ b/src/commercetools/contrib/pytest.py
@@ -22,7 +22,7 @@ def commercetools_client(commercetools_api) -> typing.Generator[Client, None, No
         client_secret="client-secret",
         scope=[],
         url="https://api.sphere.io",
-        token_url="https://auth.sphere.io",
+        token_url="https://auth.sphere.io/oauth/token",
     )
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -31,7 +31,7 @@ def test_auto_refresh(commercetools_api):
         client_secret="mysecret",
         project_key="test",
         url="https://api.sphere.io",
-        token_url="https://auth.sphere.io",
+        token_url="https://auth.sphere.io/oauth/token",
     )
     client.products.query()
     time.sleep(1)
@@ -53,7 +53,7 @@ def test_cache_token(commercetools_api):
         client_secret="none",
         project_key="test",
         url="https://api.sphere.io",
-        token_url="https://auth.sphere.io",
+        token_url="https://auth.sphere.io/oauth/token",
     )
     assert len(commercetools_api.requests_mock.request_history) == 1
 
@@ -62,6 +62,6 @@ def test_cache_token(commercetools_api):
         client_secret="none",
         project_key="test",
         url="https://api.sphere.io",
-        token_url="https://auth.sphere.io",
+        token_url="https://auth.sphere.io/oauth/token",
     )
     assert len(commercetools_api.requests_mock.request_history) == 1


### PR DESCRIPTION
When creating the client the token url should now be a compete URL. When
using environment variables it will automatically append /oauth/token if
the url has no path specified.

See #27