### PR TITLE
Fix incompatible change in marsmallow

### DIFF
--- a/src/commercetools/services/product_projections.py
+++ b/src/commercetools/services/product_projections.py
@@ -41,7 +41,7 @@ class ProductProjectionsSearchSchema(ProductProjectionsBaseSchema):
         return result
 
     @post_dump
-    def merge_text(self, data):
+    def merge_text(self, data, **kwargs):
         value = data.pop("text")
         data.update(value)
         return data


### PR DESCRIPTION
Fix issue with merge_text not expecting keyword argument 'many'

`kages/marshmallow/schema.py", line 1135, in _invoke_processors
    data = processor(data, many=many, **kwargs)
TypeError: merge_text() got an unexpected keyword argument 'many'`