### PR TITLE
Add X-Correlation-ID to CT exception class and testing framework

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,8 @@
+2.5.3 (2019-04-24)
+------------------
+ - Add X-Correlation-ID to exception class
+ - Mock X-Correlation-ID header in testing framework
+
 2.5.2 (2019-04-17)
 ------------------
  - Implement testing predicates gte and lte

--- a/src/commercetools/client.py
+++ b/src/commercetools/client.py
@@ -10,6 +10,7 @@ from requests_oauthlib import OAuth2Session
 from urllib3.util.retry import Retry
 
 from commercetools import schemas
+from commercetools.constants import HEADER_CORRELATION_ID
 from commercetools.exceptions import CommercetoolsError
 from commercetools.helpers import _concurrent_retry
 from commercetools.services.carts import CartService
@@ -243,10 +244,11 @@ class Client:
         return remote_http_call(params)
 
     def _process_error(self, response: requests.Response) -> None:
+        correlation_id = response.headers.get(HEADER_CORRELATION_ID)
         if not response.content:
             response.raise_for_status()
         obj = schemas.ErrorResponseSchema().loads(response.content)
-        raise CommercetoolsError(obj.message, obj)
+        raise CommercetoolsError(obj.message, obj, correlation_id)
 
     def _read_env_vars(self, config: dict) -> dict:
         if not config.get("project_key"):

--- a/src/commercetools/constants.py
+++ b/src/commercetools/constants.py
@@ -1,0 +1,1 @@
+HEADER_CORRELATION_ID = "X-Correlation-ID"

--- a/src/commercetools/exceptions.py
+++ b/src/commercetools/exceptions.py
@@ -1,4 +1,5 @@
 class CommercetoolsError(Exception):
-    def __init__(self, message, response) -> None:
+    def __init__(self, message, response, correlation_id=None) -> None:
         super().__init__(message)
         self.response = response
+        self.correlation_id = correlation_id

--- a/src/commercetools/testing/auth.py
+++ b/src/commercetools/testing/auth.py
@@ -3,9 +3,8 @@ import typing
 import uuid
 from urllib.parse import parse_qs
 
-from requests_mock import create_response
-
 from commercetools.testing.abstract import BaseBackend
+from commercetools.testing.utils import create_commercetools_response
 
 
 class AuthModel:
@@ -47,7 +46,7 @@ class AuthBackend(BaseBackend):
         if request.headers.get("Authorization"):
             auth_type, auth_info = request.headers["Authorization"].split()
             if auth_type != "Basic":
-                response = create_response(request, status_code=401)
+                response = create_commercetools_response(request, status_code=401)
                 return response
 
             client_id, client_secret = str(base64.b64decode(auth_info)).split(":")
@@ -55,7 +54,7 @@ class AuthBackend(BaseBackend):
             client_id = params.get("client_id")
             client_secret = params.get("client_secret")
         else:
-            response = create_response(request, status_code=401)
+            response = create_commercetools_response(request, status_code=401)
             return response
 
         scope = params.get("scope", "manage_project:todo")
@@ -68,5 +67,5 @@ class AuthBackend(BaseBackend):
                 "token_type": "Bearer",
             }
             self.model.add_token(token)
-            response = create_response(request, json=token)
+            response = create_commercetools_response(request, json=token)
             return response

--- a/src/commercetools/testing/custom_objects.py
+++ b/src/commercetools/testing/custom_objects.py
@@ -2,10 +2,9 @@ import datetime
 import typing
 import uuid
 
-from requests_mock import create_response
-
 from commercetools import schemas, types
 from commercetools.testing.abstract import BaseModel, ServiceBackend
+from commercetools.testing.utils import create_commercetools_response
 
 
 class CustomObjectsModel(BaseModel):
@@ -49,14 +48,14 @@ class CustomObjectsBackend(ServiceBackend):
             (obj for obj in self.model.objects.values() if obj["id"] == id), None
         )
         if item:
-            return create_response(request, json=item)
-        return create_response(request, status_code=404)
+            return create_commercetools_response(request, json=item)
+        return create_commercetools_response(request, status_code=404)
 
     def get_by_container_key(self, request, container: str, key: str):
         id = (container, key)
         item = self.model.objects.get(id)
         if item:
-            return create_response(request, json=item)
+            return create_commercetools_response(request, json=item)
         else:
             content = schemas.ErrorResponseSchema().dumps(
                 types.ErrorResponse(
@@ -70,4 +69,4 @@ class CustomObjectsBackend(ServiceBackend):
                     ],
                 )
             )
-            return create_response(request, text=content, status_code=404)
+            return create_commercetools_response(request, text=content, status_code=404)

--- a/src/commercetools/testing/product_projections.py
+++ b/src/commercetools/testing/product_projections.py
@@ -1,11 +1,10 @@
 import typing
 
