### PR TITLE
Implement token introspection mock endpoint 

### DIFF
--- a/src/commercetools/testing/auth.py
+++ b/src/commercetools/testing/auth.py
@@ -74,8 +74,6 @@ class AuthBackend(BaseBackend):
             return response
 
     def introspect(self, request):
-        params = parse_qs(request.body)
-
         client_id: typing.Optional[str] = None
         client_secret: typing.Optional[str] = None
 
@@ -90,7 +88,7 @@ class AuthBackend(BaseBackend):
             response = create_commercetools_response(request, status_code=401)
             return response
 
-        token = params.get(str.encode('token'), [None])[0].decode()
+        token = request.qs.get('token', [None])[0]
 
         if self.model.is_valid(client_id, client_secret):
             stored_tokens = [token_object.get('access_token') for token_object in self.model.tokens]

--- a/src/commercetools/testing/auth.py
+++ b/src/commercetools/testing/auth.py
@@ -35,7 +35,10 @@ class AuthBackend(BaseBackend):
         return r"/oauth/(?P<path>.*)"
 
     def urls(self):
-        return [("token", "POST", self.token)]
+        return [
+            ("token", "POST", self.token),
+            ("introspect", "POST", self.introspect)
+        ]
 
     def token(self, request):
         params = parse_qs(request.body)
@@ -69,3 +72,37 @@ class AuthBackend(BaseBackend):
             self.model.add_token(token)
             response = create_commercetools_response(request, json=token)
             return response
+
+    def introspect(self, request):
+        params = parse_qs(request.body.decode("utf-8"))
+
+        client_id: typing.Optional[str] = None
+        client_secret: typing.Optional[str] = None
+
+        if request.headers.get("Authorization"):
+            auth_type, auth_info = request.headers["Authorization"].split()
+            if auth_type != "Basic":
+                response = create_commercetools_response(request, status_code=401)
+                return response
+
+            client_id, client_secret = str(base64.b64decode(auth_info)).split(":")
+        else:
+            response = create_commercetools_response(request, status_code=401)
+            return response
+
+        token = params.get("token", [None])[0]
+
+        if self.model.is_valid(client_id, client_secret):
+            stored_tokens = [token_object.get('access_token') for token_object in self.model.tokens]
+            if token in stored_tokens:
+                status = {
+                    "active": True,
+                    "scope": "manage_project:todo",
+                    "exp": self._expire_time
+                }
+            else:
+                status = {
+                    "active": False
+                }
+        response = create_commercetools_response(request, json=status)
+        return response

--- a/src/commercetools/testing/auth.py
+++ b/src/commercetools/testing/auth.py
@@ -74,7 +74,7 @@ class AuthBackend(BaseBackend):
             return response
 
     def introspect(self, request):
-        params = parse_qs(request.body.decode("utf-8"))
+        params = parse_qs(request.body)
 
         client_id: typing.Optional[str] = None
         client_secret: typing.Optional[str] = None
@@ -90,7 +90,7 @@ class AuthBackend(BaseBackend):
             response = create_commercetools_response(request, status_code=401)
             return response
 
-        token = params.get("token", [None])[0]
+        token = params.get(str.encode('token'), [None])[0].decode()
 
         if self.model.is_valid(client_id, client_secret):
             stored_tokens = [token_object.get('access_token') for token_object in self.model.tokens]


### PR DESCRIPTION
**Purpose:**

My team has been playing around with using the labd mock commercetools server in our integration testing. We use the commercetools [introspection](https://docs.commercetools.com/http-api-authorization#introspection) endpoint and noticed that it wasn't yet implemented in the labd mock server. 

In this pull request, I have added a mock `introspect` method on the `AuthBackend` class. It accepts a `client_id` and `client_secret` from the authorization headers, and a `token` from the request body. It then checks if this token has previously been generated and stored in the model `self.tokens` list, and returns an appropriate [active](https://docs.commercetools.com/http-api-authorization#example-response-active) or [inactive](https://docs.commercetools.com/http-api-authorization#example-response-inactive) response. 

For context, this endpoint implements Auth 2.0 supported [Token Introspection](https://tools.ietf.org/html/rfc7662).