-from requests_mock import create_response
-
 from commercetools import schemas, types
 from commercetools.services.product_projections import ProductProjectionsQuerySchema
 from commercetools.testing import utils
 from commercetools.testing.abstract import ServiceBackend
+from commercetools.testing.utils import create_commercetools_response
 
 
 class ProductProjectionsBackend(ServiceBackend):
@@ -36,7 +35,7 @@ class ProductProjectionsBackend(ServiceBackend):
             "results": results,
         }
         content = schemas.ProductProjectionPagedQueryResponseSchema().dumps(data)
-        return create_response(request, text=content)
+        return create_commercetools_response(request, text=content)
 
     def search(self, request):
         params = utils.parse_request_params(ProductProjectionsQuerySchema, request)
@@ -55,21 +54,21 @@ class ProductProjectionsBackend(ServiceBackend):
             "results": results,
         }
         content = schemas.ProductProjectionPagedQueryResponseSchema().dumps(data)
-        return create_response(request, text=content)
+        return create_commercetools_response(request, text=content)
 
     def get_by_id(self, request, id):
         obj = self.model.get_by_id(id)
         if obj:
             content = schemas.ProductProjectionSchema().dumps(obj)
-            return create_response(request, text=content)
-        return create_response(request, status_code=404)
+            return create_commercetools_response(request, text=content)
+        return create_commercetools_response(request, status_code=404)
 
     def get_by_key(self, request, key):
         obj = self.model.get_by_key(key)
         if obj:
             content = schemas.ProductProjectionSchema().dumps(obj)
-            return create_response(request, text=content)
-        return create_response(request, status_code=404)
+            return create_commercetools_response(request, text=content)
+        return create_commercetools_response(request, status_code=404)
 
     def _convert_product_projection(
         self, product: typing.Dict, staged: bool = False

--- a/src/commercetools/testing/subscriptions.py
+++ b/src/commercetools/testing/subscriptions.py
@@ -2,10 +2,9 @@ import datetime
 import typing
 import uuid
 
-from requests_mock import create_response
-
 from commercetools import schemas, types
 from commercetools.testing.abstract import BaseModel, ServiceBackend
+from commercetools.testing.utils import create_commercetools_response
 
 
 class SubscriptionsModel(BaseModel):
@@ -61,7 +60,7 @@ class SubscriptionsBackend(ServiceBackend):
                 errors=[types.InvalidInputError(message=message)],
             )
             error_data = schemas.ErrorResponseSchema().dumps(error).encode("utf-8")
-            return create_response(request, content=error_data, status_code=400)
+            return create_commercetools_response(request, content=error_data, status_code=400)
 
         data = self.model.add(obj)
-        return create_response(request, json=data)
+        return create_commercetools_response(request, json=data)

--- a/src/commercetools/testing/utils.py
+++ b/src/commercetools/testing/utils.py
@@ -4,9 +4,11 @@ import typing
 import uuid
 
 from marshmallow import Schema
+from requests_mock import create_response
 from requests_mock.request import _RequestObjectProxy
 
 from commercetools import schemas, types
+from commercetools.constants import HEADER_CORRELATION_ID
 
 
 class InternalUpdateError(ValueError):
@@ -166,3 +168,10 @@ def get_product_from_storage(
         raise ValueError("SKU or productId is required")
 
     return product
+
+
+def create_commercetools_response(request, **kwargs):
+    correlation_id = request.headers.get(HEADER_CORRELATION_ID, f"projects-{str(uuid.uuid4())}")
+    headers = kwargs.pop("headers", {})
+    headers.update({HEADER_CORRELATION_ID: correlation_id})
+    return create_response(request, headers=headers, **kwargs)

--- a/tests/test_testing_headers.py
+++ b/tests/test_testing_headers.py
@@ -1,0 +1,27 @@
+import pytest
+
+from commercetools import types, CommercetoolsError
+
+
+def test_correlation_id_is_set_in_exception(client):
+    product = client.products.create(types.ProductDraft(key="test-product"))
+
+    product = client.products.update_by_id(
+        id=product.id,
+        version=product.version,
+        actions=[
+            types.ProductChangeSlugAction(slug=types.LocalizedString(nl="nl-slug2"))
+        ],
+    )
+
+    # This should raise a version conflict error
+    with pytest.raises(CommercetoolsError) as exc:
+        client.products.update_by_id(
+            id=product.id,
+            version=1,
+            actions=[
+                types.ProductChangeSlugAction(slug=types.LocalizedString(nl="nl-slug3"))
+            ],
+        )
+
+    assert exc.value.correlation_id is not None


### PR DESCRIPTION
This will be enough to log it in Sentry (since correlation_id is a local variable, which are always logged).

Another solution would be to use something like https://github.com/jmcarp/requests-middleware and overwrite the HTTPAdapter in client.py line 131. Then pass in some kind of SentryMiddleware which sets a tag with the response header X-Correlation-ID https://docs.sentry.io/enriching-error-data/context/?platform=python#tagging-events