### PR TITLE
Remove default values for required values in type constructors

### DIFF
--- a/codegen/generate_schema.py
+++ b/codegen/generate_schema.py
@@ -382,7 +382,8 @@ class SchemaClassGenerator:
                         args=[],
                         keywords=[
                             ast.keyword(
-                                arg="allow_none", value=ast.NameConstant(True, kind=None)
+                                arg="allow_none",
+                                value=ast.NameConstant(True, kind=None),
                             )
                         ],
                     )
@@ -487,19 +488,21 @@ class SchemaClassGenerator:
 
     def _create_regex_call(self, field_name, method_name):
         """Generate `data = self.fields[{ field_name }].{ method_name }(data)`"""
-        self.generator.add_import_statement(
-            self.resource.package_name, "typing"
-        )
+        self.generator.add_import_statement(self.resource.package_name, "typing")
         return ast.Assign(
             targets=[ast.Name(id="data")],
             value=ast.Call(
                 func=ast.Attribute(
                     value=ast.Call(
-                        func=ast.Attribute(value=ast.Name(id='typing'), attr='cast'),
+                        func=ast.Attribute(value=ast.Name(id="typing"), attr="cast"),
                         args=[
-                            ast.Attribute(value=ast.Name(id='helpers'), attr='RegexField'),
+                            ast.Attribute(
+                                value=ast.Name(id="helpers"), attr="RegexField"
+                            ),
                             ast.Subscript(
-                                value=ast.Attribute(value=ast.Name(id="self"), attr="fields"),
+                                value=ast.Attribute(
+                                    value=ast.Name(id="self"), attr="fields"
+                                ),
                                 slice=ast.Index(value=ast.Str(s=field_name, kind=None)),
                             ),
                         ],

--- a/codegen/generate_schema.py
+++ b/codegen/generate_schema.py
@@ -203,6 +203,13 @@ class SchemaClassGenerator:
             if node:
                 class_node.body.append(node)
 
+                # Properties set by marshmallow Schema confuses mypy. It thinks
+                # the class properties conflict, however since the fields
+                # defined here are removed by a metaclass this isn't the case
+                # simple workaround to silicen these
+                if prop.name in ["fields"]:
+                    class_node.body.append(ast.Name(id="  # type: ignore"))
+
         # Add the Meta class
         class_node.body.append(
             ast.ClassDef(

--- a/codegen/generate_types.py
+++ b/codegen/generate_types.py
@@ -455,6 +455,10 @@ class _ResourceClassGenerator:
             if not attribute_name:
                 continue
 
+            # The discriminator value is an internal value
+            if self.discriminator_attr and self.discriminator_attr.name == prop.name:
+                continue
+
             arg = ast.arg(
                 arg=attribute_name,
                 annotation=self._get_annotation_for_property(prop),

--- a/codegen/generate_types.py
+++ b/codegen/generate_types.py
@@ -460,8 +460,7 @@ class _ResourceClassGenerator:
                 continue
 
             arg = ast.arg(
-                arg=attribute_name,
-                annotation=self._get_annotation_for_property(prop),
+                arg=attribute_name, annotation=self._get_annotation_for_property(prop)
             )
 
             if prop.optional:

--- a/codegen/main.py
+++ b/codegen/main.py
@@ -32,7 +32,7 @@ def generate_types_module(types):
 
 
 def generate_schemas_modules(types):
-    generator = SchemaModuleGenerator()
+    generator = SchemaModuleGenerator(types)
     for resource in types:
         generator.add_type_definition(resource)
     return generator.get_module_nodes()

--- a/src/commercetools/_schemas/_cart.py
+++ b/src/commercetools/_schemas/_cart.py
@@ -1926,7 +1926,7 @@ class CartSetCustomLineItemCustomTypeActionSchema(CartUpdateActionSchema):
         allow_none=True,
         missing=None,
     )
-    fields = FieldContainerField(allow_none=True, missing=None)
+    fields = FieldContainerField(allow_none=True, missing=None)  # type: ignore
 
     class Meta:
         unknown = marshmallow.EXCLUDE
@@ -2051,7 +2051,7 @@ class CartSetCustomTypeActionSchema(CartUpdateActionSchema):
         allow_none=True,
         missing=None,
     )
-    fields = FieldContainerField(allow_none=True, missing=None)
+    fields = FieldContainerField(allow_none=True, missing=None)  # type: ignore
 
     class Meta:
         unknown = marshmallow.EXCLUDE
@@ -2154,7 +2154,7 @@ class CartSetLineItemCustomTypeActionSchema(CartUpdateActionSchema):
         allow_none=True,
         missing=None,
     )
-    fields = FieldContainerField(allow_none=True, missing=None)
+    fields = FieldContainerField(allow_none=True, missing=None)  # type: ignore
 
     class Meta:
         unknown = marshmallow.EXCLUDE

--- a/src/commercetools/_schemas/_cart_discount.py
+++ b/src/commercetools/_schemas/_cart_discount.py
@@ -565,7 +565,7 @@ class CartDiscountSetCustomTypeActionSchema(CartDiscountUpdateActionSchema):
         allow_none=True,
         missing=None,
     )
-    fields = marshmallow.fields.Dict(allow_none=True, missing=None)
+    fields = marshmallow.fields.Dict(allow_none=True, missing=None)  # type: ignore
 
     class Meta:
         unknown = marshmallow.EXCLUDE
@@ -664,7 +664,7 @@ class CartDiscountShippingCostTargetSchema(CartDiscountTargetSchema):
     @marshmallow.post_load
     def post_load(self, data, **kwargs):
         del data["type"]
-        return types.CartDiscountShippingCostTarget(**data)
+        return types.CartDiscountShippingCostTarget()
 
 
 class CartDiscountValueAbsoluteDraftSchema(CartDiscountValueDraftSchema):

--- a/src/commercetools/_schemas/_category.py
+++ b/src/commercetools/_schemas/_category.py
@@ -449,7 +449,7 @@ class CategorySetAssetCustomTypeActionSchema(CategoryUpdateActionSchema):
         allow_none=True,
         missing=None,
     )
-    fields = marshmallow.fields.Dict(allow_none=True, missing=None)
+    fields = marshmallow.fields.Dict(allow_none=True, missing=None)  # type: ignore
 
     class Meta:
         unknown = marshmallow.EXCLUDE
@@ -568,7 +568,7 @@ class CategorySetCustomTypeActionSchema(CategoryUpdateActionSchema):
         allow_none=True,
         missing=None,
     )
-    fields = FieldContainerField(allow_none=True, missing=None)
+    fields = FieldContainerField(allow_none=True, missing=None)  # type: ignore
 
     class Meta:
         unknown = marshmallow.EXCLUDE

--- a/src/commercetools/_schemas/_channel.py
+++ b/src/commercetools/_schemas/_channel.py
@@ -356,7 +356,7 @@ class ChannelSetCustomTypeActionSchema(ChannelUpdateActionSchema):
         allow_none=True,
         missing=None,
     )
-    fields = FieldContainerField(allow_none=True, missing=None)
+    fields = FieldContainerField(allow_none=True, missing=None)  # type: ignore
 
     class Meta:
         unknown = marshmallow.EXCLUDE

--- a/src/commercetools/_schemas/_customer.py
+++ b/src/commercetools/_schemas/_customer.py
@@ -744,7 +744,7 @@ class CustomerSetCustomTypeActionSchema(CustomerUpdateActionSchema):
         allow_none=True,
         missing=None,
     )
-    fields = FieldContainerField(allow_none=True, missing=None)
+    fields = FieldContainerField(allow_none=True, missing=None)  # type: ignore
 
     class Meta:
         unknown = marshmallow.EXCLUDE

--- a/src/commercetools/_schemas/_customer_group.py
+++ b/src/commercetools/_schemas/_customer_group.py
@@ -216,7 +216,7 @@ class CustomerGroupSetCustomTypeActionSchema(CustomerGroupUpdateActionSchema):
         allow_none=True,
         missing=None,
     )
-    fields = FieldContainerField(allow_none=True, missing=None)
+    fields = FieldContainerField(allow_none=True, missing=None)  # type: ignore
 
     class Meta:
         unknown = marshmallow.EXCLUDE

--- a/src/commercetools/_schemas/_discount_code.py
+++ b/src/commercetools/_schemas/_discount_code.py
@@ -371,7 +371,7 @@ class DiscountCodeSetCustomTypeActionSchema(DiscountCodeUpdateActionSchema):
         allow_none=True,
         missing=None,
     )
-    fields = FieldContainerField(allow_none=True, missing=None)
+    fields = FieldContainerField(allow_none=True, missing=None)  # type: ignore
 
     class Meta:
         unknown = marshmallow.EXCLUDE

--- a/src/commercetools/_schemas/_inventory.py
+++ b/src/commercetools/_schemas/_inventory.py
@@ -285,7 +285,7 @@ class InventoryEntrySetCustomTypeActionSchema(InventoryEntryUpdateActionSchema):
         allow_none=True,
         missing=None,
     )
-    fields = FieldContainerField(allow_none=True, missing=None)
+    fields = FieldContainerField(allow_none=True, missing=None)  # type: ignore
 
     class Meta:
         unknown = marshmallow.EXCLUDE

--- a/src/commercetools/_schemas/_me.py
+++ b/src/commercetools/_schemas/_me.py
@@ -1460,7 +1460,7 @@ class MyCartSetCustomTypeActionSchema(MyCartUpdateActionSchema):
         allow_none=True,
         missing=None,
     )
-    fields = FieldContainerField(allow_none=True, missing=None)
+    fields = FieldContainerField(allow_none=True, missing=None)  # type: ignore
 
     class Meta:
         unknown = marshmallow.EXCLUDE
@@ -1513,7 +1513,7 @@ class MyCartSetLineItemCustomTypeActionSchema(MyCartUpdateActionSchema):
         allow_none=True,
         missing=None,
     )
-    fields = FieldContainerField(allow_none=True, missing=None)
+    fields = FieldContainerField(allow_none=True, missing=None)  # type: ignore
 
     class Meta:
         unknown = marshmallow.EXCLUDE
@@ -1784,7 +1784,7 @@ class MyCustomerSetCustomTypeActionSchema(MyCustomerUpdateActionSchema):
         allow_none=True,
         missing=None,
     )
-    fields = FieldContainerField(allow_none=True, missing=None)
+    fields = FieldContainerField(allow_none=True, missing=None)  # type: ignore
 
     class Meta:
         unknown = marshmallow.EXCLUDE
@@ -2254,7 +2254,7 @@ class MyShoppingListSetCustomTypeActionSchema(MyShoppingListUpdateActionSchema):
         allow_none=True,
         missing=None,
     )
-    fields = FieldContainerField(allow_none=True, missing=None)
+    fields = FieldContainerField(allow_none=True, missing=None)  # type: ignore
 
     class Meta:
         unknown = marshmallow.EXCLUDE
@@ -2325,7 +2325,7 @@ class MyShoppingListSetLineItemCustomTypeActionSchema(MyShoppingListUpdateAction
         allow_none=True,
         missing=None,
     )
-    fields = FieldContainerField(allow_none=True, missing=None)
+    fields = FieldContainerField(allow_none=True, missing=None)  # type: ignore
 
     class Meta:
         unknown = marshmallow.EXCLUDE
@@ -2370,7 +2370,7 @@ class MyShoppingListSetTextLineItemCustomTypeActionSchema(
         allow_none=True,
         missing=None,
     )
-    fields = FieldContainerField(allow_none=True, missing=None)
+    fields = FieldContainerField(allow_none=True, missing=None)  # type: ignore
 
     class Meta:
         unknown = marshmallow.EXCLUDE

--- a/src/commercetools/_schemas/_message.py
+++ b/src/commercetools/_schemas/_message.py
@@ -791,7 +791,7 @@ class CustomerEmailVerifiedMessagePayloadSchema(MessagePayloadSchema):
     @marshmallow.post_load
     def post_load(self, data, **kwargs):
         del data["type"]
-        return types.CustomerEmailVerifiedMessagePayload(**data)
+        return types.CustomerEmailVerifiedMessagePayload()
 
 
 class CustomerEmailVerifiedMessageSchema(MessageSchema):
@@ -3215,7 +3215,7 @@ class ProductUnpublishedMessagePayloadSchema(MessagePayloadSchema):
     @marshmallow.post_load
     def post_load(self, data, **kwargs):
         del data["type"]
-        return types.ProductUnpublishedMessagePayload(**data)
+        return types.ProductUnpublishedMessagePayload()
 
 
 class ProductUnpublishedMessageSchema(MessageSchema):

--- a/src/commercetools/_schemas/_order.py
+++ b/src/commercetools/_schemas/_order.py
@@ -1480,7 +1480,7 @@ class OrderSetCustomLineItemCustomTypeActionSchema(OrderUpdateActionSchema):
         allow_none=True,
         missing=None,
     )
-    fields = FieldContainerField(allow_none=True, missing=None)
+    fields = FieldContainerField(allow_none=True, missing=None)  # type: ignore
 
     class Meta:
         unknown = marshmallow.EXCLUDE
@@ -1523,7 +1523,7 @@ class OrderSetCustomTypeActionSchema(OrderUpdateActionSchema):
         allow_none=True,
         missing=None,
     )
-    fields = FieldContainerField(allow_none=True, missing=None)
+    fields = FieldContainerField(allow_none=True, missing=None)  # type: ignore
 
     class Meta:
         unknown = marshmallow.EXCLUDE
@@ -1630,7 +1630,7 @@ class OrderSetLineItemCustomTypeActionSchema(OrderUpdateActionSchema):
         allow_none=True,
         missing=None,
     )
-    fields = FieldContainerField(allow_none=True, missing=None)
+    fields = FieldContainerField(allow_none=True, missing=None)  # type: ignore
 
     class Meta:
         unknown = marshmallow.EXCLUDE

--- a/src/commercetools/_schemas/_order_edit.py
+++ b/src/commercetools/_schemas/_order_edit.py
@@ -1217,7 +1217,7 @@ class StagedOrderSetCustomLineItemCustomTypeActionSchema(StagedOrderUpdateAction
         allow_none=True,
         missing=None,
     )
-    fields = FieldContainerField(allow_none=True, missing=None)
+    fields = FieldContainerField(allow_none=True, missing=None)  # type: ignore
 
     class Meta:
         unknown = marshmallow.EXCLUDE
@@ -1344,7 +1344,7 @@ class StagedOrderSetCustomTypeActionSchema(StagedOrderUpdateActionSchema):
         allow_none=True,
         missing=None,
     )
-    fields = FieldContainerField(allow_none=True, missing=None)
+    fields = FieldContainerField(allow_none=True, missing=None)  # type: ignore
 
     class Meta:
         unknown = marshmallow.EXCLUDE
@@ -1471,7 +1471,7 @@ class StagedOrderSetLineItemCustomTypeActionSchema(StagedOrderUpdateActionSchema
         allow_none=True,
         missing=None,
     )
-    fields = FieldContainerField(allow_none=True, missing=None)
+    fields = FieldContainerField(allow_none=True, missing=None)  # type: ignore
 
     class Meta:
         unknown = marshmallow.EXCLUDE
@@ -2176,7 +2176,7 @@ class OrderEditNotProcessedSchema(OrderEditResultSchema):
     @marshmallow.post_load
     def post_load(self, data, **kwargs):
         del data["type"]
-        return types.OrderEditNotProcessed(**data)
+        return types.OrderEditNotProcessed()
 
 
 class OrderEditPreviewFailureSchema(OrderEditResultSchema):
@@ -2371,7 +2371,7 @@ class OrderEditSetCustomTypeActionSchema(OrderEditUpdateActionSchema):
         allow_none=True,
         missing=None,
     )
-    fields = marshmallow.fields.Dict(allow_none=True, missing=None)
+    fields = marshmallow.fields.Dict(allow_none=True, missing=None)  # type: ignore
 
     class Meta:
         unknown = marshmallow.EXCLUDE

--- a/src/commercetools/_schemas/_payment.py
+++ b/src/commercetools/_schemas/_payment.py
@@ -507,7 +507,7 @@ class PaymentAddInterfaceInteractionActionSchema(PaymentUpdateActionSchema):
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
     )
-    fields = FieldContainerField(allow_none=True, missing=None)
+    fields = FieldContainerField(allow_none=True, missing=None)  # type: ignore
 
     class Meta:
         unknown = marshmallow.EXCLUDE
@@ -705,7 +705,7 @@ class PaymentSetCustomTypeActionSchema(PaymentUpdateActionSchema):
         allow_none=True,
         missing=None,
     )
-    fields = FieldContainerField(allow_none=True, missing=None)
+    fields = FieldContainerField(allow_none=True, missing=None)  # type: ignore
 
     class Meta:
         unknown = marshmallow.EXCLUDE

--- a/src/commercetools/_schemas/_product.py
+++ b/src/commercetools/_schemas/_product.py
@@ -1458,7 +1458,7 @@ class ProductRevertStagedChangesActionSchema(ProductUpdateActionSchema):
     @marshmallow.post_load
     def post_load(self, data, **kwargs):
         del data["action"]
-        return types.ProductRevertStagedChangesAction(**data)
+        return types.ProductRevertStagedChangesAction()
 
 
 class ProductRevertStagedVariantChangesActionSchema(ProductUpdateActionSchema):
@@ -1521,7 +1521,7 @@ class ProductSetAssetCustomTypeActionSchema(ProductUpdateActionSchema):
         allow_none=True,
         missing=None,
     )
-    fields = marshmallow.fields.Dict(allow_none=True, missing=None)
+    fields = marshmallow.fields.Dict(allow_none=True, missing=None)  # type: ignore
 
     class Meta:
         unknown = marshmallow.EXCLUDE
@@ -1863,7 +1863,7 @@ class ProductSetProductPriceCustomTypeActionSchema(ProductUpdateActionSchema):
         allow_none=True,
         missing=None,
     )
-    fields = FieldContainerField(allow_none=True, missing=None)
+    fields = FieldContainerField(allow_none=True, missing=None)  # type: ignore
 
     class Meta:
         unknown = marshmallow.EXCLUDE
@@ -1978,7 +1978,7 @@ class ProductUnpublishActionSchema(ProductUpdateActionSchema):
     @marshmallow.post_load
     def post_load(self, data, **kwargs):
         del data["action"]
-        return types.ProductUnpublishAction(**data)
+        return types.ProductUnpublishAction()
 
 
 class RangeFacetResultSchema(FacetResultSchema):
@@ -2034,4 +2034,4 @@ class WhitespaceTokenizerSchema(SuggestTokenizerSchema):
     @marshmallow.post_load
     def post_load(self, data, **kwargs):
         del data["type"]
-        return types.WhitespaceTokenizer(**data)
+        return types.WhitespaceTokenizer()

--- a/src/commercetools/_schemas/_product_discount.py
+++ b/src/commercetools/_schemas/_product_discount.py
@@ -519,7 +519,7 @@ class ProductDiscountValueExternalDraftSchema(ProductDiscountValueDraftSchema):
     @marshmallow.post_load
     def post_load(self, data, **kwargs):
         del data["type"]
-        return types.ProductDiscountValueExternalDraft(**data)
+        return types.ProductDiscountValueExternalDraft()
 
 
 class ProductDiscountValueExternalSchema(ProductDiscountValueSchema):
@@ -531,7 +531,7 @@ class ProductDiscountValueExternalSchema(ProductDiscountValueSchema):
     @marshmallow.post_load
     def post_load(self, data, **kwargs):
         del data["type"]
-        return types.ProductDiscountValueExternal(**data)
+        return types.ProductDiscountValueExternal()
 
 
 class ProductDiscountValueRelativeDraftSchema(ProductDiscountValueDraftSchema):

--- a/src/commercetools/_schemas/_product_type.py
+++ b/src/commercetools/_schemas/_product_type.py
@@ -377,7 +377,7 @@ class AttributeBooleanTypeSchema(AttributeTypeSchema):
     @marshmallow.post_load
     def post_load(self, data, **kwargs):
         del data["name"]
-        return types.AttributeBooleanType(**data)
+        return types.AttributeBooleanType()
 
 
 class AttributeDateTimeTypeSchema(AttributeTypeSchema):
@@ -389,7 +389,7 @@ class AttributeDateTimeTypeSchema(AttributeTypeSchema):
     @marshmallow.post_load
     def post_load(self, data, **kwargs):
         del data["name"]
-        return types.AttributeDateTimeType(**data)
+        return types.AttributeDateTimeType()
 
 
 class AttributeDateTypeSchema(AttributeTypeSchema):
@@ -401,7 +401,7 @@ class AttributeDateTypeSchema(AttributeTypeSchema):
     @marshmallow.post_load
     def post_load(self, data, **kwargs):
         del data["name"]
-        return types.AttributeDateType(**data)
+        return types.AttributeDateType()
 
 
 class AttributeEnumTypeSchema(AttributeTypeSchema):
@@ -432,7 +432,7 @@ class AttributeLocalizableTextTypeSchema(AttributeTypeSchema):
     @marshmallow.post_load
     def post_load(self, data, **kwargs):
         del data["name"]
-        return types.AttributeLocalizableTextType(**data)
+        return types.AttributeLocalizableTextType()
 
 
 class AttributeLocalizedEnumTypeSchema(AttributeTypeSchema):
@@ -463,7 +463,7 @@ class AttributeMoneyTypeSchema(AttributeTypeSchema):
     @marshmallow.post_load
     def post_load(self, data, **kwargs):
         del data["name"]
-        return types.AttributeMoneyType(**data)
+        return types.AttributeMoneyType()
 
 
 class AttributeNestedTypeSchema(AttributeTypeSchema):
@@ -494,7 +494,7 @@ class AttributeNumberTypeSchema(AttributeTypeSchema):
     @marshmallow.post_load
     def post_load(self, data, **kwargs):
         del data["name"]
-        return types.AttributeNumberType(**data)
+        return types.AttributeNumberType()
 
 
 class AttributeReferenceTypeSchema(AttributeTypeSchema):
@@ -556,7 +556,7 @@ class AttributeTextTypeSchema(AttributeTypeSchema):
     @marshmallow.post_load
     def post_load(self, data, **kwargs):
         del data["name"]
-        return types.AttributeTextType(**data)
+        return types.AttributeTextType()
 
 
 class AttributeTimeTypeSchema(AttributeTypeSchema):
@@ -568,7 +568,7 @@ class AttributeTimeTypeSchema(AttributeTypeSchema):
     @marshmallow.post_load
     def post_load(self, data, **kwargs):
         del data["name"]
-        return types.AttributeTimeType(**data)
+        return types.AttributeTimeType()
 
 
 class ProductTypeAddAttributeDefinitionActionSchema(ProductTypeUpdateActionSchema):

--- a/src/commercetools/_schemas/_project.py
+++ b/src/commercetools/_schemas/_project.py
@@ -198,7 +198,7 @@ class CartScoreTypeSchema(ShippingRateInputTypeSchema):
     @marshmallow.post_load
     def post_load(self, data, **kwargs):
         del data["type"]
-        return types.CartScoreType(**data)
+        return types.CartScoreType()
 
 
 class CartValueTypeSchema(ShippingRateInputTypeSchema):
@@ -210,7 +210,7 @@ class CartValueTypeSchema(ShippingRateInputTypeSchema):
     @marshmallow.post_load
     def post_load(self, data, **kwargs):
         del data["type"]
-        return types.CartValueType(**data)
+        return types.CartValueType()
 
 
 class ProjectChangeCountriesActionSchema(ProjectUpdateActionSchema):

--- a/src/commercetools/_schemas/_review.py
+++ b/src/commercetools/_schemas/_review.py
@@ -313,7 +313,7 @@ class ReviewSetCustomTypeActionSchema(ReviewUpdateActionSchema):
         allow_none=True,
         missing=None,
     )
-    fields = FieldContainerField(allow_none=True, missing=None)
+    fields = FieldContainerField(allow_none=True, missing=None)  # type: ignore
 
     class Meta:
         unknown = marshmallow.EXCLUDE

--- a/src/commercetools/_schemas/_shopping_list.py
+++ b/src/commercetools/_schemas/_shopping_list.py
@@ -696,7 +696,7 @@ class ShoppingListSetCustomTypeActionSchema(ShoppingListUpdateActionSchema):
         allow_none=True,
         missing=None,
     )
-    fields = FieldContainerField(allow_none=True, missing=None)
+    fields = FieldContainerField(allow_none=True, missing=None)  # type: ignore
 
     class Meta:
         unknown = marshmallow.EXCLUDE
@@ -798,7 +798,7 @@ class ShoppingListSetLineItemCustomTypeActionSchema(ShoppingListUpdateActionSche
         allow_none=True,
         missing=None,
     )
-    fields = FieldContainerField(allow_none=True, missing=None)
+    fields = FieldContainerField(allow_none=True, missing=None)  # type: ignore
 
     class Meta:
         unknown = marshmallow.EXCLUDE
@@ -855,7 +855,7 @@ class ShoppingListSetTextLineItemCustomTypeActionSchema(ShoppingListUpdateAction
         allow_none=True,
         missing=None,
     )
-    fields = FieldContainerField(allow_none=True, missing=None)
+    fields = FieldContainerField(allow_none=True, missing=None)  # type: ignore
 
     class Meta:
         unknown = marshmallow.EXCLUDE

--- a/src/commercetools/_schemas/_store.py
+++ b/src/commercetools/_schemas/_store.py
@@ -22,8 +22,11 @@ __all__ = [
     "StoreUpdateActionSchema",
     "StoreUpdateSchema",
     "StoresAddDistributionChannelsActionSchema",
+    "StoresAddSupplyChannelsActionSchema",
     "StoresRemoveDistributionChannelsActionSchema",
+    "StoresRemoveSupplyChannelsActionSchema",
     "StoresSetDistributionChannelsActionSchema",
+    "StoresSetSupplyChannelsActionSchema",
 ]
 
 
@@ -42,6 +45,14 @@ class StoreDraftSchema(marshmallow.Schema):
         many=True,
         missing=None,
         data_key="distributionChannels",
+    )
+    supply_channels = helpers.LazyNestedField(
+        nested="commercetools._schemas._channel.ChannelResourceIdentifierSchema",
+        unknown=marshmallow.EXCLUDE,
+        allow_none=True,
+        many=True,
+        missing=None,
+        data_key="supplyChannels",
     )
 
     class Meta:
@@ -152,6 +163,14 @@ class StoreSchema(BaseResourceSchema):
         many=True,
         data_key="distributionChannels",
     )
+    supply_channels = helpers.LazyNestedField(
+        nested="commercetools._schemas._channel.ChannelResourceIdentifierSchema",
+        unknown=marshmallow.EXCLUDE,
+        allow_none=True,
+        many=True,
+        missing=None,
+        data_key="supplyChannels",
+    )
 
     class Meta:
         unknown = marshmallow.EXCLUDE
@@ -186,8 +205,11 @@ class StoreUpdateSchema(marshmallow.Schema):
                 "setLanguages": "commercetools._schemas._store.StoreSetLanguagesActionSchema",
                 "setName": "commercetools._schemas._store.StoreSetNameActionSchema",
                 "addDistributionChannel": "commercetools._schemas._store.StoresAddDistributionChannelsActionSchema",
+                "addSupplyChannel": "commercetools._schemas._store.StoresAddSupplyChannelsActionSchema",
                 "removeDistributionChannel": "commercetools._schemas._store.StoresRemoveDistributionChannelsActionSchema",
+                "removeSupplyChannel": "commercetools._schemas._store.StoresRemoveSupplyChannelsActionSchema",
                 "setDistributionChannels": "commercetools._schemas._store.StoresSetDistributionChannelsActionSchema",
+                "setSupplyChannels": "commercetools._schemas._store.StoresSetSupplyChannelsActionSchema",
             },
             unknown=marshmallow.EXCLUDE,
             allow_none=True,
@@ -252,6 +274,25 @@ class StoresAddDistributionChannelsActionSchema(StoreUpdateActionSchema):
         return types.StoresAddDistributionChannelsAction(**data)
 
 
+class StoresAddSupplyChannelsActionSchema(StoreUpdateActionSchema):
+    """Marshmallow schema for :class:`commercetools.types.StoresAddSupplyChannelsAction`."""
+
+    supply_channel = helpers.LazyNestedField(
+        nested="commercetools._schemas._channel.ChannelResourceIdentifierSchema",
+        unknown=marshmallow.EXCLUDE,
+        allow_none=True,
+        data_key="supplyChannel",
+    )
+
+    class Meta:
+        unknown = marshmallow.EXCLUDE
+
+    @marshmallow.post_load
+    def post_load(self, data, **kwargs):
+        del data["action"]
+        return types.StoresAddSupplyChannelsAction(**data)
+
+
 class StoresRemoveDistributionChannelsActionSchema(StoreUpdateActionSchema):
     """Marshmallow schema for :class:`commercetools.types.StoresRemoveDistributionChannelsAction`."""
 
@@ -269,6 +310,25 @@ class StoresRemoveDistributionChannelsActionSchema(StoreUpdateActionSchema):
     def post_load(self, data, **kwargs):
         del data["action"]
         return types.StoresRemoveDistributionChannelsAction(**data)
+
+
+class StoresRemoveSupplyChannelsActionSchema(StoreUpdateActionSchema):
+    """Marshmallow schema for :class:`commercetools.types.StoresRemoveSupplyChannelsAction`."""
+
+    supply_channel = helpers.LazyNestedField(
+        nested="commercetools._schemas._channel.ChannelResourceIdentifierSchema",
+        unknown=marshmallow.EXCLUDE,
+        allow_none=True,
+        data_key="supplyChannel",
+    )
+
+    class Meta:
+        unknown = marshmallow.EXCLUDE
+
+    @marshmallow.post_load
+    def post_load(self, data, **kwargs):
+        del data["action"]
+        return types.StoresRemoveSupplyChannelsAction(**data)
 
 
 class StoresSetDistributionChannelsActionSchema(StoreUpdateActionSchema):
@@ -290,3 +350,24 @@ class StoresSetDistributionChannelsActionSchema(StoreUpdateActionSchema):
     def post_load(self, data, **kwargs):
         del data["action"]
         return types.StoresSetDistributionChannelsAction(**data)
+
+
+class StoresSetSupplyChannelsActionSchema(StoreUpdateActionSchema):
+    """Marshmallow schema for :class:`commercetools.types.StoresSetSupplyChannelsAction`."""
+
+    supply_channels = helpers.LazyNestedField(
+        nested="commercetools._schemas._channel.ChannelResourceIdentifierSchema",
+        unknown=marshmallow.EXCLUDE,
+        allow_none=True,
+        many=True,
+        missing=None,
+        data_key="supplyChannels",
+    )
+
+    class Meta:
+        unknown = marshmallow.EXCLUDE
+
+    @marshmallow.post_load
+    def post_load(self, data, **kwargs):
+        del data["action"]
+        return types.StoresSetSupplyChannelsAction(**data)

--- a/src/commercetools/_schemas/_subscription.py
+++ b/src/commercetools/_schemas/_subscription.py
@@ -402,7 +402,7 @@ class DeliveryPlatformFormatSchema(DeliveryFormatSchema):
     @marshmallow.post_load
     def post_load(self, data, **kwargs):
         del data["type"]
-        return types.DeliveryPlatformFormat(**data)
+        return types.DeliveryPlatformFormat()
 
 
 class GoogleCloudPubSubDestinationSchema(DestinationSchema):

--- a/src/commercetools/_schemas/_type.py
+++ b/src/commercetools/_schemas/_type.py
@@ -96,7 +96,7 @@ class CustomFieldsDraftSchema(marshmallow.Schema):
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
     )
-    fields = FieldContainerField(allow_none=True, missing=None)
+    fields = FieldContainerField(allow_none=True, missing=None)  # type: ignore
 
     class Meta:
         unknown = marshmallow.EXCLUDE
@@ -114,7 +114,7 @@ class CustomFieldsSchema(marshmallow.Schema):
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
     )
-    fields = FieldContainerField(allow_none=True)
+    fields = FieldContainerField(allow_none=True)  # type: ignore
 
     class Meta:
         unknown = marshmallow.EXCLUDE
@@ -362,7 +362,7 @@ class CustomFieldBooleanTypeSchema(FieldTypeSchema):
     @marshmallow.post_load
     def post_load(self, data, **kwargs):
         del data["name"]
-        return types.CustomFieldBooleanType(**data)
+        return types.CustomFieldBooleanType()
 
 
 class CustomFieldDateTimeTypeSchema(FieldTypeSchema):
@@ -374,7 +374,7 @@ class CustomFieldDateTimeTypeSchema(FieldTypeSchema):
     @marshmallow.post_load
     def post_load(self, data, **kwargs):
         del data["name"]
-        return types.CustomFieldDateTimeType(**data)
+        return types.CustomFieldDateTimeType()
 
 
 class CustomFieldDateTypeSchema(FieldTypeSchema):
@@ -386,7 +386,7 @@ class CustomFieldDateTypeSchema(FieldTypeSchema):
     @marshmallow.post_load
     def post_load(self, data, **kwargs):
         del data["name"]
-        return types.CustomFieldDateType(**data)
+        return types.CustomFieldDateType()
 
 
 class CustomFieldEnumTypeSchema(FieldTypeSchema):
@@ -436,7 +436,7 @@ class CustomFieldLocalizedStringTypeSchema(FieldTypeSchema):
     @marshmallow.post_load
     def post_load(self, data, **kwargs):
         del data["name"]
-        return types.CustomFieldLocalizedStringType(**data)
+        return types.CustomFieldLocalizedStringType()
 
 
 class CustomFieldMoneyTypeSchema(FieldTypeSchema):
@@ -448,7 +448,7 @@ class CustomFieldMoneyTypeSchema(FieldTypeSchema):
     @marshmallow.post_load
     def post_load(self, data, **kwargs):
         del data["name"]
-        return types.CustomFieldMoneyType(**data)
+        return types.CustomFieldMoneyType()
 
 
 class CustomFieldNumberTypeSchema(FieldTypeSchema):
@@ -460,7 +460,7 @@ class CustomFieldNumberTypeSchema(FieldTypeSchema):
     @marshmallow.post_load
     def post_load(self, data, **kwargs):
         del data["name"]
-        return types.CustomFieldNumberType(**data)
+        return types.CustomFieldNumberType()
 
 
 class CustomFieldReferenceTypeSchema(FieldTypeSchema):
@@ -521,7 +521,7 @@ class CustomFieldStringTypeSchema(FieldTypeSchema):
     @marshmallow.post_load
     def post_load(self, data, **kwargs):
         del data["name"]
-        return types.CustomFieldStringType(**data)
+        return types.CustomFieldStringType()
 
 
 class CustomFieldTimeTypeSchema(FieldTypeSchema):
@@ -533,7 +533,7 @@ class CustomFieldTimeTypeSchema(FieldTypeSchema):
     @marshmallow.post_load
     def post_load(self, data, **kwargs):
         del data["name"]
-        return types.CustomFieldTimeType(**data)
+        return types.CustomFieldTimeType()
 
 
 class TypeAddEnumValueActionSchema(TypeUpdateActionSchema):

--- a/src/commercetools/client.py
+++ b/src/commercetools/client.py
@@ -145,6 +145,7 @@ class Client(ServicesMixin):
 
             response = self._http_client.post(self._base_url + endpoint, **kwargs)
             if response.status_code in (200, 201):
+                print(response.json())
                 return response_schema_cls().load(response.json())
             return self._process_error(response)
 

--- a/src/commercetools/client.py
+++ b/src/commercetools/client.py
@@ -145,7 +145,6 @@ class Client(ServicesMixin):
 
             response = self._http_client.post(self._base_url + endpoint, **kwargs)
             if response.status_code in (200, 201):
-                print(response.json())
                 return response_schema_cls().load(response.json())
             return self._process_error(response)
 

--- a/src/commercetools/helpers.py
+++ b/src/commercetools/helpers.py
@@ -57,7 +57,6 @@ class RemoveEmptyValuesMixin:
 
 
 class RegexField(Field):
-
     def _serialize(self, nested_obj, attr, obj):
         result = {}
         data = obj[attr]

--- a/src/commercetools/protocols.py
+++ b/src/commercetools/protocols.py
@@ -1,4 +1,5 @@
 import typing
+
 from marshmallow.base import SchemaABC
 
 

--- a/src/commercetools/testing/abstract.py
+++ b/src/commercetools/testing/abstract.py
@@ -57,7 +57,6 @@ class BaseModel:
 
                 msg = f"A duplicate value '{value}' exists for field '{field}'."
                 error = types.DuplicateFieldError(
-                    code="DuplicateField",
                     message=msg,
                     field=field,
                     duplicate_value=value,

--- a/src/commercetools/testing/abstract.py
+++ b/src/commercetools/testing/abstract.py
@@ -182,6 +182,7 @@ class ServiceBackend(BaseBackend):
     _schema_update: typing.Optional[marshmallow.Schema] = None
     _schema_query_response: typing.Optional[marshmallow.Schema] = None
     _schema_query_params: marshmallow.Schema = GenericSchema
+    _query_default_limit = 20
 
     _verify_version: bool = True
 
@@ -216,8 +217,9 @@ class ServiceBackend(BaseBackend):
         params = utils.parse_request_params(self._schema_query_params, request)
         results = self.model.query(params.get("where"))
         total_count = len(results)
-        if params.get("limit"):
-            results = results[: params["limit"]]
+        limit = params.get("limit", self._query_default_limit)
+        if limit:
+            results = results[: limit]
 
         if params.get("expand"):
             expanded_results = []
@@ -229,6 +231,7 @@ class ServiceBackend(BaseBackend):
             "count": len(results),
             "total": total_count,
             "offset": 0,
+            "limit": limit,
             "results": self.model._resource_schema().load(results, many=True),
         }
         content = self._schema_query_response().dumps(data)

--- a/src/commercetools/testing/abstract.py
+++ b/src/commercetools/testing/abstract.py
@@ -218,7 +218,7 @@ class ServiceBackend(BaseBackend):
         total_count = len(results)
         limit = params.get("limit", self._query_default_limit)
         if limit:
-            results = results[: limit]
+            results = results[:limit]
 
         if params.get("expand"):
             expanded_results = []

--- a/src/commercetools/testing/carts.py
+++ b/src/commercetools/testing/carts.py
@@ -60,10 +60,14 @@ class CartsModel(BaseModel):
         self, draft: types.CartDraft, id: typing.Optional[str] = None
     ) -> types.Cart:
         object_id = str(uuid.UUID(id) if id is not None else uuid.uuid4())
-        line_items = [
-            self._create_line_item_from_draft(draft, line_item)
-            for line_item in draft.line_items
-        ]
+        if draft.line_items:
+            line_items = [
+                self._create_line_item_from_draft(draft, line_item)
+                for line_item in draft.line_items
+            ]
+        else:
+            line_items = []
+
         total_price = None
         taxed_price = None
         if line_items:
@@ -116,14 +120,16 @@ class CartsModel(BaseModel):
             anonymous_id=draft.anonymous_id,
             country=draft.country,
             inventory_mode=draft.inventory_mode,
-            tax_mode=draft.tax_mode,
-            tax_rounding_mode=draft.tax_rounding_mode,
-            tax_calculation_mode=draft.tax_calculation_mode,
+            tax_mode=draft.tax_mode or types.TaxMode.PLATFORM,
+            tax_rounding_mode=draft.tax_rounding_mode or types.RoundingMode.HALF_EVEN,
+            tax_calculation_mode=draft.tax_calculation_mode or types.TaxCalculationMode.LINE_ITEM_LEVEL,
             line_items=line_items,
+            custom_line_items=[],
+            refused_gifts=[],
             shipping_address=draft.shipping_address,
             billing_address=draft.billing_address,
             locale=draft.locale,
-            origin=draft.origin,
+            origin=draft.origin or types.CartOrigin.CUSTOMER,
             created_at=datetime.datetime.now(datetime.timezone.utc),
             last_modified_at=datetime.datetime.now(datetime.timezone.utc),
             custom=utils.create_from_draft(draft.custom),

--- a/src/commercetools/testing/carts.py
+++ b/src/commercetools/testing/carts.py
@@ -10,9 +10,9 @@ from commercetools._schemas._cart import (
     CartSchema,
     CartUpdateSchema,
 )
-from commercetools._schemas._product import ProductSchema
 from commercetools._schemas._order import PaymentInfoSchema
 from commercetools._schemas._payment import PaymentResourceIdentifierSchema
+from commercetools._schemas._product import ProductSchema
 from commercetools.testing import utils
 from commercetools.testing.abstract import BaseModel, ServiceBackend
 
@@ -226,4 +226,3 @@ class CartsBackend(ServiceBackend):
         "setCustomField": set_custom_field,
         "setCustomType": set_custom_type,
     }
-

--- a/src/commercetools/testing/categories.py
+++ b/src/commercetools/testing/categories.py
@@ -31,6 +31,8 @@ class CategoriesModel(BaseModel):
             key=draft.key,
             created_at=datetime.datetime.now(datetime.timezone.utc),
             last_modified_at=datetime.datetime.now(datetime.timezone.utc),
+            ancestors=[],
+            order_hint="",
             custom=utils.create_from_draft(draft.custom),
         )
 

--- a/src/commercetools/testing/customer_groups.py
+++ b/src/commercetools/testing/customer_groups.py
@@ -26,6 +26,7 @@ class CustomerGroupModel(abstract.BaseModel):
             key=draft.key,
             version=1,
             created_at=datetime.datetime.now(datetime.timezone.utc),
+            last_modified_at=datetime.datetime.now(datetime.timezone.utc),
             name=draft.group_name,
             custom=utils.create_from_draft(draft.custom),
         )

--- a/src/commercetools/testing/orders.py
+++ b/src/commercetools/testing/orders.py
@@ -4,6 +4,7 @@ import typing
 import uuid
 
 from commercetools import types
+from commercetools._schemas._cart import CartSchema
 from commercetools._schemas._order import (
     DeliverySchema,
     OrderFromCartDraftSchema,
@@ -11,7 +12,6 @@ from commercetools._schemas._order import (
     OrderSchema,
     OrderUpdateSchema,
 )
-from commercetools._schemas._cart import CartSchema
 from commercetools._schemas._payment import PaymentReferenceSchema
 from commercetools.testing.abstract import BaseModel, ServiceBackend
 from commercetools.testing.utils import (

--- a/src/commercetools/testing/orders.py
+++ b/src/commercetools/testing/orders.py
@@ -68,6 +68,7 @@ def add_delivery():
         delivery = types.Delivery(
             id=str(uuid.uuid4()),
             created_at=datetime.datetime.now(datetime.timezone.utc),
+            items=[],
             parcels=[
                 types.Parcel(
                     id=str(uuid.uuid4()),

--- a/src/commercetools/testing/orders.py
+++ b/src/commercetools/testing/orders.py
@@ -11,6 +11,7 @@ from commercetools._schemas._order import (
     OrderSchema,
     OrderUpdateSchema,
 )
+from commercetools._schemas._cart import CartSchema
 from commercetools._schemas._payment import PaymentReferenceSchema
 from commercetools.testing.abstract import BaseModel, ServiceBackend
 from commercetools.testing.utils import (
@@ -35,11 +36,24 @@ class OrdersModel(BaseModel):
         """
 
         object_id = str(uuid.UUID(id) if id is not None else uuid.uuid4())
+        cart_identifier = types.CartResourceIdentifier(id=draft.id)
+
+        cart_data = self._storage.get_by_resource_identifier(cart_identifier)
+        cart = None
+        if cart_data:
+            cart = CartSchema().load(cart_data)
+
         order = types.Order(
             id=str(object_id),
             version=1,
             created_at=datetime.datetime.now(datetime.timezone.utc),
             last_modified_at=datetime.datetime.now(datetime.timezone.utc),
+            line_items=[],
+            custom_line_items=[],
+            total_price=copy.deepcopy(cart.total_price),
+            sync_info=[],
+            last_message_sequence_number=0,
+            refused_gifts=[],
             order_number=draft.order_number,
             payment_state=draft.payment_state,
             order_state=OrderState.OPEN,

--- a/src/commercetools/testing/payments.py
+++ b/src/commercetools/testing/payments.py
@@ -45,6 +45,7 @@ class PaymentsModel(BaseModel):
                 for transaction in draft.transactions or []
             ],
             custom=utils.create_from_draft(draft.custom),
+            interface_interactions=[],
         )
         return payment
 
@@ -112,7 +113,9 @@ def change_transaction_interaction_id():
 
 def add_interface_interaction():
     def updater(self, obj, action):
-        value = types.CustomFields(fields=getattr(action, "fields"))
+        self.model._storage.get_by_resource_identifier(action.type)
+
+        value = types.CustomFields(type=action.type, fields=getattr(action, "fields"))
         value = CustomFieldsSchema().dump(value)
         if not obj["interfaceInteractions"]:
             obj["interfaceInteractions"] = []

--- a/src/commercetools/testing/product_discounts.py
+++ b/src/commercetools/testing/product_discounts.py
@@ -1,3 +1,4 @@
+import datetime
 import typing
 import uuid
 
@@ -22,6 +23,8 @@ class ProductDiscountsModel(BaseModel):
         return types.ProductDiscount(
             id=str(object_id),
             version=1,
+            created_at=datetime.datetime.now(datetime.timezone.utc),
+            last_modified_at=datetime.datetime.now(datetime.timezone.utc),
             name=draft.name,
             description=draft.description,
             value=draft.value,

--- a/src/commercetools/testing/product_projections.py
+++ b/src/commercetools/testing/product_projections.py
@@ -4,6 +4,7 @@ from commercetools import types
 from commercetools._schemas._product import (
     ProductProjectionPagedQueryResponseSchema,
     ProductProjectionSchema,
+    ProductSchema,
 )
 from commercetools.services.product_projections import _ProductProjectionQuerySchema
 from commercetools.testing import utils
@@ -25,106 +26,125 @@ class ProductProjectionsBackend(ServiceBackend):
 
     def query(self, request):
         params = utils.parse_request_params(_ProductProjectionQuerySchema, request)
-        results = [
-            self._convert_product_projection(product, params["staged"])
-            for product in self.model.objects.values()
-        ]
-        results = [x for x in results if x]
-        if params.get("limit"):
-            results = results[: params["limit"]]
+        limit = params.get("limit")
 
-        if params.get("expand"):
-            expanded_results = []
-            for result in results:
-                expanded_results.append(self._expand(request, result))
-            results = expanded_results
+        results = []
+        found = 0
+        for obj in self.model.objects.values():
+            expanded_obj = self._expand(request, obj)
+            product = ProductSchema().load(expanded_obj)
+
+            result = self._convert_product_projection(product, params["staged"])
+            if result:
+                results.append(result)
+                found += 1
+
+            if limit is not None and found == limit:
+                break
 
         data = {
             "count": len(results),
             "total": len(results),
             "offset": 0,
             "results": results,
+            "limit": limit,
         }
         content = ProductProjectionPagedQueryResponseSchema().dumps(data)
         return create_commercetools_response(request, text=content)
 
     def search(self, request):
-        params = utils.parse_request_params(ProductProjectionsQuerySchema, request)
-        results = [
-            self._convert_product_projection(product, params["staged"])
-            for product in self.model.objects.values()
-        ]
-        results = [x for x in results if x]
-        if params.get("limit"):
-            results = results[: params["limit"]]
+        params = utils.parse_request_params(_ProductProjectionQuerySchema, request)
 
-        if params.get("expand"):
-            expanded_results = []
-            for result in results:
-                expanded_results.append(self._expand(request, result))
-            results = expanded_results
+        limit = params.get("limit")
+
+        results = []
+        found = 0
+        for obj in self.model.objects.values():
+            expanded_obj = self._expand(request, obj)
+            product = ProductSchema().load(expanded_obj)
+
+            result = self._convert_product_projection(product, params["staged"])
+            if result:
+                results.append(results)
+                found += 1
+
+            if limit is not None and found == limit:
+                break
 
         data = {
             "count": len(results),
-            "total": len(results),
+            "total": len(results),  # FIXME
             "offset": 0,
             "results": results,
+            "limit": limit,
         }
         content = ProductProjectionPagedQueryResponseSchema().dumps(data)
         return create_commercetools_response(request, text=content)
 
     def get_by_id(self, request, id):
+        params = utils.parse_request_params(_ProductProjectionQuerySchema, request)
         obj = self.model.get_by_id(id)
         if obj:
             expanded_obj = self._expand(request, obj)
-            content = ProductProjectionSchema().dumps(expanded_obj)
+            product = ProductSchema().load(expanded_obj)
+
+            result = self._convert_product_projection(product, params["staged"])
+            if not result:
+                return create_commercetools_response(request, status_code=404)
+            content = ProductProjectionSchema().dumps(result)
             return create_commercetools_response(request, text=content)
         return create_commercetools_response(request, status_code=404)
 
     def get_by_key(self, request, key):
+        params = utils.parse_request_params(_ProductProjectionQuerySchema, request)
         obj = self.model.get_by_key(key)
         if obj:
             expanded_obj = self._expand(request, obj)
-            content = ProductProjectionSchema().dumps(expanded_obj)
+            product = ProductSchema().load(expanded_obj)
+
+            result = self._convert_product_projection(product, params["staged"])
+            if not result:
+                return create_commercetools_response(request, status_code=404)
+            content = ProductProjectionSchema().dumps(result)
             return create_commercetools_response(request, text=content)
         return create_commercetools_response(request, status_code=404)
 
     def _convert_product_projection(
-        self, product: typing.Dict, staged: bool = False
+        self, product: types.Product, staged: bool = False
     ) -> typing.Optional[typing.Dict]:
         """Convert a Product object to a ProductProjection object"""
-        if product["masterData"] is None:
+        if product.master_data is None:
             return None
 
         if staged:
-            data = product["masterData"]["staged"]
+            data: types.ProductData = product.master_data.staged
         else:
-            data = product["masterData"]["current"]
+            data: types.ProductData = product.master_data.current
 
         if data is None:
             return None
 
-        return {
-            "id": product["id"],
-            "key": product["key"],
-            "version": product["version"],
-            "createdAt": product["createdAt"],
-            "lastModifiedAt": product["lastModifiedAt"],
-            "productType": product["productType"],
-            "name": data["name"],
-            "description": data["description"],
-            "slug": data["slug"],
-            "categories": data["categories"],
-            "categoryOrderHints": data["categoryOrderHints"],
-            "metaTitle": data["metaTitle"],
-            "metaDescription": data["metaDescription"],
-            "metaKeywords": data["metaKeywords"],
-            "searchKeywords": data["searchKeywords"],
-            "hasStagedChanges": product["masterData"]["hasStagedChanges"],
-            "published": product["masterData"]["published"],
-            "masterVariant": data["masterVariant"],
-            "variants": data["variants"],
-            "taxCategory": product["taxCategory"],
-            "state": product["state"],
-            "reviewRatingStatistics": product["reviewRatingStatistics"],
-        }
+        return types.ProductProjection(
+            id=product.id,
+            version=product.version,
+            key=product.key,
+            created_at=product.created_at,
+            last_modified_at=product.last_modified_at,
+            product_type=product.product_type,
+            name=data.name,
+            description=data.description,
+            slug=data.slug,
+            categories=data.categories,
+            category_order_hints=data.category_order_hints,
+            meta_title=data.meta_title,
+            meta_description=data.meta_description,
+            meta_keywords=data.meta_keywords,
+            search_keywords=data.search_keywords,
+            has_staged_changes=product.master_data.has_staged_changes,
+            published=product.master_data.published,
+            master_variant=data.master_variant,
+            variants=data.variants,
+            tax_category=product.tax_category,
+            state=product.state,
+            review_rating_statistics=product.review_rating_statistics,
+        )

--- a/src/commercetools/testing/products.py
+++ b/src/commercetools/testing/products.py
@@ -47,7 +47,7 @@ class ProductsModel(BaseModel):
             master_variant=master_variant,
             variants=[master_variant] if master_variant else [],
             slug=draft.slug or types.LocalizedString(),
-            search_keywords=types.SearchKeywords()
+            search_keywords=types.SearchKeywords(),
         )
 
         if draft.publish:
@@ -167,7 +167,8 @@ class ProductsModel(BaseModel):
             )
         elif isinstance(draft, types.Money):
             return types.CentPrecisionMoney(
-                cent_amount=draft.cent_amount, currency_code=draft.currency_code,
+                cent_amount=draft.cent_amount,
+                currency_code=draft.currency_code,
                 fraction_digits=2,
             )
         else:

--- a/src/commercetools/testing/project.py
+++ b/src/commercetools/testing/project.py
@@ -28,6 +28,7 @@ class ProjectBackend(ServiceBackend):
             "languages": ["en", "nl", "de", "nl-BE"],
             "createdAt": "2018-10-04T11:32:12.603Z",
             "trialUntil": "2018-12",
+            "carts": {},
             "messages": {"enabled": False, "deleteDaysAfterCreation": 15},
             "externalOAuth": None,
             "version": 4,

--- a/src/commercetools/testing/reviews.py
+++ b/src/commercetools/testing/reviews.py
@@ -27,6 +27,7 @@ class ReviewModel(abstract.BaseModel):
             version=1,
             key=draft.key,
             created_at=datetime.datetime.now(datetime.timezone.utc),
+            last_modified_at=datetime.datetime.now(datetime.timezone.utc),
             uniqueness_value=draft.uniqueness_value,
             locale=draft.locale,
             author_name=draft.author_name,

--- a/src/commercetools/testing/shopping_lists.py
+++ b/src/commercetools/testing/shopping_lists.py
@@ -86,6 +86,8 @@ class ShoppingListModel(BaseModel):
         return types.ShoppingList(
             id=str(object_id),
             version=1,
+            created_at=datetime.datetime.now(datetime.timezone.utc),
+            last_modified_at=datetime.datetime.now(datetime.timezone.utc),
             custom=utils.create_from_draft(draft.custom),
             customer=draft.customer,
             delete_days_after_last_modification=draft.delete_days_after_last_modification,

--- a/src/commercetools/testing/states.py
+++ b/src/commercetools/testing/states.py
@@ -32,6 +32,7 @@ class StateModel(BaseModel):
             type=draft.type,
             name=draft.name,
             description=draft.description,
+            built_in=False,
             roles=draft.roles,
             initial=draft.initial or False,
             transitions=create_references_from_resources(self, draft.transitions),

--- a/src/commercetools/testing/stores.py
+++ b/src/commercetools/testing/stores.py
@@ -35,10 +35,11 @@ class StoresModel(BaseModel):
 
         return types.Store(
             id=str(object_id),
+            created_at=datetime.datetime.now(datetime.timezone.utc),
+            last_modified_at=datetime.datetime.now(datetime.timezone.utc),
             version=1,
             key=draft.key,
             name=draft.name,
-            created_at=datetime.datetime.now(datetime.timezone.utc),
             languages=draft.languages,
             distribution_channels=distribution_channels,
         )

--- a/src/commercetools/testing/tax_categories.py
+++ b/src/commercetools/testing/tax_categories.py
@@ -84,7 +84,7 @@ def replace_tax_rate_action():
 class TaxCategoryBackend(ServiceBackend):
     service_path = "tax-categories"
     model_class = TaxCategoryModel
-    _schema_draft = TaxCategorySchema
+    _schema_draft = TaxCategoryDraftSchema
     _schema_update = TaxCategoryUpdateSchema
     _schema_query_response = TaxCategoryPagedQueryResponseSchema
 

--- a/src/commercetools/types/_api_client.py
+++ b/src/commercetools/types/_api_client.py
@@ -26,9 +26,9 @@ class ApiClient(_BaseType):
     def __init__(
         self,
         *,
-        id: str = None,
-        name: str = None,
-        scope: str = None,
+        id: str,
+        name: str,
+        scope: str,
         created_at: typing.Optional[datetime.datetime] = None,
         last_used_at: typing.Optional[datetime.date] = None,
         delete_at: typing.Optional[datetime.datetime] = None,
@@ -69,8 +69,8 @@ class ApiClientDraft(_BaseType):
     def __init__(
         self,
         *,
-        name: str = None,
-        scope: str = None,
+        name: str,
+        scope: str,
         delete_days_after_creation: typing.Optional[int] = None
     ) -> None:
         self.name = name
@@ -101,11 +101,11 @@ class ApiClientPagedQueryResponse(_BaseType):
     def __init__(
         self,
         *,
-        limit: int = None,
-        count: int = None,
-        total: typing.Optional[int] = None,
-        offset: int = None,
-        results: typing.Sequence["ApiClient"] = None
+        limit: int,
+        count: int,
+        offset: int,
+        results: typing.Sequence["ApiClient"],
+        total: typing.Optional[int] = None
     ) -> None:
         self.limit = limit
         self.count = count

--- a/src/commercetools/types/_cart.py
+++ b/src/commercetools/types/_cart.py
@@ -220,27 +220,29 @@ class Cart(BaseResource):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        line_items: typing.List["LineItem"],
+        custom_line_items: typing.List["CustomLineItem"],
+        total_price: "TypedMoney",
+        cart_state: "CartState",
+        tax_mode: "TaxMode",
+        tax_rounding_mode: "RoundingMode",
+        tax_calculation_mode: "TaxCalculationMode",
+        refused_gifts: typing.List["CartDiscountReference"],
+        origin: "CartOrigin",
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
         customer_id: typing.Optional[str] = None,
         customer_email: typing.Optional[str] = None,
         anonymous_id: typing.Optional[str] = None,
         store: typing.Optional["StoreKeyReference"] = None,
-        line_items: typing.List["LineItem"] = None,
-        custom_line_items: typing.List["CustomLineItem"] = None,
-        total_price: "TypedMoney" = None,
         taxed_price: typing.Optional["TaxedPrice"] = None,
-        cart_state: "CartState" = None,
         shipping_address: typing.Optional["Address"] = None,
         billing_address: typing.Optional["Address"] = None,
         inventory_mode: typing.Optional["InventoryMode"] = None,
-        tax_mode: "TaxMode" = None,
-        tax_rounding_mode: "RoundingMode" = None,
-        tax_calculation_mode: "TaxCalculationMode" = None,
         customer_group: typing.Optional["CustomerGroupReference"] = None,
         country: typing.Optional["str"] = None,
         shipping_info: typing.Optional["ShippingInfo"] = None,
@@ -249,8 +251,6 @@ class Cart(BaseResource):
         payment_info: typing.Optional["PaymentInfo"] = None,
         locale: typing.Optional[str] = None,
         delete_days_after_last_modification: typing.Optional[int] = None,
-        refused_gifts: typing.List["CartDiscountReference"] = None,
-        origin: "CartOrigin" = None,
         shipping_rate_input: typing.Optional["ShippingRateInput"] = None,
         item_shipping_addresses: typing.Optional[typing.List["Address"]] = None
     ) -> None:
@@ -386,7 +386,7 @@ class CartDraft(_BaseType):
     def __init__(
         self,
         *,
-        currency: "str" = None,
+        currency: "str",
         customer_id: typing.Optional[str] = None,
         customer_email: typing.Optional[str] = None,
         customer_group: typing.Optional["CustomerGroupResourceIdentifier"] = None,
@@ -490,11 +490,11 @@ class CartPagedQueryResponse(_BaseType):
     def __init__(
         self,
         *,
-        limit: int = None,
-        count: int = None,
-        total: typing.Optional[int] = None,
-        offset: int = None,
-        results: typing.Sequence["Cart"] = None
+        limit: int,
+        count: int,
+        offset: int,
+        results: typing.Sequence["Cart"],
+        total: typing.Optional[int] = None
     ) -> None:
         self.limit = limit
         self.count = count
@@ -514,13 +514,7 @@ class CartReference(Reference):
     #: Optional :class:`commercetools.types.Cart`
     obj: typing.Optional["Cart"]
 
-    def __init__(
-        self,
-        *,
-        type_id: "ReferenceTypeId" = None,
-        id: str = None,
-        obj: typing.Optional["Cart"] = None
-    ) -> None:
+    def __init__(self, *, id: str, obj: typing.Optional["Cart"] = None) -> None:
         self.obj = obj
         super().__init__(type_id=ReferenceTypeId.CART, id=id)
 
@@ -534,11 +528,7 @@ class CartReference(Reference):
 
 class CartResourceIdentifier(ResourceIdentifier):
     def __init__(
-        self,
-        *,
-        type_id: typing.Optional["ReferenceTypeId"] = None,
-        id: typing.Optional[str] = None,
-        key: typing.Optional[str] = None
+        self, *, id: typing.Optional[str] = None, key: typing.Optional[str] = None
     ) -> None:
         super().__init__(type_id=ReferenceTypeId.CART, id=id, key=key)
 
@@ -562,7 +552,7 @@ class CartUpdate(_BaseType):
     #: :class:`list`
     actions: list
 
-    def __init__(self, *, version: int = None, actions: list = None) -> None:
+    def __init__(self, *, version: int, actions: list) -> None:
         self.version = version
         self.actions = actions
         super().__init__()
@@ -575,7 +565,7 @@ class CartUpdateAction(_BaseType):
     #: :class:`str`
     action: str
 
-    def __init__(self, *, action: str = None) -> None:
+    def __init__(self, *, action: str) -> None:
         self.action = action
         super().__init__()
 
@@ -614,19 +604,19 @@ class CustomLineItem(_BaseType):
     def __init__(
         self,
         *,
-        id: str = None,
-        name: "LocalizedString" = None,
-        money: "TypedMoney" = None,
-        taxed_price: typing.Optional["TaxedItemPrice"] = None,
-        total_price: "TypedMoney" = None,
-        slug: str = None,
-        quantity: int = None,
-        state: typing.List["ItemState"] = None,
-        tax_category: typing.Optional["TaxCategoryReference"] = None,
-        tax_rate: typing.Optional["TaxRate"] = None,
+        id: str,
+        name: "LocalizedString",
+        money: "TypedMoney",
+        total_price: "TypedMoney",
+        slug: str,
+        quantity: int,
+        state: typing.List["ItemState"],
         discounted_price_per_quantity: typing.List[
             "DiscountedLineItemPriceForQuantity"
-        ] = None,
+        ],
+        taxed_price: typing.Optional["TaxedItemPrice"] = None,
+        tax_category: typing.Optional["TaxCategoryReference"] = None,
+        tax_rate: typing.Optional["TaxRate"] = None,
         custom: typing.Optional["CustomFields"] = None,
         shipping_details: typing.Optional["ItemShippingDetails"] = None
     ) -> None:
@@ -687,10 +677,10 @@ class CustomLineItemDraft(_BaseType):
     def __init__(
         self,
         *,
-        name: "LocalizedString" = None,
-        quantity: int = None,
-        money: "Money" = None,
-        slug: str = None,
+        name: "LocalizedString",
+        quantity: int,
+        money: "Money",
+        slug: str,
         tax_category: typing.Optional["TaxCategoryResourceIdentifier"] = None,
         external_tax_rate: typing.Optional["ExternalTaxRateDraft"] = None,
         custom: typing.Optional["CustomFields"] = None,
@@ -729,10 +719,7 @@ class DiscountCodeInfo(_BaseType):
     state: "DiscountCodeState"
 
     def __init__(
-        self,
-        *,
-        discount_code: "DiscountCodeReference" = None,
-        state: "DiscountCodeState" = None
+        self, *, discount_code: "DiscountCodeReference", state: "DiscountCodeState"
     ) -> None:
         self.discount_code = discount_code
         self.state = state
@@ -761,10 +748,7 @@ class DiscountedLineItemPortion(_BaseType):
     discounted_amount: "TypedMoney"
 
     def __init__(
-        self,
-        *,
-        discount: "CartDiscountReference" = None,
-        discounted_amount: "TypedMoney" = None
+        self, *, discount: "CartDiscountReference", discounted_amount: "TypedMoney"
     ) -> None:
         self.discount = discount
         self.discounted_amount = discounted_amount
@@ -786,8 +770,8 @@ class DiscountedLineItemPrice(_BaseType):
     def __init__(
         self,
         *,
-        value: "TypedMoney" = None,
-        included_discounts: typing.List["DiscountedLineItemPortion"] = None
+        value: "TypedMoney",
+        included_discounts: typing.List["DiscountedLineItemPortion"]
     ) -> None:
         self.value = value
         self.included_discounts = included_discounts
@@ -807,10 +791,7 @@ class DiscountedLineItemPriceForQuantity(_BaseType):
     discounted_price: "DiscountedLineItemPrice"
 
     def __init__(
-        self,
-        *,
-        quantity: int = None,
-        discounted_price: "DiscountedLineItemPrice" = None
+        self, *, quantity: int, discounted_price: "DiscountedLineItemPrice"
     ) -> None:
         self.quantity = quantity
         self.discounted_price = discounted_price
@@ -829,7 +810,7 @@ class ExternalLineItemTotalPrice(_BaseType):
     #: :class:`commercetools.types.Money` `(Named` ``totalPrice`` `in Commercetools)`
     total_price: "Money"
 
-    def __init__(self, *, price: "Money" = None, total_price: "Money" = None) -> None:
+    def __init__(self, *, price: "Money", total_price: "Money") -> None:
         self.price = price
         self.total_price = total_price
         super().__init__()
@@ -848,7 +829,7 @@ class ExternalTaxAmountDraft(_BaseType):
     tax_rate: "ExternalTaxRateDraft"
 
     def __init__(
-        self, *, total_gross: "Money" = None, tax_rate: "ExternalTaxRateDraft" = None
+        self, *, total_gross: "Money", tax_rate: "ExternalTaxRateDraft"
     ) -> None:
         self.total_gross = total_gross
         self.tax_rate = tax_rate
@@ -878,9 +859,9 @@ class ExternalTaxRateDraft(_BaseType):
     def __init__(
         self,
         *,
-        name: str = None,
+        name: str,
+        country: str,
         amount: typing.Optional[int] = None,
-        country: str = None,
         state: typing.Optional[str] = None,
         sub_rates: typing.Optional[typing.List["SubRate"]] = None,
         included_in_price: typing.Optional[bool] = None
@@ -920,7 +901,7 @@ class ItemShippingDetails(_BaseType):
     valid: bool
 
     def __init__(
-        self, *, targets: typing.List["ItemShippingTarget"] = None, valid: bool = None
+        self, *, targets: typing.List["ItemShippingTarget"], valid: bool
     ) -> None:
         self.targets = targets
         self.valid = valid
@@ -934,7 +915,7 @@ class ItemShippingDetailsDraft(_BaseType):
     #: List of :class:`commercetools.types.ItemShippingTarget`
     targets: typing.List["ItemShippingTarget"]
 
-    def __init__(self, *, targets: typing.List["ItemShippingTarget"] = None) -> None:
+    def __init__(self, *, targets: typing.List["ItemShippingTarget"]) -> None:
         self.targets = targets
         super().__init__()
 
@@ -948,7 +929,7 @@ class ItemShippingTarget(_BaseType):
     #: :class:`int`
     quantity: int
 
-    def __init__(self, *, address_key: str = None, quantity: int = None) -> None:
+    def __init__(self, *, address_key: str, quantity: int) -> None:
         self.address_key = address_key
         self.quantity = quantity
         super().__init__()
@@ -1003,25 +984,25 @@ class LineItem(_BaseType):
     def __init__(
         self,
         *,
-        id: str = None,
-        product_id: str = None,
-        name: "LocalizedString" = None,
+        id: str,
+        product_id: str,
+        name: "LocalizedString",
+        product_type: "ProductTypeReference",
+        variant: "ProductVariant",
+        price: "Price",
+        total_price: "TypedMoney",
+        quantity: int,
+        state: typing.List["ItemState"],
+        discounted_price_per_quantity: typing.List[
+            "DiscountedLineItemPriceForQuantity"
+        ],
+        price_mode: "LineItemPriceMode",
+        line_item_mode: "LineItemMode",
         product_slug: typing.Optional["LocalizedString"] = None,
-        product_type: "ProductTypeReference" = None,
-        variant: "ProductVariant" = None,
-        price: "Price" = None,
         taxed_price: typing.Optional["TaxedItemPrice"] = None,
-        total_price: "TypedMoney" = None,
-        quantity: int = None,
-        state: typing.List["ItemState"] = None,
         tax_rate: typing.Optional["TaxRate"] = None,
         supply_channel: typing.Optional["ChannelReference"] = None,
         distribution_channel: typing.Optional["ChannelReference"] = None,
-        discounted_price_per_quantity: typing.List[
-            "DiscountedLineItemPriceForQuantity"
-        ] = None,
-        price_mode: "LineItemPriceMode" = None,
-        line_item_mode: "LineItemMode" = None,
         custom: typing.Optional["CustomFields"] = None,
         shipping_details: typing.Optional["ItemShippingDetails"] = None
     ) -> None:
@@ -1164,7 +1145,7 @@ class ReplicaCartDraft(_BaseType):
     #: :class:`commercetools.types.CartReference`
     reference: "CartReference"
 
-    def __init__(self, *, reference: "CartReference" = None) -> None:
+    def __init__(self, *, reference: "CartReference") -> None:
         self.reference = reference
         super().__init__()
 
@@ -1203,16 +1184,16 @@ class ShippingInfo(_BaseType):
     def __init__(
         self,
         *,
-        shipping_method_name: str = None,
-        price: "TypedMoney" = None,
-        shipping_rate: "ShippingRate" = None,
+        shipping_method_name: str,
+        price: "TypedMoney",
+        shipping_rate: "ShippingRate",
+        shipping_method_state: "ShippingMethodState",
         taxed_price: typing.Optional["TaxedItemPrice"] = None,
         tax_rate: typing.Optional["TaxRate"] = None,
         tax_category: typing.Optional["TaxCategoryReference"] = None,
         shipping_method: typing.Optional["ShippingMethodReference"] = None,
         deliveries: typing.Optional[typing.List["Delivery"]] = None,
-        discounted_price: typing.Optional["DiscountedLineItemPrice"] = None,
-        shipping_method_state: "ShippingMethodState" = None
+        discounted_price: typing.Optional["DiscountedLineItemPrice"] = None
     ) -> None:
         self.shipping_method_name = shipping_method_name
         self.price = price
@@ -1253,7 +1234,7 @@ class ShippingRateInput(_BaseType):
     #: :class:`str`
     type: str
 
-    def __init__(self, *, type: str = None) -> None:
+    def __init__(self, *, type: str) -> None:
         self.type = type
         super().__init__()
 
@@ -1265,7 +1246,7 @@ class ShippingRateInputDraft(_BaseType):
     #: :class:`str`
     type: str
 
-    def __init__(self, *, type: str = None) -> None:
+    def __init__(self, *, type: str) -> None:
         self.type = type
         super().__init__()
 
@@ -1294,11 +1275,7 @@ class TaxPortion(_BaseType):
     amount: "TypedMoney"
 
     def __init__(
-        self,
-        *,
-        name: typing.Optional[str] = None,
-        rate: float = None,
-        amount: "TypedMoney" = None
+        self, *, rate: float, amount: "TypedMoney", name: typing.Optional[str] = None
     ) -> None:
         self.name = name
         self.rate = rate
@@ -1322,11 +1299,7 @@ class TaxPortionDraft(_BaseType):
     amount: "Money"
 
     def __init__(
-        self,
-        *,
-        name: typing.Optional[str] = None,
-        rate: float = None,
-        amount: "Money" = None
+        self, *, rate: float, amount: "Money", name: typing.Optional[str] = None
     ) -> None:
         self.name = name
         self.rate = rate
@@ -1347,9 +1320,7 @@ class TaxedItemPrice(_BaseType):
     #: :class:`commercetools.types.TypedMoney` `(Named` ``totalGross`` `in Commercetools)`
     total_gross: "TypedMoney"
 
-    def __init__(
-        self, *, total_net: "TypedMoney" = None, total_gross: "TypedMoney" = None
-    ) -> None:
+    def __init__(self, *, total_net: "TypedMoney", total_gross: "TypedMoney") -> None:
         self.total_net = total_net
         self.total_gross = total_gross
         super().__init__()
@@ -1372,9 +1343,9 @@ class TaxedPrice(_BaseType):
     def __init__(
         self,
         *,
-        total_net: "TypedMoney" = None,
-        total_gross: "TypedMoney" = None,
-        tax_portions: typing.List["TaxPortion"] = None
+        total_net: "TypedMoney",
+        total_gross: "TypedMoney",
+        tax_portions: typing.List["TaxPortion"]
     ) -> None:
         self.total_net = total_net
         self.total_gross = total_gross
@@ -1400,9 +1371,9 @@ class TaxedPriceDraft(_BaseType):
     def __init__(
         self,
         *,
-        total_net: "TypedMoneyDraft" = None,
-        total_gross: "TypedMoneyDraft" = None,
-        tax_portions: typing.List["TaxPortionDraft"] = None
+        total_net: "TypedMoneyDraft",
+        total_gross: "TypedMoneyDraft",
+        tax_portions: typing.List["TaxPortionDraft"]
     ) -> None:
         self.total_net = total_net
         self.total_gross = total_gross
@@ -1436,11 +1407,10 @@ class CartAddCustomLineItemAction(CartUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
-        money: "Money" = None,
-        name: "LocalizedString" = None,
-        quantity: int = None,
-        slug: str = None,
+        money: "Money",
+        name: "LocalizedString",
+        quantity: int,
+        slug: str,
         tax_category: typing.Optional["TaxCategoryResourceIdentifier"] = None,
         custom: typing.Optional["CustomFieldsDraft"] = None,
         external_tax_rate: typing.Optional["ExternalTaxRateDraft"] = None
@@ -1474,7 +1444,7 @@ class CartAddDiscountCodeAction(CartUpdateAction):
     #: :class:`str`
     code: str
 
-    def __init__(self, *, action: str = None, code: str = None) -> None:
+    def __init__(self, *, code: str) -> None:
         self.code = code
         super().__init__(action="addDiscountCode")
 
@@ -1489,7 +1459,7 @@ class CartAddItemShippingAddressAction(CartUpdateAction):
     #: :class:`commercetools.types.Address`
     address: "Address"
 
-    def __init__(self, *, action: str = None, address: "Address" = None) -> None:
+    def __init__(self, *, address: "Address") -> None:
         self.address = address
         super().__init__(action="addItemShippingAddress")
 
@@ -1527,7 +1497,6 @@ class CartAddLineItemAction(CartUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
         custom: typing.Optional["CustomFieldsDraft"] = None,
         distribution_channel: typing.Optional["ChannelResourceIdentifier"] = None,
         external_tax_rate: typing.Optional["ExternalTaxRateDraft"] = None,
@@ -1577,9 +1546,7 @@ class CartAddPaymentAction(CartUpdateAction):
     #: :class:`commercetools.types.PaymentResourceIdentifier`
     payment: "PaymentResourceIdentifier"
 
-    def __init__(
-        self, *, action: str = None, payment: "PaymentResourceIdentifier" = None
-    ) -> None:
+    def __init__(self, *, payment: "PaymentResourceIdentifier") -> None:
         self.payment = payment
         super().__init__(action="addPayment")
 
@@ -1601,8 +1568,7 @@ class CartAddShoppingListAction(CartUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
-        shopping_list: "ShoppingListResourceIdentifier" = None,
+        shopping_list: "ShoppingListResourceIdentifier",
         supply_channel: typing.Optional["ChannelResourceIdentifier"] = None,
         distribution_channel: typing.Optional["ChannelResourceIdentifier"] = None
     ) -> None:
@@ -1632,9 +1598,8 @@ class CartApplyDeltaToCustomLineItemShippingDetailsTargetsAction(CartUpdateActio
     def __init__(
         self,
         *,
-        action: str = None,
-        custom_line_item_id: str = None,
-        targets_delta: typing.List["ItemShippingTarget"] = None
+        custom_line_item_id: str,
+        targets_delta: typing.List["ItemShippingTarget"]
     ) -> None:
         self.custom_line_item_id = custom_line_item_id
         self.targets_delta = targets_delta
@@ -1654,11 +1619,7 @@ class CartApplyDeltaToLineItemShippingDetailsTargetsAction(CartUpdateAction):
     targets_delta: typing.List["ItemShippingTarget"]
 
     def __init__(
-        self,
-        *,
-        action: str = None,
-        line_item_id: str = None,
-        targets_delta: typing.List["ItemShippingTarget"] = None
+        self, *, line_item_id: str, targets_delta: typing.List["ItemShippingTarget"]
     ) -> None:
         self.line_item_id = line_item_id
         self.targets_delta = targets_delta
@@ -1677,13 +1638,7 @@ class CartChangeCustomLineItemMoneyAction(CartUpdateAction):
     #: :class:`commercetools.types.Money`
     money: "Money"
 
-    def __init__(
-        self,
-        *,
-        action: str = None,
-        custom_line_item_id: str = None,
-        money: "Money" = None
-    ) -> None:
+    def __init__(self, *, custom_line_item_id: str, money: "Money") -> None:
         self.custom_line_item_id = custom_line_item_id
         self.money = money
         super().__init__(action="changeCustomLineItemMoney")
@@ -1701,13 +1656,7 @@ class CartChangeCustomLineItemQuantityAction(CartUpdateAction):
     #: :class:`int`
     quantity: int
 
-    def __init__(
-        self,
-        *,
-        action: str = None,
-        custom_line_item_id: str = None,
-        quantity: int = None
-    ) -> None:
+    def __init__(self, *, custom_line_item_id: str, quantity: int) -> None:
         self.custom_line_item_id = custom_line_item_id
         self.quantity = quantity
         super().__init__(action="changeCustomLineItemQuantity")
@@ -1732,9 +1681,8 @@ class CartChangeLineItemQuantityAction(CartUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
-        line_item_id: str = None,
-        quantity: int = None,
+        line_item_id: str,
+        quantity: int,
         external_price: typing.Optional["Money"] = None,
         external_total_price: typing.Optional["ExternalLineItemTotalPrice"] = None
     ) -> None:
@@ -1761,9 +1709,7 @@ class CartChangeTaxCalculationModeAction(CartUpdateAction):
     #: :class:`commercetools.types.TaxCalculationMode` `(Named` ``taxCalculationMode`` `in Commercetools)`
     tax_calculation_mode: "TaxCalculationMode"
 
-    def __init__(
-        self, *, action: str = None, tax_calculation_mode: "TaxCalculationMode" = None
-    ) -> None:
+    def __init__(self, *, tax_calculation_mode: "TaxCalculationMode") -> None:
         self.tax_calculation_mode = tax_calculation_mode
         super().__init__(action="changeTaxCalculationMode")
 
@@ -1778,7 +1724,7 @@ class CartChangeTaxModeAction(CartUpdateAction):
     #: :class:`commercetools.types.TaxMode` `(Named` ``taxMode`` `in Commercetools)`
     tax_mode: "TaxMode"
 
-    def __init__(self, *, action: str = None, tax_mode: "TaxMode" = None) -> None:
+    def __init__(self, *, tax_mode: "TaxMode") -> None:
         self.tax_mode = tax_mode
         super().__init__(action="changeTaxMode")
 
@@ -1793,9 +1739,7 @@ class CartChangeTaxRoundingModeAction(CartUpdateAction):
     #: :class:`commercetools.types.RoundingMode` `(Named` ``taxRoundingMode`` `in Commercetools)`
     tax_rounding_mode: "RoundingMode"
 
-    def __init__(
-        self, *, action: str = None, tax_rounding_mode: "RoundingMode" = None
-    ) -> None:
+    def __init__(self, *, tax_rounding_mode: "RoundingMode") -> None:
         self.tax_rounding_mode = tax_rounding_mode
         super().__init__(action="changeTaxRoundingMode")
 
@@ -1810,9 +1754,7 @@ class CartRecalculateAction(CartUpdateAction):
     #: Optional :class:`bool` `(Named` ``updateProductData`` `in Commercetools)`
     update_product_data: typing.Optional[bool]
 
-    def __init__(
-        self, *, action: str = None, update_product_data: typing.Optional[bool] = None
-    ) -> None:
+    def __init__(self, *, update_product_data: typing.Optional[bool] = None) -> None:
         self.update_product_data = update_product_data
         super().__init__(action="recalculate")
 
@@ -1827,7 +1769,7 @@ class CartRemoveCustomLineItemAction(CartUpdateAction):
     #: :class:`str` `(Named` ``customLineItemId`` `in Commercetools)`
     custom_line_item_id: str
 
-    def __init__(self, *, action: str = None, custom_line_item_id: str = None) -> None:
+    def __init__(self, *, custom_line_item_id: str) -> None:
         self.custom_line_item_id = custom_line_item_id
         super().__init__(action="removeCustomLineItem")
 
@@ -1842,9 +1784,7 @@ class CartRemoveDiscountCodeAction(CartUpdateAction):
     #: :class:`commercetools.types.DiscountCodeReference` `(Named` ``discountCode`` `in Commercetools)`
     discount_code: "DiscountCodeReference"
 
-    def __init__(
-        self, *, action: str = None, discount_code: "DiscountCodeReference" = None
-    ) -> None:
+    def __init__(self, *, discount_code: "DiscountCodeReference") -> None:
         self.discount_code = discount_code
         super().__init__(action="removeDiscountCode")
 
@@ -1859,7 +1799,7 @@ class CartRemoveItemShippingAddressAction(CartUpdateAction):
     #: :class:`str` `(Named` ``addressKey`` `in Commercetools)`
     address_key: str
 
-    def __init__(self, *, action: str = None, address_key: str = None) -> None:
+    def __init__(self, *, address_key: str) -> None:
         self.address_key = address_key
         super().__init__(action="removeItemShippingAddress")
 
@@ -1885,8 +1825,7 @@ class CartRemoveLineItemAction(CartUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
-        line_item_id: str = None,
+        line_item_id: str,
         quantity: typing.Optional[int] = None,
         external_price: typing.Optional["Money"] = None,
         external_total_price: typing.Optional["ExternalLineItemTotalPrice"] = None,
@@ -1917,9 +1856,7 @@ class CartRemovePaymentAction(CartUpdateAction):
     #: :class:`commercetools.types.PaymentResourceIdentifier`
     payment: "PaymentResourceIdentifier"
 
-    def __init__(
-        self, *, action: str = None, payment: "PaymentResourceIdentifier" = None
-    ) -> None:
+    def __init__(self, *, payment: "PaymentResourceIdentifier") -> None:
         self.payment = payment
         super().__init__(action="removePayment")
 
@@ -1934,9 +1871,7 @@ class CartSetAnonymousIdAction(CartUpdateAction):
     #: Optional :class:`str` `(Named` ``anonymousId`` `in Commercetools)`
     anonymous_id: typing.Optional[str]
 
-    def __init__(
-        self, *, action: str = None, anonymous_id: typing.Optional[str] = None
-    ) -> None:
+    def __init__(self, *, anonymous_id: typing.Optional[str] = None) -> None:
         self.anonymous_id = anonymous_id
         super().__init__(action="setAnonymousId")
 
@@ -1951,9 +1886,7 @@ class CartSetBillingAddressAction(CartUpdateAction):
     #: Optional :class:`commercetools.types.Address`
     address: typing.Optional["Address"]
 
-    def __init__(
-        self, *, action: str = None, address: typing.Optional["Address"] = None
-    ) -> None:
+    def __init__(self, *, address: typing.Optional["Address"] = None) -> None:
         self.address = address
         super().__init__(action="setBillingAddress")
 
@@ -1973,8 +1906,7 @@ class CartSetCartTotalTaxAction(CartUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
-        external_total_gross: "Money" = None,
+        external_total_gross: "Money",
         external_tax_portions: typing.Optional[typing.List["TaxPortionDraft"]] = None
     ) -> None:
         self.external_total_gross = external_total_gross
@@ -1992,9 +1924,7 @@ class CartSetCountryAction(CartUpdateAction):
     #: Optional :class:`str`
     country: typing.Optional["str"]
 
-    def __init__(
-        self, *, action: str = None, country: typing.Optional["str"] = None
-    ) -> None:
+    def __init__(self, *, country: typing.Optional["str"] = None) -> None:
         self.country = country
         super().__init__(action="setCountry")
 
@@ -2011,13 +1941,7 @@ class CartSetCustomFieldAction(CartUpdateAction):
     #: Optional :class:`typing.Any`
     value: typing.Optional[typing.Any]
 
-    def __init__(
-        self,
-        *,
-        action: str = None,
-        name: str = None,
-        value: typing.Optional[typing.Any] = None
-    ) -> None:
+    def __init__(self, *, name: str, value: typing.Optional[typing.Any] = None) -> None:
         self.name = name
         self.value = value
         super().__init__(action="setCustomField")
@@ -2041,9 +1965,8 @@ class CartSetCustomLineItemCustomFieldAction(CartUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
-        custom_line_item_id: str = None,
-        name: str = None,
+        custom_line_item_id: str,
+        name: str,
         value: typing.Optional[typing.Any] = None
     ) -> None:
         self.custom_line_item_id = custom_line_item_id
@@ -2069,8 +1992,7 @@ class CartSetCustomLineItemCustomTypeAction(CartUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
-        custom_line_item_id: str = None,
+        custom_line_item_id: str,
         type: typing.Optional["TypeResourceIdentifier"] = None,
         fields: typing.Optional["FieldContainer"] = None
     ) -> None:
@@ -2095,8 +2017,7 @@ class CartSetCustomLineItemShippingDetailsAction(CartUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
-        custom_line_item_id: str = None,
+        custom_line_item_id: str,
         shipping_details: typing.Optional["ItemShippingDetailsDraft"] = None
     ) -> None:
         self.custom_line_item_id = custom_line_item_id
@@ -2119,8 +2040,7 @@ class CartSetCustomLineItemTaxAmountAction(CartUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
-        custom_line_item_id: str = None,
+        custom_line_item_id: str,
         external_tax_amount: typing.Optional["ExternalTaxAmountDraft"] = None
     ) -> None:
         self.custom_line_item_id = custom_line_item_id
@@ -2143,8 +2063,7 @@ class CartSetCustomLineItemTaxRateAction(CartUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
-        custom_line_item_id: str = None,
+        custom_line_item_id: str,
         external_tax_rate: typing.Optional["ExternalTaxRateDraft"] = None
     ) -> None:
         self.custom_line_item_id = custom_line_item_id
@@ -2171,9 +2090,8 @@ class CartSetCustomShippingMethodAction(CartUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
-        shipping_method_name: str = None,
-        shipping_rate: "ShippingRateDraft" = None,
+        shipping_method_name: str,
+        shipping_rate: "ShippingRateDraft",
         tax_category: typing.Optional["TaxCategoryResourceIdentifier"] = None,
         external_tax_rate: typing.Optional["ExternalTaxRateDraft"] = None
     ) -> None:
@@ -2205,7 +2123,6 @@ class CartSetCustomTypeAction(CartUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
         type: typing.Optional["TypeResourceIdentifier"] = None,
         fields: typing.Optional["FieldContainer"] = None
     ) -> None:
@@ -2225,7 +2142,7 @@ class CartSetCustomerEmailAction(CartUpdateAction):
     #: :class:`str`
     email: str
 
-    def __init__(self, *, action: str = None, email: str = None) -> None:
+    def __init__(self, *, email: str) -> None:
         self.email = email
         super().__init__(action="setCustomerEmail")
 
@@ -2243,7 +2160,6 @@ class CartSetCustomerGroupAction(CartUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
         customer_group: typing.Optional["CustomerGroupResourceIdentifier"] = None
     ) -> None:
         self.customer_group = customer_group
@@ -2260,9 +2176,7 @@ class CartSetCustomerIdAction(CartUpdateAction):
     #: Optional :class:`str` `(Named` ``customerId`` `in Commercetools)`
     customer_id: typing.Optional[str]
 
-    def __init__(
-        self, *, action: str = None, customer_id: typing.Optional[str] = None
-    ) -> None:
+    def __init__(self, *, customer_id: typing.Optional[str] = None) -> None:
         self.customer_id = customer_id
         super().__init__(action="setCustomerId")
 
@@ -2278,10 +2192,7 @@ class CartSetDeleteDaysAfterLastModificationAction(CartUpdateAction):
     delete_days_after_last_modification: typing.Optional[int]
 
     def __init__(
-        self,
-        *,
-        action: str = None,
-        delete_days_after_last_modification: typing.Optional[int] = None
+        self, *, delete_days_after_last_modification: typing.Optional[int] = None
     ) -> None:
         self.delete_days_after_last_modification = delete_days_after_last_modification
         super().__init__(action="setDeleteDaysAfterLastModification")
@@ -2302,12 +2213,7 @@ class CartSetLineItemCustomFieldAction(CartUpdateAction):
     value: typing.Optional[typing.Any]
 
     def __init__(
-        self,
-        *,
-        action: str = None,
-        line_item_id: str = None,
-        name: str = None,
-        value: typing.Optional[typing.Any] = None
+        self, *, line_item_id: str, name: str, value: typing.Optional[typing.Any] = None
     ) -> None:
         self.line_item_id = line_item_id
         self.name = name
@@ -2332,8 +2238,7 @@ class CartSetLineItemCustomTypeAction(CartUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
-        line_item_id: str = None,
+        line_item_id: str,
         type: typing.Optional["TypeResourceIdentifier"] = None,
         fields: typing.Optional["FieldContainer"] = None
     ) -> None:
@@ -2356,11 +2261,7 @@ class CartSetLineItemPriceAction(CartUpdateAction):
     external_price: typing.Optional["Money"]
 
     def __init__(
-        self,
-        *,
-        action: str = None,
-        line_item_id: str = None,
-        external_price: typing.Optional["Money"] = None
+        self, *, line_item_id: str, external_price: typing.Optional["Money"] = None
     ) -> None:
         self.line_item_id = line_item_id
         self.external_price = external_price
@@ -2382,8 +2283,7 @@ class CartSetLineItemShippingDetailsAction(CartUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
-        line_item_id: str = None,
+        line_item_id: str,
         shipping_details: typing.Optional["ItemShippingDetailsDraft"] = None
     ) -> None:
         self.line_item_id = line_item_id
@@ -2406,8 +2306,7 @@ class CartSetLineItemTaxAmountAction(CartUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
-        line_item_id: str = None,
+        line_item_id: str,
         external_tax_amount: typing.Optional["ExternalTaxAmountDraft"] = None
     ) -> None:
         self.line_item_id = line_item_id
@@ -2430,8 +2329,7 @@ class CartSetLineItemTaxRateAction(CartUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
-        line_item_id: str = None,
+        line_item_id: str,
         external_tax_rate: typing.Optional["ExternalTaxRateDraft"] = None
     ) -> None:
         self.line_item_id = line_item_id
@@ -2454,8 +2352,7 @@ class CartSetLineItemTotalPriceAction(CartUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
-        line_item_id: str = None,
+        line_item_id: str,
         external_total_price: typing.Optional["ExternalLineItemTotalPrice"] = None
     ) -> None:
         self.line_item_id = line_item_id
@@ -2473,9 +2370,7 @@ class CartSetLocaleAction(CartUpdateAction):
     #: Optional :class:`str`
     locale: typing.Optional[str]
 
-    def __init__(
-        self, *, action: str = None, locale: typing.Optional[str] = None
-    ) -> None:
+    def __init__(self, *, locale: typing.Optional[str] = None) -> None:
         self.locale = locale
         super().__init__(action="setLocale")
 
@@ -2487,9 +2382,7 @@ class CartSetShippingAddressAction(CartUpdateAction):
     #: Optional :class:`commercetools.types.Address`
     address: typing.Optional["Address"]
 
-    def __init__(
-        self, *, action: str = None, address: typing.Optional["Address"] = None
-    ) -> None:
+    def __init__(self, *, address: typing.Optional["Address"] = None) -> None:
         self.address = address
         super().__init__(action="setShippingAddress")
 
@@ -2509,7 +2402,6 @@ class CartSetShippingMethodAction(CartUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
         shipping_method: typing.Optional["ShippingMethodResourceIdentifier"] = None,
         external_tax_rate: typing.Optional["ExternalTaxRateDraft"] = None
     ) -> None:
@@ -2529,10 +2421,7 @@ class CartSetShippingMethodTaxAmountAction(CartUpdateAction):
     external_tax_amount: typing.Optional["ExternalTaxAmountDraft"]
 
     def __init__(
-        self,
-        *,
-        action: str = None,
-        external_tax_amount: typing.Optional["ExternalTaxAmountDraft"] = None
+        self, *, external_tax_amount: typing.Optional["ExternalTaxAmountDraft"] = None
     ) -> None:
         self.external_tax_amount = external_tax_amount
         super().__init__(action="setShippingMethodTaxAmount")
@@ -2549,10 +2438,7 @@ class CartSetShippingMethodTaxRateAction(CartUpdateAction):
     external_tax_rate: typing.Optional["ExternalTaxRateDraft"]
 
     def __init__(
-        self,
-        *,
-        action: str = None,
-        external_tax_rate: typing.Optional["ExternalTaxRateDraft"] = None
+        self, *, external_tax_rate: typing.Optional["ExternalTaxRateDraft"] = None
     ) -> None:
         self.external_tax_rate = external_tax_rate
         super().__init__(action="setShippingMethodTaxRate")
@@ -2569,10 +2455,7 @@ class CartSetShippingRateInputAction(CartUpdateAction):
     shipping_rate_input: typing.Optional["ShippingRateInputDraft"]
 
     def __init__(
-        self,
-        *,
-        action: str = None,
-        shipping_rate_input: typing.Optional["ShippingRateInputDraft"] = None
+        self, *, shipping_rate_input: typing.Optional["ShippingRateInputDraft"] = None
     ) -> None:
         self.shipping_rate_input = shipping_rate_input
         super().__init__(action="setShippingRateInput")
@@ -2588,7 +2471,7 @@ class CartUpdateItemShippingAddressAction(CartUpdateAction):
     #: :class:`commercetools.types.Address`
     address: "Address"
 
-    def __init__(self, *, action: str = None, address: "Address" = None) -> None:
+    def __init__(self, *, address: "Address") -> None:
         self.address = address
         super().__init__(action="updateItemShippingAddress")
 
@@ -2605,9 +2488,7 @@ class ClassificationShippingRateInput(ShippingRateInput):
     #: :class:`commercetools.types.LocalizedString`
     label: "LocalizedString"
 
-    def __init__(
-        self, *, type: str = None, key: str = None, label: "LocalizedString" = None
-    ) -> None:
+    def __init__(self, *, key: str, label: "LocalizedString") -> None:
         self.key = key
         self.label = label
         super().__init__(type="Classification")
@@ -2624,7 +2505,7 @@ class ClassificationShippingRateInputDraft(ShippingRateInputDraft):
     #: :class:`str`
     key: str
 
-    def __init__(self, *, type: str = None, key: str = None) -> None:
+    def __init__(self, *, key: str) -> None:
         self.key = key
         super().__init__(type="Classification")
 
@@ -2639,7 +2520,7 @@ class ScoreShippingRateInput(ShippingRateInput):
     #: :class:`int`
     score: int
 
-    def __init__(self, *, type: str = None, score: int = None) -> None:
+    def __init__(self, *, score: int) -> None:
         self.score = score
         super().__init__(type="Score")
 
@@ -2651,7 +2532,7 @@ class ScoreShippingRateInputDraft(ShippingRateInputDraft):
     #: :class:`int`
     score: int
 
-    def __init__(self, *, type: str = None, score: int = None) -> None:
+    def __init__(self, *, score: int) -> None:
         self.score = score
         super().__init__(type="Score")
 

--- a/src/commercetools/types/_cart_discount.py
+++ b/src/commercetools/types/_cart_discount.py
@@ -103,25 +103,25 @@ class CartDiscount(BaseResource):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        name: "LocalizedString",
+        value: "CartDiscountValue",
+        cart_predicate: str,
+        sort_order: str,
+        is_active: bool,
+        requires_discount_code: bool,
+        references: typing.List["Reference"],
+        stacking_mode: "StackingMode",
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
-        name: "LocalizedString" = None,
         key: typing.Optional[str] = None,
         description: typing.Optional["LocalizedString"] = None,
-        value: "CartDiscountValue" = None,
-        cart_predicate: str = None,
         target: typing.Optional["CartDiscountTarget"] = None,
-        sort_order: str = None,
-        is_active: bool = None,
         valid_from: typing.Optional[datetime.datetime] = None,
         valid_until: typing.Optional[datetime.datetime] = None,
-        requires_discount_code: bool = None,
-        references: typing.List["Reference"] = None,
-        stacking_mode: "StackingMode" = None,
         custom: typing.Optional["CustomFields"] = None
     ) -> None:
         self.id = id
@@ -210,17 +210,17 @@ class CartDiscountDraft(_BaseType):
     def __init__(
         self,
         *,
-        name: "LocalizedString" = None,
+        name: "LocalizedString",
+        value: "CartDiscountValueDraft",
+        cart_predicate: str,
+        sort_order: str,
+        requires_discount_code: bool,
         key: typing.Optional[str] = None,
         description: typing.Optional["LocalizedString"] = None,
-        value: "CartDiscountValueDraft" = None,
-        cart_predicate: str = None,
         target: typing.Optional["CartDiscountTarget"] = None,
-        sort_order: str = None,
         is_active: typing.Optional[bool] = None,
         valid_from: typing.Optional[datetime.datetime] = None,
         valid_until: typing.Optional[datetime.datetime] = None,
-        requires_discount_code: bool = None,
         stacking_mode: typing.Optional["StackingMode"] = None,
         custom: typing.Optional["CustomFields"] = None
     ) -> None:
@@ -275,11 +275,11 @@ class CartDiscountPagedQueryResponse(_BaseType):
     def __init__(
         self,
         *,
-        limit: int = None,
-        count: int = None,
-        total: typing.Optional[int] = None,
-        offset: int = None,
-        results: typing.Sequence["CartDiscount"] = None
+        limit: int,
+        count: int,
+        offset: int,
+        results: typing.Sequence["CartDiscount"],
+        total: typing.Optional[int] = None
     ) -> None:
         self.limit = limit
         self.count = count
@@ -299,13 +299,7 @@ class CartDiscountReference(Reference):
     #: Optional :class:`commercetools.types.CartDiscount`
     obj: typing.Optional["CartDiscount"]
 
-    def __init__(
-        self,
-        *,
-        type_id: "ReferenceTypeId" = None,
-        id: str = None,
-        obj: typing.Optional["CartDiscount"] = None
-    ) -> None:
+    def __init__(self, *, id: str, obj: typing.Optional["CartDiscount"] = None) -> None:
         self.obj = obj
         super().__init__(type_id=ReferenceTypeId.CART_DISCOUNT, id=id)
 
@@ -319,11 +313,7 @@ class CartDiscountReference(Reference):
 
 class CartDiscountResourceIdentifier(ResourceIdentifier):
     def __init__(
-        self,
-        *,
-        type_id: typing.Optional["ReferenceTypeId"] = None,
-        id: typing.Optional[str] = None,
-        key: typing.Optional[str] = None
+        self, *, id: typing.Optional[str] = None, key: typing.Optional[str] = None
     ) -> None:
         super().__init__(type_id=ReferenceTypeId.CART_DISCOUNT, id=id, key=key)
 
@@ -339,7 +329,7 @@ class CartDiscountTarget(_BaseType):
     #: :class:`str`
     type: str
 
-    def __init__(self, *, type: str = None) -> None:
+    def __init__(self, *, type: str) -> None:
         self.type = type
         super().__init__()
 
@@ -353,7 +343,7 @@ class CartDiscountUpdate(_BaseType):
     #: :class:`list`
     actions: list
 
-    def __init__(self, *, version: int = None, actions: list = None) -> None:
+    def __init__(self, *, version: int, actions: list) -> None:
         self.version = version
         self.actions = actions
         super().__init__()
@@ -369,7 +359,7 @@ class CartDiscountUpdateAction(_BaseType):
     #: :class:`str`
     action: str
 
-    def __init__(self, *, action: str = None) -> None:
+    def __init__(self, *, action: str) -> None:
         self.action = action
         super().__init__()
 
@@ -381,7 +371,7 @@ class CartDiscountValue(_BaseType):
     #: :class:`str`
     type: str
 
-    def __init__(self, *, type: str = None) -> None:
+    def __init__(self, *, type: str) -> None:
         self.type = type
         super().__init__()
 
@@ -393,7 +383,7 @@ class CartDiscountValueDraft(_BaseType):
     #: :class:`str`
     type: str
 
-    def __init__(self, *, type: str = None) -> None:
+    def __init__(self, *, type: str) -> None:
         self.type = type
         super().__init__()
 
@@ -415,7 +405,7 @@ class CartDiscountChangeCartPredicateAction(CartDiscountUpdateAction):
     #: :class:`str` `(Named` ``cartPredicate`` `in Commercetools)`
     cart_predicate: str
 
-    def __init__(self, *, action: str = None, cart_predicate: str = None) -> None:
+    def __init__(self, *, cart_predicate: str) -> None:
         self.cart_predicate = cart_predicate
         super().__init__(action="changeCartPredicate")
 
@@ -430,7 +420,7 @@ class CartDiscountChangeIsActiveAction(CartDiscountUpdateAction):
     #: :class:`bool` `(Named` ``isActive`` `in Commercetools)`
     is_active: bool
 
-    def __init__(self, *, action: str = None, is_active: bool = None) -> None:
+    def __init__(self, *, is_active: bool) -> None:
         self.is_active = is_active
         super().__init__(action="changeIsActive")
 
@@ -445,7 +435,7 @@ class CartDiscountChangeNameAction(CartDiscountUpdateAction):
     #: :class:`commercetools.types.LocalizedString`
     name: "LocalizedString"
 
-    def __init__(self, *, action: str = None, name: "LocalizedString" = None) -> None:
+    def __init__(self, *, name: "LocalizedString") -> None:
         self.name = name
         super().__init__(action="changeName")
 
@@ -460,9 +450,7 @@ class CartDiscountChangeRequiresDiscountCodeAction(CartDiscountUpdateAction):
     #: :class:`bool` `(Named` ``requiresDiscountCode`` `in Commercetools)`
     requires_discount_code: bool
 
-    def __init__(
-        self, *, action: str = None, requires_discount_code: bool = None
-    ) -> None:
+    def __init__(self, *, requires_discount_code: bool) -> None:
         self.requires_discount_code = requires_discount_code
         super().__init__(action="changeRequiresDiscountCode")
 
@@ -477,7 +465,7 @@ class CartDiscountChangeSortOrderAction(CartDiscountUpdateAction):
     #: :class:`str` `(Named` ``sortOrder`` `in Commercetools)`
     sort_order: str
 
-    def __init__(self, *, action: str = None, sort_order: str = None) -> None:
+    def __init__(self, *, sort_order: str) -> None:
         self.sort_order = sort_order
         super().__init__(action="changeSortOrder")
 
@@ -492,9 +480,7 @@ class CartDiscountChangeStackingModeAction(CartDiscountUpdateAction):
     #: :class:`commercetools.types.StackingMode` `(Named` ``stackingMode`` `in Commercetools)`
     stacking_mode: "StackingMode"
 
-    def __init__(
-        self, *, action: str = None, stacking_mode: "StackingMode" = None
-    ) -> None:
+    def __init__(self, *, stacking_mode: "StackingMode") -> None:
         self.stacking_mode = stacking_mode
         super().__init__(action="changeStackingMode")
 
@@ -509,9 +495,7 @@ class CartDiscountChangeTargetAction(CartDiscountUpdateAction):
     #: :class:`commercetools.types.CartDiscountTarget`
     target: "CartDiscountTarget"
 
-    def __init__(
-        self, *, action: str = None, target: "CartDiscountTarget" = None
-    ) -> None:
+    def __init__(self, *, target: "CartDiscountTarget") -> None:
         self.target = target
         super().__init__(action="changeTarget")
 
@@ -526,9 +510,7 @@ class CartDiscountChangeValueAction(CartDiscountUpdateAction):
     #: :class:`commercetools.types.CartDiscountValueDraft`
     value: "CartDiscountValueDraft"
 
-    def __init__(
-        self, *, action: str = None, value: "CartDiscountValueDraft" = None
-    ) -> None:
+    def __init__(self, *, value: "CartDiscountValueDraft") -> None:
         self.value = value
         super().__init__(action="changeValue")
 
@@ -543,7 +525,7 @@ class CartDiscountCustomLineItemsTarget(CartDiscountTarget):
     #: :class:`str`
     predicate: str
 
-    def __init__(self, *, type: str = None, predicate: str = None) -> None:
+    def __init__(self, *, predicate: str) -> None:
         self.predicate = predicate
         super().__init__(type="customLineItems")
 
@@ -558,7 +540,7 @@ class CartDiscountLineItemsTarget(CartDiscountTarget):
     #: :class:`str`
     predicate: str
 
-    def __init__(self, *, type: str = None, predicate: str = None) -> None:
+    def __init__(self, *, predicate: str) -> None:
         self.predicate = predicate
         super().__init__(type="lineItems")
 
@@ -575,13 +557,7 @@ class CartDiscountSetCustomFieldAction(CartDiscountUpdateAction):
     #: Optional :class:`typing.Any`
     value: typing.Optional[typing.Any]
 
-    def __init__(
-        self,
-        *,
-        action: str = None,
-        name: str = None,
-        value: typing.Optional[typing.Any] = None
-    ) -> None:
+    def __init__(self, *, name: str, value: typing.Optional[typing.Any] = None) -> None:
         self.name = name
         self.value = value
         super().__init__(action="setCustomField")
@@ -603,7 +579,6 @@ class CartDiscountSetCustomTypeAction(CartDiscountUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
         type: typing.Optional["TypeResourceIdentifier"] = None,
         fields: typing.Optional[object] = None
     ) -> None:
@@ -624,10 +599,7 @@ class CartDiscountSetDescriptionAction(CartDiscountUpdateAction):
     description: typing.Optional["LocalizedString"]
 
     def __init__(
-        self,
-        *,
-        action: str = None,
-        description: typing.Optional["LocalizedString"] = None
+        self, *, description: typing.Optional["LocalizedString"] = None
     ) -> None:
         self.description = description
         super().__init__(action="setDescription")
@@ -643,7 +615,7 @@ class CartDiscountSetKeyAction(CartDiscountUpdateAction):
     #: Optional :class:`str`
     key: typing.Optional[str]
 
-    def __init__(self, *, action: str = None, key: typing.Optional[str] = None) -> None:
+    def __init__(self, *, key: typing.Optional[str] = None) -> None:
         self.key = key
         super().__init__(action="setKey")
 
@@ -656,10 +628,7 @@ class CartDiscountSetValidFromAction(CartDiscountUpdateAction):
     valid_from: typing.Optional[datetime.datetime]
 
     def __init__(
-        self,
-        *,
-        action: str = None,
-        valid_from: typing.Optional[datetime.datetime] = None
+        self, *, valid_from: typing.Optional[datetime.datetime] = None
     ) -> None:
         self.valid_from = valid_from
         super().__init__(action="setValidFrom")
@@ -680,7 +649,6 @@ class CartDiscountSetValidFromAndUntilAction(CartDiscountUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
         valid_from: typing.Optional[datetime.datetime] = None,
         valid_until: typing.Optional[datetime.datetime] = None
     ) -> None:
@@ -700,10 +668,7 @@ class CartDiscountSetValidUntilAction(CartDiscountUpdateAction):
     valid_until: typing.Optional[datetime.datetime]
 
     def __init__(
-        self,
-        *,
-        action: str = None,
-        valid_until: typing.Optional[datetime.datetime] = None
+        self, *, valid_until: typing.Optional[datetime.datetime] = None
     ) -> None:
         self.valid_until = valid_until
         super().__init__(action="setValidUntil")
@@ -716,7 +681,7 @@ class CartDiscountSetValidUntilAction(CartDiscountUpdateAction):
 
 
 class CartDiscountShippingCostTarget(CartDiscountTarget):
-    def __init__(self, *, type: str = None) -> None:
+    def __init__(self) -> None:
         super().__init__(type="shipping")
 
     def __repr__(self) -> str:
@@ -727,9 +692,7 @@ class CartDiscountValueAbsolute(CartDiscountValue):
     #: List of :class:`commercetools.types.TypedMoney`
     money: typing.List["TypedMoney"]
 
-    def __init__(
-        self, *, type: str = None, money: typing.List["TypedMoney"] = None
-    ) -> None:
+    def __init__(self, *, money: typing.List["TypedMoney"]) -> None:
         self.money = money
         super().__init__(type="absolute")
 
@@ -741,7 +704,7 @@ class CartDiscountValueAbsoluteDraft(CartDiscountValueDraft):
     #: List of :class:`commercetools.types.Money`
     money: typing.List["Money"]
 
-    def __init__(self, *, type: str = None, money: typing.List["Money"] = None) -> None:
+    def __init__(self, *, money: typing.List["Money"]) -> None:
         self.money = money
         super().__init__(type="absolute")
 
@@ -765,9 +728,8 @@ class CartDiscountValueGiftLineItem(CartDiscountValue):
     def __init__(
         self,
         *,
-        type: str = None,
-        product: "ProductReference" = None,
-        variant_id: int = None,
+        product: "ProductReference",
+        variant_id: int,
         supply_channel: typing.Optional["ChannelReference"] = None,
         distribution_channel: typing.Optional["ChannelReference"] = None
     ) -> None:
@@ -803,9 +765,8 @@ class CartDiscountValueGiftLineItemDraft(CartDiscountValueDraft):
     def __init__(
         self,
         *,
-        type: str = None,
-        product: "ProductReference" = None,
-        variant_id: int = None,
+        product: "ProductReference",
+        variant_id: int,
         supply_channel: typing.Optional["ChannelReference"] = None,
         distribution_channel: typing.Optional["ChannelReference"] = None
     ) -> None:
@@ -832,7 +793,7 @@ class CartDiscountValueRelative(CartDiscountValue):
     #: :class:`int`
     permyriad: int
 
-    def __init__(self, *, type: str = None, permyriad: int = None) -> None:
+    def __init__(self, *, permyriad: int) -> None:
         self.permyriad = permyriad
         super().__init__(type="relative")
 
@@ -847,7 +808,7 @@ class CartDiscountValueRelativeDraft(CartDiscountValueDraft):
     #: :class:`int`
     permyriad: int
 
-    def __init__(self, *, type: str = None, permyriad: int = None) -> None:
+    def __init__(self, *, permyriad: int) -> None:
         self.permyriad = permyriad
         super().__init__(type="relative")
 
@@ -873,12 +834,11 @@ class MultiBuyCustomLineItemsTarget(CartDiscountTarget):
     def __init__(
         self,
         *,
-        type: str = None,
-        predicate: str = None,
-        trigger_quantity: int = None,
-        discounted_quantity: int = None,
-        max_occurrence: typing.Optional[int] = None,
-        selection_mode: "SelectionMode" = None
+        predicate: str,
+        trigger_quantity: int,
+        discounted_quantity: int,
+        selection_mode: "SelectionMode",
+        max_occurrence: typing.Optional[int] = None
     ) -> None:
         self.predicate = predicate
         self.trigger_quantity = trigger_quantity
@@ -916,12 +876,11 @@ class MultiBuyLineItemsTarget(CartDiscountTarget):
     def __init__(
         self,
         *,
-        type: str = None,
-        predicate: str = None,
-        trigger_quantity: int = None,
-        discounted_quantity: int = None,
-        max_occurrence: typing.Optional[int] = None,
-        selection_mode: "SelectionMode" = None
+        predicate: str,
+        trigger_quantity: int,
+        discounted_quantity: int,
+        selection_mode: "SelectionMode",
+        max_occurrence: typing.Optional[int] = None
     ) -> None:
         self.predicate = predicate
         self.trigger_quantity = trigger_quantity

--- a/src/commercetools/types/_category.py
+++ b/src/commercetools/types/_category.py
@@ -101,18 +101,18 @@ class Category(BaseResource):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        name: "LocalizedString",
+        slug: "LocalizedString",
+        ancestors: typing.List["CategoryReference"],
+        order_hint: str,
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
-        name: "LocalizedString" = None,
-        slug: "LocalizedString" = None,
         description: typing.Optional["LocalizedString"] = None,
-        ancestors: typing.List["CategoryReference"] = None,
         parent: typing.Optional["CategoryReference"] = None,
-        order_hint: str = None,
         external_id: typing.Optional[str] = None,
         meta_title: typing.Optional["LocalizedString"] = None,
         meta_description: typing.Optional["LocalizedString"] = None,
@@ -203,8 +203,8 @@ class CategoryDraft(_BaseType):
     def __init__(
         self,
         *,
-        name: "LocalizedString" = None,
-        slug: "LocalizedString" = None,
+        name: "LocalizedString",
+        slug: "LocalizedString",
         description: typing.Optional["LocalizedString"] = None,
         parent: typing.Optional["CategoryResourceIdentifier"] = None,
         order_hint: typing.Optional[str] = None,
@@ -265,11 +265,11 @@ class CategoryPagedQueryResponse(_BaseType):
     def __init__(
         self,
         *,
-        limit: int = None,
-        count: int = None,
-        total: typing.Optional[int] = None,
-        offset: int = None,
-        results: typing.Sequence["Category"] = None
+        limit: int,
+        count: int,
+        offset: int,
+        results: typing.Sequence["Category"],
+        total: typing.Optional[int] = None
     ) -> None:
         self.limit = limit
         self.count = count
@@ -289,13 +289,7 @@ class CategoryReference(Reference):
     #: Optional :class:`commercetools.types.Category`
     obj: typing.Optional["Category"]
 
-    def __init__(
-        self,
-        *,
-        type_id: "ReferenceTypeId" = None,
-        id: str = None,
-        obj: typing.Optional["Category"] = None
-    ) -> None:
+    def __init__(self, *, id: str, obj: typing.Optional["Category"] = None) -> None:
         self.obj = obj
         super().__init__(type_id=ReferenceTypeId.CATEGORY, id=id)
 
@@ -309,11 +303,7 @@ class CategoryReference(Reference):
 
 class CategoryResourceIdentifier(ResourceIdentifier):
     def __init__(
-        self,
-        *,
-        type_id: typing.Optional["ReferenceTypeId"] = None,
-        id: typing.Optional[str] = None,
-        key: typing.Optional[str] = None
+        self, *, id: typing.Optional[str] = None, key: typing.Optional[str] = None
     ) -> None:
         super().__init__(type_id=ReferenceTypeId.CATEGORY, id=id, key=key)
 
@@ -331,7 +321,7 @@ class CategoryUpdate(_BaseType):
     #: :class:`list`
     actions: list
 
-    def __init__(self, *, version: int = None, actions: list = None) -> None:
+    def __init__(self, *, version: int, actions: list) -> None:
         self.version = version
         self.actions = actions
         super().__init__()
@@ -344,7 +334,7 @@ class CategoryUpdateAction(_BaseType):
     #: :class:`str`
     action: str
 
-    def __init__(self, *, action: str = None) -> None:
+    def __init__(self, *, action: str) -> None:
         self.action = action
         super().__init__()
 
@@ -359,11 +349,7 @@ class CategoryAddAssetAction(CategoryUpdateAction):
     position: typing.Optional[int]
 
     def __init__(
-        self,
-        *,
-        action: str = None,
-        asset: "AssetDraft" = None,
-        position: typing.Optional[int] = None
+        self, *, asset: "AssetDraft", position: typing.Optional[int] = None
     ) -> None:
         self.asset = asset
         self.position = position
@@ -388,10 +374,9 @@ class CategoryChangeAssetNameAction(CategoryUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
+        name: "LocalizedString",
         asset_id: typing.Optional[str] = None,
-        asset_key: typing.Optional[str] = None,
-        name: "LocalizedString" = None
+        asset_key: typing.Optional[str] = None
     ) -> None:
         self.asset_id = asset_id
         self.asset_key = asset_key
@@ -409,9 +394,7 @@ class CategoryChangeAssetOrderAction(CategoryUpdateAction):
     #: List of :class:`str` `(Named` ``assetOrder`` `in Commercetools)`
     asset_order: typing.List[str]
 
-    def __init__(
-        self, *, action: str = None, asset_order: typing.List[str] = None
-    ) -> None:
+    def __init__(self, *, asset_order: typing.List[str]) -> None:
         self.asset_order = asset_order
         super().__init__(action="changeAssetOrder")
 
@@ -426,7 +409,7 @@ class CategoryChangeNameAction(CategoryUpdateAction):
     #: :class:`commercetools.types.LocalizedString`
     name: "LocalizedString"
 
-    def __init__(self, *, action: str = None, name: "LocalizedString" = None) -> None:
+    def __init__(self, *, name: "LocalizedString") -> None:
         self.name = name
         super().__init__(action="changeName")
 
@@ -438,7 +421,7 @@ class CategoryChangeOrderHintAction(CategoryUpdateAction):
     #: :class:`str` `(Named` ``orderHint`` `in Commercetools)`
     order_hint: str
 
-    def __init__(self, *, action: str = None, order_hint: str = None) -> None:
+    def __init__(self, *, order_hint: str) -> None:
         self.order_hint = order_hint
         super().__init__(action="changeOrderHint")
 
@@ -453,9 +436,7 @@ class CategoryChangeParentAction(CategoryUpdateAction):
     #: :class:`commercetools.types.CategoryResourceIdentifier`
     parent: "CategoryResourceIdentifier"
 
-    def __init__(
-        self, *, action: str = None, parent: "CategoryResourceIdentifier" = None
-    ) -> None:
+    def __init__(self, *, parent: "CategoryResourceIdentifier") -> None:
         self.parent = parent
         super().__init__(action="changeParent")
 
@@ -470,7 +451,7 @@ class CategoryChangeSlugAction(CategoryUpdateAction):
     #: :class:`commercetools.types.LocalizedString`
     slug: "LocalizedString"
 
-    def __init__(self, *, action: str = None, slug: "LocalizedString" = None) -> None:
+    def __init__(self, *, slug: "LocalizedString") -> None:
         self.slug = slug
         super().__init__(action="changeSlug")
 
@@ -487,7 +468,6 @@ class CategoryRemoveAssetAction(CategoryUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
         asset_id: typing.Optional[str] = None,
         asset_key: typing.Optional[str] = None
     ) -> None:
@@ -516,10 +496,9 @@ class CategorySetAssetCustomFieldAction(CategoryUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
+        name: str,
         asset_id: typing.Optional[str] = None,
         asset_key: typing.Optional[str] = None,
-        name: str = None,
         value: typing.Optional[typing.Any] = None
     ) -> None:
         self.asset_id = asset_id
@@ -548,7 +527,6 @@ class CategorySetAssetCustomTypeAction(CategoryUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
         asset_id: typing.Optional[str] = None,
         asset_key: typing.Optional[str] = None,
         type: typing.Optional["TypeResourceIdentifier"] = None,
@@ -578,7 +556,6 @@ class CategorySetAssetDescriptionAction(CategoryUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
         asset_id: typing.Optional[str] = None,
         asset_key: typing.Optional[str] = None,
         description: typing.Optional["LocalizedString"] = None
@@ -602,11 +579,7 @@ class CategorySetAssetKeyAction(CategoryUpdateAction):
     asset_key: typing.Optional[str]
 
     def __init__(
-        self,
-        *,
-        action: str = None,
-        asset_id: str = None,
-        asset_key: typing.Optional[str] = None
+        self, *, asset_id: str, asset_key: typing.Optional[str] = None
     ) -> None:
         self.asset_id = asset_id
         self.asset_key = asset_key
@@ -631,10 +604,9 @@ class CategorySetAssetSourcesAction(CategoryUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
+        sources: typing.List["AssetSource"],
         asset_id: typing.Optional[str] = None,
-        asset_key: typing.Optional[str] = None,
-        sources: typing.List["AssetSource"] = None
+        asset_key: typing.Optional[str] = None
     ) -> None:
         self.asset_id = asset_id
         self.asset_key = asset_key
@@ -659,7 +631,6 @@ class CategorySetAssetTagsAction(CategoryUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
         asset_id: typing.Optional[str] = None,
         asset_key: typing.Optional[str] = None,
         tags: typing.Optional[typing.List[str]] = None
@@ -682,13 +653,7 @@ class CategorySetCustomFieldAction(CategoryUpdateAction):
     #: Optional :class:`typing.Any`
     value: typing.Optional[typing.Any]
 
-    def __init__(
-        self,
-        *,
-        action: str = None,
-        name: str = None,
-        value: typing.Optional[typing.Any] = None
-    ) -> None:
+    def __init__(self, *, name: str, value: typing.Optional[typing.Any] = None) -> None:
         self.name = name
         self.value = value
         super().__init__(action="setCustomField")
@@ -710,7 +675,6 @@ class CategorySetCustomTypeAction(CategoryUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
         type: typing.Optional["TypeResourceIdentifier"] = None,
         fields: typing.Optional["FieldContainer"] = None
     ) -> None:
@@ -731,10 +695,7 @@ class CategorySetDescriptionAction(CategoryUpdateAction):
     description: typing.Optional["LocalizedString"]
 
     def __init__(
-        self,
-        *,
-        action: str = None,
-        description: typing.Optional["LocalizedString"] = None
+        self, *, description: typing.Optional["LocalizedString"] = None
     ) -> None:
         self.description = description
         super().__init__(action="setDescription")
@@ -750,9 +711,7 @@ class CategorySetExternalIdAction(CategoryUpdateAction):
     #: Optional :class:`str` `(Named` ``externalId`` `in Commercetools)`
     external_id: typing.Optional[str]
 
-    def __init__(
-        self, *, action: str = None, external_id: typing.Optional[str] = None
-    ) -> None:
+    def __init__(self, *, external_id: typing.Optional[str] = None) -> None:
         self.external_id = external_id
         super().__init__(action="setExternalId")
 
@@ -767,7 +726,7 @@ class CategorySetKeyAction(CategoryUpdateAction):
     #: Optional :class:`str`
     key: typing.Optional[str]
 
-    def __init__(self, *, action: str = None, key: typing.Optional[str] = None) -> None:
+    def __init__(self, *, key: typing.Optional[str] = None) -> None:
         self.key = key
         super().__init__(action="setKey")
 
@@ -780,10 +739,7 @@ class CategorySetMetaDescriptionAction(CategoryUpdateAction):
     meta_description: typing.Optional["LocalizedString"]
 
     def __init__(
-        self,
-        *,
-        action: str = None,
-        meta_description: typing.Optional["LocalizedString"] = None
+        self, *, meta_description: typing.Optional["LocalizedString"] = None
     ) -> None:
         self.meta_description = meta_description
         super().__init__(action="setMetaDescription")
@@ -800,10 +756,7 @@ class CategorySetMetaKeywordsAction(CategoryUpdateAction):
     meta_keywords: typing.Optional["LocalizedString"]
 
     def __init__(
-        self,
-        *,
-        action: str = None,
-        meta_keywords: typing.Optional["LocalizedString"] = None
+        self, *, meta_keywords: typing.Optional["LocalizedString"] = None
     ) -> None:
         self.meta_keywords = meta_keywords
         super().__init__(action="setMetaKeywords")
@@ -820,10 +773,7 @@ class CategorySetMetaTitleAction(CategoryUpdateAction):
     meta_title: typing.Optional["LocalizedString"]
 
     def __init__(
-        self,
-        *,
-        action: str = None,
-        meta_title: typing.Optional["LocalizedString"] = None
+        self, *, meta_title: typing.Optional["LocalizedString"] = None
     ) -> None:
         self.meta_title = meta_title
         super().__init__(action="setMetaTitle")

--- a/src/commercetools/types/_channel.py
+++ b/src/commercetools/types/_channel.py
@@ -75,14 +75,14 @@ class Channel(BaseResource):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        key: str,
+        roles: typing.List["ChannelRoleEnum"],
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
-        key: str = None,
-        roles: typing.List["ChannelRoleEnum"] = None,
         name: typing.Optional["LocalizedString"] = None,
         description: typing.Optional["LocalizedString"] = None,
         address: typing.Optional["Address"] = None,
@@ -152,7 +152,7 @@ class ChannelDraft(_BaseType):
     def __init__(
         self,
         *,
-        key: str = None,
+        key: str,
         roles: typing.Optional[typing.List["ChannelRoleEnum"]] = None,
         name: typing.Optional["LocalizedString"] = None,
         description: typing.Optional["LocalizedString"] = None,
@@ -199,11 +199,11 @@ class ChannelPagedQueryResponse(_BaseType):
     def __init__(
         self,
         *,
-        limit: int = None,
-        count: int = None,
-        total: typing.Optional[int] = None,
-        offset: int = None,
-        results: typing.Sequence["Channel"] = None
+        limit: int,
+        count: int,
+        offset: int,
+        results: typing.Sequence["Channel"],
+        total: typing.Optional[int] = None
     ) -> None:
         self.limit = limit
         self.count = count
@@ -223,13 +223,7 @@ class ChannelReference(Reference):
     #: Optional :class:`commercetools.types.Channel`
     obj: typing.Optional["Channel"]
 
-    def __init__(
-        self,
-        *,
-        type_id: "ReferenceTypeId" = None,
-        id: str = None,
-        obj: typing.Optional["Channel"] = None
-    ) -> None:
+    def __init__(self, *, id: str, obj: typing.Optional["Channel"] = None) -> None:
         self.obj = obj
         super().__init__(type_id=ReferenceTypeId.CHANNEL, id=id)
 
@@ -243,11 +237,7 @@ class ChannelReference(Reference):
 
 class ChannelResourceIdentifier(ResourceIdentifier):
     def __init__(
-        self,
-        *,
-        type_id: typing.Optional["ReferenceTypeId"] = None,
-        id: typing.Optional[str] = None,
-        key: typing.Optional[str] = None
+        self, *, id: typing.Optional[str] = None, key: typing.Optional[str] = None
     ) -> None:
         super().__init__(type_id=ReferenceTypeId.CHANNEL, id=id, key=key)
 
@@ -273,7 +263,7 @@ class ChannelUpdate(_BaseType):
     #: :class:`list`
     actions: list
 
-    def __init__(self, *, version: int = None, actions: list = None) -> None:
+    def __init__(self, *, version: int, actions: list) -> None:
         self.version = version
         self.actions = actions
         super().__init__()
@@ -286,7 +276,7 @@ class ChannelUpdateAction(_BaseType):
     #: :class:`str`
     action: str
 
-    def __init__(self, *, action: str = None) -> None:
+    def __init__(self, *, action: str) -> None:
         self.action = action
         super().__init__()
 
@@ -298,9 +288,7 @@ class ChannelAddRolesAction(ChannelUpdateAction):
     #: List of :class:`commercetools.types.ChannelRoleEnum`
     roles: typing.List["ChannelRoleEnum"]
 
-    def __init__(
-        self, *, action: str = None, roles: typing.List["ChannelRoleEnum"] = None
-    ) -> None:
+    def __init__(self, *, roles: typing.List["ChannelRoleEnum"]) -> None:
         self.roles = roles
         super().__init__(action="addRoles")
 
@@ -312,9 +300,7 @@ class ChannelChangeDescriptionAction(ChannelUpdateAction):
     #: :class:`commercetools.types.LocalizedString`
     description: "LocalizedString"
 
-    def __init__(
-        self, *, action: str = None, description: "LocalizedString" = None
-    ) -> None:
+    def __init__(self, *, description: "LocalizedString") -> None:
         self.description = description
         super().__init__(action="changeDescription")
 
@@ -329,7 +315,7 @@ class ChannelChangeKeyAction(ChannelUpdateAction):
     #: :class:`str`
     key: str
 
-    def __init__(self, *, action: str = None, key: str = None) -> None:
+    def __init__(self, *, key: str) -> None:
         self.key = key
         super().__init__(action="changeKey")
 
@@ -341,7 +327,7 @@ class ChannelChangeNameAction(ChannelUpdateAction):
     #: :class:`commercetools.types.LocalizedString`
     name: "LocalizedString"
 
-    def __init__(self, *, action: str = None, name: "LocalizedString" = None) -> None:
+    def __init__(self, *, name: "LocalizedString") -> None:
         self.name = name
         super().__init__(action="changeName")
 
@@ -353,9 +339,7 @@ class ChannelRemoveRolesAction(ChannelUpdateAction):
     #: List of :class:`commercetools.types.ChannelRoleEnum`
     roles: typing.List["ChannelRoleEnum"]
 
-    def __init__(
-        self, *, action: str = None, roles: typing.List["ChannelRoleEnum"] = None
-    ) -> None:
+    def __init__(self, *, roles: typing.List["ChannelRoleEnum"]) -> None:
         self.roles = roles
         super().__init__(action="removeRoles")
 
@@ -370,9 +354,7 @@ class ChannelSetAddressAction(ChannelUpdateAction):
     #: Optional :class:`commercetools.types.Address`
     address: typing.Optional["Address"]
 
-    def __init__(
-        self, *, action: str = None, address: typing.Optional["Address"] = None
-    ) -> None:
+    def __init__(self, *, address: typing.Optional["Address"] = None) -> None:
         self.address = address
         super().__init__(action="setAddress")
 
@@ -389,13 +371,7 @@ class ChannelSetCustomFieldAction(ChannelUpdateAction):
     #: Optional :class:`typing.Any`
     value: typing.Optional[typing.Any]
 
-    def __init__(
-        self,
-        *,
-        action: str = None,
-        name: str = None,
-        value: typing.Optional[typing.Any] = None
-    ) -> None:
+    def __init__(self, *, name: str, value: typing.Optional[typing.Any] = None) -> None:
         self.name = name
         self.value = value
         super().__init__(action="setCustomField")
@@ -417,7 +393,6 @@ class ChannelSetCustomTypeAction(ChannelUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
         type: typing.Optional["TypeResourceIdentifier"] = None,
         fields: typing.Optional["FieldContainer"] = None
     ) -> None:
@@ -437,9 +412,7 @@ class ChannelSetGeoLocationAction(ChannelUpdateAction):
     #: Optional :class:`commercetools.types.GeoJson` `(Named` ``geoLocation`` `in Commercetools)`
     geo_location: typing.Optional["GeoJson"]
 
-    def __init__(
-        self, *, action: str = None, geo_location: typing.Optional["GeoJson"] = None
-    ) -> None:
+    def __init__(self, *, geo_location: typing.Optional["GeoJson"] = None) -> None:
         self.geo_location = geo_location
         super().__init__(action="setGeoLocation")
 
@@ -454,9 +427,7 @@ class ChannelSetRolesAction(ChannelUpdateAction):
     #: List of :class:`commercetools.types.ChannelRoleEnum`
     roles: typing.List["ChannelRoleEnum"]
 
-    def __init__(
-        self, *, action: str = None, roles: typing.List["ChannelRoleEnum"] = None
-    ) -> None:
+    def __init__(self, *, roles: typing.List["ChannelRoleEnum"]) -> None:
         self.roles = roles
         super().__init__(action="setRoles")
 

--- a/src/commercetools/types/_common.py
+++ b/src/commercetools/types/_common.py
@@ -107,6 +107,7 @@ class Address(_BaseType):
     def __init__(
         self,
         *,
+        country: "str",
         id: typing.Optional[str] = None,
         key: typing.Optional[str] = None,
         title: typing.Optional[str] = None,
@@ -120,7 +121,6 @@ class Address(_BaseType):
         city: typing.Optional[str] = None,
         region: typing.Optional[str] = None,
         state: typing.Optional[str] = None,
-        country: "str" = None,
         company: typing.Optional[str] = None,
         department: typing.Optional[str] = None,
         building: typing.Optional[str] = None,
@@ -212,9 +212,9 @@ class Asset(_BaseType):
     def __init__(
         self,
         *,
-        id: str = None,
-        sources: typing.List["AssetSource"] = None,
-        name: "LocalizedString" = None,
+        id: str,
+        sources: typing.List["AssetSource"],
+        name: "LocalizedString",
         description: typing.Optional["LocalizedString"] = None,
         tags: typing.Optional[typing.List[str]] = None,
         custom: typing.Optional["CustomFields"] = None,
@@ -250,7 +250,7 @@ class AssetDimensions(_BaseType):
     #: :class:`int`
     h: int
 
-    def __init__(self, *, w: int = None, h: int = None) -> None:
+    def __init__(self, *, w: int, h: int) -> None:
         self.w = w
         self.h = h
         super().__init__()
@@ -276,8 +276,8 @@ class AssetDraft(_BaseType):
     def __init__(
         self,
         *,
-        sources: typing.List["AssetSource"] = None,
-        name: "LocalizedString" = None,
+        sources: typing.List["AssetSource"],
+        name: "LocalizedString",
         description: typing.Optional["LocalizedString"] = None,
         tags: typing.Optional[typing.List[str]] = None,
         custom: typing.Optional["CustomFieldsDraft"] = None,
@@ -318,7 +318,7 @@ class AssetSource(_BaseType):
     def __init__(
         self,
         *,
-        uri: str = None,
+        uri: str,
         key: typing.Optional[str] = None,
         dimensions: typing.Optional["AssetDimensions"] = None,
         content_type: typing.Optional[str] = None,
@@ -351,10 +351,10 @@ class BaseResource(_BaseType):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
     ) -> None:
         self.id = id
         self.version = version
@@ -408,9 +408,7 @@ class DiscountedPrice(_BaseType):
     #: :class:`commercetools.types.ProductDiscountReference`
     discount: "ProductDiscountReference"
 
-    def __init__(
-        self, *, value: "Money" = None, discount: "ProductDiscountReference" = None
-    ) -> None:
+    def __init__(self, *, value: "Money", discount: "ProductDiscountReference") -> None:
         self.value = value
         self.discount = discount
         super().__init__()
@@ -423,7 +421,7 @@ class GeoJson(_BaseType):
     #: :class:`str`
     type: str
 
-    def __init__(self, *, type: str = None) -> None:
+    def __init__(self, *, type: str) -> None:
         self.type = type
         super().__init__()
 
@@ -442,8 +440,8 @@ class Image(_BaseType):
     def __init__(
         self,
         *,
-        url: str = None,
-        dimensions: "ImageDimensions" = None,
+        url: str,
+        dimensions: "ImageDimensions",
         label: typing.Optional[str] = None,
     ) -> None:
         self.url = url
@@ -465,7 +463,7 @@ class ImageDimensions(_BaseType):
     #: :class:`int`
     h: int
 
-    def __init__(self, *, w: int = None, h: int = None) -> None:
+    def __init__(self, *, w: int, h: int) -> None:
         self.w = w
         self.h = h
         super().__init__()
@@ -480,7 +478,7 @@ class KeyReference(_BaseType):
     #: :class:`str`
     key: str
 
-    def __init__(self, *, type_id: "ReferenceTypeId" = None, key: str = None) -> None:
+    def __init__(self, *, type_id: "ReferenceTypeId", key: str) -> None:
         self.type_id = type_id
         self.key = key
         super().__init__()
@@ -502,7 +500,7 @@ class Money(_BaseType):
     #: :class:`str` `(Named` ``currencyCode`` `in Commercetools)`
     currency_code: "str"
 
-    def __init__(self, *, cent_amount: int = None, currency_code: "str" = None) -> None:
+    def __init__(self, *, cent_amount: int, currency_code: "str") -> None:
         self.cent_amount = cent_amount
         self.currency_code = currency_code
         super().__init__()
@@ -538,11 +536,11 @@ class PagedQueryResponse(_BaseType):
     def __init__(
         self,
         *,
-        limit: int = None,
-        count: int = None,
+        limit: int,
+        count: int,
+        offset: int,
+        results: typing.Sequence["BaseResource"],
         total: typing.Optional[int] = None,
-        offset: int = None,
-        results: typing.Sequence["BaseResource"] = None,
         facets: typing.Optional["FacetResults"] = None,
         meta: typing.Optional[object] = None,
     ) -> None:
@@ -595,8 +593,8 @@ class Price(_BaseType):
     def __init__(
         self,
         *,
-        id: str = None,
-        value: "TypedMoney" = None,
+        id: str,
+        value: "TypedMoney",
         country: typing.Optional["str"] = None,
         customer_group: typing.Optional["CustomerGroupReference"] = None,
         channel: typing.Optional["ChannelReference"] = None,
@@ -659,7 +657,7 @@ class PriceDraft(_BaseType):
     def __init__(
         self,
         *,
-        value: "Money" = None,
+        value: "Money",
         country: typing.Optional["str"] = None,
         customer_group: typing.Optional["CustomerGroupResourceIdentifier"] = None,
         channel: typing.Optional["ChannelResourceIdentifier"] = None,
@@ -703,9 +701,7 @@ class PriceTier(_BaseType):
     #: :class:`commercetools.types.TypedMoney`
     value: "TypedMoney"
 
-    def __init__(
-        self, *, minimum_quantity: int = None, value: "TypedMoney" = None
-    ) -> None:
+    def __init__(self, *, minimum_quantity: int, value: "TypedMoney") -> None:
         self.minimum_quantity = minimum_quantity
         self.value = value
         super().__init__()
@@ -723,7 +719,7 @@ class PriceTierDraft(_BaseType):
     #: :class:`commercetools.types.Money`
     value: "Money"
 
-    def __init__(self, *, minimum_quantity: int = None, value: "Money" = None) -> None:
+    def __init__(self, *, minimum_quantity: int, value: "Money") -> None:
         self.minimum_quantity = minimum_quantity
         self.value = value
         super().__init__()
@@ -760,8 +756,8 @@ class QueryPrice(_BaseType):
     def __init__(
         self,
         *,
-        id: str = None,
-        value: "Money" = None,
+        id: str,
+        value: "Money",
         country: typing.Optional["str"] = None,
         customer_group: typing.Optional["CustomerGroupReference"] = None,
         channel: typing.Optional["ChannelReference"] = None,
@@ -807,7 +803,7 @@ class Reference(_BaseType):
     #: :class:`str`
     id: str
 
-    def __init__(self, *, type_id: "ReferenceTypeId" = None, id: str = None) -> None:
+    def __init__(self, *, type_id: "ReferenceTypeId", id: str) -> None:
         self.type_id = type_id
         self.id = id
         super().__init__()
@@ -895,9 +891,9 @@ class ScopedPrice(_BaseType):
     def __init__(
         self,
         *,
-        id: str = None,
-        value: "TypedMoney" = None,
-        current_value: "TypedMoney" = None,
+        id: str,
+        value: "TypedMoney",
+        current_value: "TypedMoney",
         country: typing.Optional["str"] = None,
         customer_group: typing.Optional["CustomerGroupReference"] = None,
         channel: typing.Optional["ChannelReference"] = None,
@@ -949,10 +945,10 @@ class TypedMoney(_BaseType):
     def __init__(
         self,
         *,
-        type: "MoneyType" = None,
-        fraction_digits: int = None,
-        cent_amount: int = None,
-        currency_code: "str" = None,
+        type: "MoneyType",
+        fraction_digits: int,
+        cent_amount: int,
+        currency_code: "str",
     ) -> None:
         self.type = type
         self.fraction_digits = fraction_digits
@@ -973,7 +969,7 @@ class Update(_BaseType):
     #: :class:`list`
     actions: list
 
-    def __init__(self, *, version: int = None, actions: list = None) -> None:
+    def __init__(self, *, version: int, actions: list) -> None:
         self.version = version
         self.actions = actions
         super().__init__()
@@ -986,7 +982,7 @@ class UpdateAction(_BaseType):
     #: :class:`str`
     action: str
 
-    def __init__(self, *, action: str = None) -> None:
+    def __init__(self, *, action: str) -> None:
         self.action = action
         super().__init__()
 
@@ -996,12 +992,7 @@ class UpdateAction(_BaseType):
 
 class CentPrecisionMoney(TypedMoney):
     def __init__(
-        self,
-        *,
-        type: "MoneyType" = None,
-        fraction_digits: int = None,
-        cent_amount: int = None,
-        currency_code: "str" = None,
+        self, *, fraction_digits: int, cent_amount: int, currency_code: "str"
     ) -> None:
         super().__init__(
             type=MoneyType.CENT_PRECISION,
@@ -1044,7 +1035,7 @@ class GeoJsonPoint(GeoJson):
     #: :class:`list`
     coordinates: list
 
-    def __init__(self, *, type: str = None, coordinates: list = None) -> None:
+    def __init__(self, *, coordinates: list) -> None:
         self.coordinates = coordinates
         super().__init__(type="Point")
 
@@ -1059,11 +1050,10 @@ class HighPrecisionMoney(TypedMoney):
     def __init__(
         self,
         *,
-        type: "MoneyType" = None,
-        fraction_digits: int = None,
-        cent_amount: int = None,
-        currency_code: "str" = None,
-        precise_amount: int = None,
+        fraction_digits: int,
+        cent_amount: int,
+        currency_code: "str",
+        precise_amount: int,
     ) -> None:
         self.precise_amount = precise_amount
         super().__init__(
@@ -1114,11 +1104,7 @@ class TypedMoneyDraft(Money):
     type: "MoneyType"
 
     def __init__(
-        self,
-        *,
-        cent_amount: int = None,
-        currency_code: "str" = None,
-        type: "MoneyType" = None,
+        self, *, cent_amount: int, currency_code: "str", type: "MoneyType"
     ) -> None:
         self.type = type
         super().__init__(cent_amount=cent_amount, currency_code=currency_code)
@@ -1132,13 +1118,7 @@ class TypedMoneyDraft(Money):
 
 
 class CentPrecisionMoneyDraft(TypedMoneyDraft):
-    def __init__(
-        self,
-        *,
-        cent_amount: int = None,
-        currency_code: "str" = None,
-        type: "MoneyType" = None,
-    ) -> None:
+    def __init__(self, *, cent_amount: int, currency_code: "str") -> None:
         super().__init__(
             cent_amount=cent_amount,
             currency_code=currency_code,
@@ -1158,12 +1138,7 @@ class HighPrecisionMoneyDraft(TypedMoneyDraft):
     precise_amount: int
 
     def __init__(
-        self,
-        *,
-        cent_amount: int = None,
-        currency_code: "str" = None,
-        type: "MoneyType" = None,
-        precise_amount: int = None,
+        self, *, cent_amount: int, currency_code: "str", precise_amount: int
     ) -> None:
         self.precise_amount = precise_amount
         super().__init__(

--- a/src/commercetools/types/_custom_object.py
+++ b/src/commercetools/types/_custom_object.py
@@ -38,15 +38,15 @@ class CustomObject(BaseResource):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        container: str,
+        key: str,
+        value: typing.Any,
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
-        created_by: typing.Optional["CreatedBy"] = None,
-        container: str = None,
-        key: str = None,
-        value: typing.Any = None
+        created_by: typing.Optional["CreatedBy"] = None
     ) -> None:
         self.id = id
         self.version = version
@@ -94,9 +94,9 @@ class CustomObjectDraft(_BaseType):
     def __init__(
         self,
         *,
-        container: str = None,
-        key: str = None,
-        value: typing.Any = None,
+        container: str,
+        key: str,
+        value: typing.Any,
         version: typing.Optional[int] = None
     ) -> None:
         self.container = container
@@ -129,11 +129,11 @@ class CustomObjectPagedQueryResponse(_BaseType):
     def __init__(
         self,
         *,
-        limit: int = None,
-        count: int = None,
-        total: typing.Optional[int] = None,
-        offset: int = None,
-        results: typing.Sequence["CustomObject"] = None
+        limit: int,
+        count: int,
+        offset: int,
+        results: typing.Sequence["CustomObject"],
+        total: typing.Optional[int] = None
     ) -> None:
         self.limit = limit
         self.count = count
@@ -153,13 +153,7 @@ class CustomObjectReference(Reference):
     #: Optional :class:`commercetools.types.CustomObject`
     obj: typing.Optional["CustomObject"]
 
-    def __init__(
-        self,
-        *,
-        type_id: "ReferenceTypeId" = None,
-        id: str = None,
-        obj: typing.Optional["CustomObject"] = None
-    ) -> None:
+    def __init__(self, *, id: str, obj: typing.Optional["CustomObject"] = None) -> None:
         self.obj = obj
         super().__init__(type_id=ReferenceTypeId.KEY_VALUE_DOCUMENT, id=id)
 

--- a/src/commercetools/types/_customer.py
+++ b/src/commercetools/types/_customer.py
@@ -137,15 +137,17 @@ class Customer(BaseResource):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        email: str,
+        password: str,
+        addresses: typing.List["Address"],
+        is_email_verified: bool,
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
         customer_number: typing.Optional[str] = None,
-        email: str = None,
-        password: str = None,
         first_name: typing.Optional[str] = None,
         last_name: typing.Optional[str] = None,
         middle_name: typing.Optional[str] = None,
@@ -153,12 +155,10 @@ class Customer(BaseResource):
         date_of_birth: typing.Optional[datetime.date] = None,
         company_name: typing.Optional[str] = None,
         vat_id: typing.Optional[str] = None,
-        addresses: typing.List["Address"] = None,
         default_shipping_address_id: typing.Optional[str] = None,
         shipping_address_ids: typing.Optional[typing.List[str]] = None,
         default_billing_address_id: typing.Optional[str] = None,
         billing_address_ids: typing.Optional[typing.List[str]] = None,
-        is_email_verified: bool = None,
         external_id: typing.Optional[str] = None,
         customer_group: typing.Optional["CustomerGroupReference"] = None,
         custom: typing.Optional["CustomFields"] = None,
@@ -251,12 +251,7 @@ class CustomerChangePassword(_BaseType):
     new_password: str
 
     def __init__(
-        self,
-        *,
-        id: str = None,
-        version: int = None,
-        current_password: str = None,
-        new_password: str = None
+        self, *, id: str, version: int, current_password: str, new_password: str
     ) -> None:
         self.id = id
         self.version = version
@@ -280,11 +275,7 @@ class CustomerCreateEmailToken(_BaseType):
     ttl_minutes: int
 
     def __init__(
-        self,
-        *,
-        id: str = None,
-        version: typing.Optional[int] = None,
-        ttl_minutes: int = None
+        self, *, id: str, ttl_minutes: int, version: typing.Optional[int] = None
     ) -> None:
         self.id = id
         self.version = version
@@ -305,9 +296,7 @@ class CustomerCreatePasswordResetToken(_BaseType):
     #: Optional :class:`int` `(Named` ``ttlMinutes`` `in Commercetools)`
     ttl_minutes: typing.Optional[int]
 
-    def __init__(
-        self, *, email: str = None, ttl_minutes: typing.Optional[int] = None
-    ) -> None:
+    def __init__(self, *, email: str, ttl_minutes: typing.Optional[int] = None) -> None:
         self.email = email
         self.ttl_minutes = ttl_minutes
         super().__init__()
@@ -374,9 +363,9 @@ class CustomerDraft(_BaseType):
     def __init__(
         self,
         *,
+        email: str,
+        password: str,
         customer_number: typing.Optional[str] = None,
-        email: str = None,
-        password: str = None,
         first_name: typing.Optional[str] = None,
         last_name: typing.Optional[str] = None,
         middle_name: typing.Optional[str] = None,
@@ -467,7 +456,7 @@ class CustomerEmailVerify(_BaseType):
     token_value: str
 
     def __init__(
-        self, *, version: typing.Optional[int] = None, token_value: str = None
+        self, *, token_value: str, version: typing.Optional[int] = None
     ) -> None:
         self.version = version
         self.token_value = token_value
@@ -495,11 +484,11 @@ class CustomerPagedQueryResponse(_BaseType):
     def __init__(
         self,
         *,
-        limit: int = None,
-        count: int = None,
-        total: typing.Optional[int] = None,
-        offset: int = None,
-        results: typing.Sequence["Customer"] = None
+        limit: int,
+        count: int,
+        offset: int,
+        results: typing.Sequence["Customer"],
+        total: typing.Optional[int] = None
     ) -> None:
         self.limit = limit
         self.count = count
@@ -519,13 +508,7 @@ class CustomerReference(Reference):
     #: Optional :class:`commercetools.types.Customer`
     obj: typing.Optional["Customer"]
 
-    def __init__(
-        self,
-        *,
-        type_id: "ReferenceTypeId" = None,
-        id: str = None,
-        obj: typing.Optional["Customer"] = None
-    ) -> None:
+    def __init__(self, *, id: str, obj: typing.Optional["Customer"] = None) -> None:
         self.obj = obj
         super().__init__(type_id=ReferenceTypeId.CUSTOMER, id=id)
 
@@ -548,8 +531,8 @@ class CustomerResetPassword(_BaseType):
     def __init__(
         self,
         *,
-        token_value: str = None,
-        new_password: str = None,
+        token_value: str,
+        new_password: str,
         version: typing.Optional[int] = None
     ) -> None:
         self.token_value = token_value
@@ -567,11 +550,7 @@ class CustomerResetPassword(_BaseType):
 
 class CustomerResourceIdentifier(ResourceIdentifier):
     def __init__(
-        self,
-        *,
-        type_id: typing.Optional["ReferenceTypeId"] = None,
-        id: typing.Optional[str] = None,
-        key: typing.Optional[str] = None
+        self, *, id: typing.Optional[str] = None, key: typing.Optional[str] = None
     ) -> None:
         super().__init__(type_id=ReferenceTypeId.CUSTOMER, id=id, key=key)
 
@@ -590,7 +569,7 @@ class CustomerSignInResult(_BaseType):
     cart: typing.Optional[object]
 
     def __init__(
-        self, *, customer: "Customer" = None, cart: typing.Optional[object] = None
+        self, *, customer: "Customer", cart: typing.Optional[object] = None
     ) -> None:
         self.customer = customer
         self.cart = cart
@@ -617,8 +596,8 @@ class CustomerSignin(_BaseType):
     def __init__(
         self,
         *,
-        email: str = None,
-        password: str = None,
+        email: str,
+        password: str,
         anonymous_cart_id: typing.Optional[str] = None,
         anonymous_cart_sign_in_mode: typing.Optional["AnonymousCartSignInMode"] = None,
         anonymous_id: typing.Optional[str] = None,
@@ -663,12 +642,12 @@ class CustomerToken(_BaseType):
     def __init__(
         self,
         *,
-        id: str = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: typing.Optional[datetime.datetime] = None,
-        customer_id: str = None,
-        expires_at: datetime.datetime = None,
-        value: str = None
+        id: str,
+        created_at: datetime.datetime,
+        customer_id: str,
+        expires_at: datetime.datetime,
+        value: str,
+        last_modified_at: typing.Optional[datetime.datetime] = None
     ) -> None:
         self.id = id
         self.created_at = created_at
@@ -698,7 +677,7 @@ class CustomerUpdate(_BaseType):
     #: :class:`list`
     actions: list
 
-    def __init__(self, *, version: int = None, actions: list = None) -> None:
+    def __init__(self, *, version: int, actions: list) -> None:
         self.version = version
         self.actions = actions
         super().__init__()
@@ -711,7 +690,7 @@ class CustomerUpdateAction(_BaseType):
     #: :class:`str`
     action: str
 
-    def __init__(self, *, action: str = None) -> None:
+    def __init__(self, *, action: str) -> None:
         self.action = action
         super().__init__()
 
@@ -723,7 +702,7 @@ class CustomerAddAddressAction(CustomerUpdateAction):
     #: :class:`commercetools.types.Address`
     address: "Address"
 
-    def __init__(self, *, action: str = None, address: "Address" = None) -> None:
+    def __init__(self, *, address: "Address") -> None:
         self.address = address
         super().__init__(action="addAddress")
 
@@ -743,7 +722,6 @@ class CustomerAddBillingAddressIdAction(CustomerUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
         address_id: typing.Optional[str] = None,
         address_key: typing.Optional[str] = None
     ) -> None:
@@ -767,7 +745,6 @@ class CustomerAddShippingAddressIdAction(CustomerUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
         address_id: typing.Optional[str] = None,
         address_key: typing.Optional[str] = None
     ) -> None:
@@ -786,9 +763,7 @@ class CustomerAddStoreAction(CustomerUpdateAction):
     #: :class:`commercetools.types.StoreResourceIdentifier`
     store: "StoreResourceIdentifier"
 
-    def __init__(
-        self, *, action: str = None, store: "StoreResourceIdentifier" = None
-    ) -> None:
+    def __init__(self, *, store: "StoreResourceIdentifier") -> None:
         self.store = store
         super().__init__(action="addStore")
 
@@ -807,10 +782,9 @@ class CustomerChangeAddressAction(CustomerUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
+        address: "Address",
         address_id: typing.Optional[str] = None,
-        address_key: typing.Optional[str] = None,
-        address: "Address" = None
+        address_key: typing.Optional[str] = None
     ) -> None:
         self.address_id = address_id
         self.address_key = address_key
@@ -828,7 +802,7 @@ class CustomerChangeEmailAction(CustomerUpdateAction):
     #: :class:`str`
     email: str
 
-    def __init__(self, *, action: str = None, email: str = None) -> None:
+    def __init__(self, *, email: str) -> None:
         self.email = email
         super().__init__(action="changeEmail")
 
@@ -848,7 +822,6 @@ class CustomerRemoveAddressAction(CustomerUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
         address_id: typing.Optional[str] = None,
         address_key: typing.Optional[str] = None
     ) -> None:
@@ -872,7 +845,6 @@ class CustomerRemoveBillingAddressIdAction(CustomerUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
         address_id: typing.Optional[str] = None,
         address_key: typing.Optional[str] = None
     ) -> None:
@@ -896,7 +868,6 @@ class CustomerRemoveShippingAddressIdAction(CustomerUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
         address_id: typing.Optional[str] = None,
         address_key: typing.Optional[str] = None
     ) -> None:
@@ -915,9 +886,7 @@ class CustomerRemoveStoreAction(CustomerUpdateAction):
     #: :class:`commercetools.types.StoreResourceIdentifier`
     store: "StoreResourceIdentifier"
 
-    def __init__(
-        self, *, action: str = None, store: "StoreResourceIdentifier" = None
-    ) -> None:
+    def __init__(self, *, store: "StoreResourceIdentifier") -> None:
         self.store = store
         super().__init__(action="removeStore")
 
@@ -932,9 +901,7 @@ class CustomerSetCompanyNameAction(CustomerUpdateAction):
     #: Optional :class:`str` `(Named` ``companyName`` `in Commercetools)`
     company_name: typing.Optional[str]
 
-    def __init__(
-        self, *, action: str = None, company_name: typing.Optional[str] = None
-    ) -> None:
+    def __init__(self, *, company_name: typing.Optional[str] = None) -> None:
         self.company_name = company_name
         super().__init__(action="setCompanyName")
 
@@ -951,13 +918,7 @@ class CustomerSetCustomFieldAction(CustomerUpdateAction):
     #: Optional :class:`typing.Any`
     value: typing.Optional[typing.Any]
 
-    def __init__(
-        self,
-        *,
-        action: str = None,
-        name: str = None,
-        value: typing.Optional[typing.Any] = None
-    ) -> None:
+    def __init__(self, *, name: str, value: typing.Optional[typing.Any] = None) -> None:
         self.name = name
         self.value = value
         super().__init__(action="setCustomField")
@@ -979,7 +940,6 @@ class CustomerSetCustomTypeAction(CustomerUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
         type: typing.Optional["TypeResourceIdentifier"] = None,
         fields: typing.Optional["FieldContainer"] = None
     ) -> None:
@@ -1002,7 +962,6 @@ class CustomerSetCustomerGroupAction(CustomerUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
         customer_group: typing.Optional["CustomerGroupResourceIdentifier"] = None
     ) -> None:
         self.customer_group = customer_group
@@ -1019,9 +978,7 @@ class CustomerSetCustomerNumberAction(CustomerUpdateAction):
     #: Optional :class:`str` `(Named` ``customerNumber`` `in Commercetools)`
     customer_number: typing.Optional[str]
 
-    def __init__(
-        self, *, action: str = None, customer_number: typing.Optional[str] = None
-    ) -> None:
+    def __init__(self, *, customer_number: typing.Optional[str] = None) -> None:
         self.customer_number = customer_number
         super().__init__(action="setCustomerNumber")
 
@@ -1036,12 +993,7 @@ class CustomerSetDateOfBirthAction(CustomerUpdateAction):
     #: Optional :class:`datetime.date` `(Named` ``dateOfBirth`` `in Commercetools)`
     date_of_birth: typing.Optional[datetime.date]
 
-    def __init__(
-        self,
-        *,
-        action: str = None,
-        date_of_birth: typing.Optional[datetime.date] = None
-    ) -> None:
+    def __init__(self, *, date_of_birth: typing.Optional[datetime.date] = None) -> None:
         self.date_of_birth = date_of_birth
         super().__init__(action="setDateOfBirth")
 
@@ -1061,7 +1013,6 @@ class CustomerSetDefaultBillingAddressAction(CustomerUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
         address_id: typing.Optional[str] = None,
         address_key: typing.Optional[str] = None
     ) -> None:
@@ -1085,7 +1036,6 @@ class CustomerSetDefaultShippingAddressAction(CustomerUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
         address_id: typing.Optional[str] = None,
         address_key: typing.Optional[str] = None
     ) -> None:
@@ -1104,9 +1054,7 @@ class CustomerSetExternalIdAction(CustomerUpdateAction):
     #: Optional :class:`str` `(Named` ``externalId`` `in Commercetools)`
     external_id: typing.Optional[str]
 
-    def __init__(
-        self, *, action: str = None, external_id: typing.Optional[str] = None
-    ) -> None:
+    def __init__(self, *, external_id: typing.Optional[str] = None) -> None:
         self.external_id = external_id
         super().__init__(action="setExternalId")
 
@@ -1121,9 +1069,7 @@ class CustomerSetFirstNameAction(CustomerUpdateAction):
     #: Optional :class:`str` `(Named` ``firstName`` `in Commercetools)`
     first_name: typing.Optional[str]
 
-    def __init__(
-        self, *, action: str = None, first_name: typing.Optional[str] = None
-    ) -> None:
+    def __init__(self, *, first_name: typing.Optional[str] = None) -> None:
         self.first_name = first_name
         super().__init__(action="setFirstName")
 
@@ -1138,7 +1084,7 @@ class CustomerSetKeyAction(CustomerUpdateAction):
     #: Optional :class:`str`
     key: typing.Optional[str]
 
-    def __init__(self, *, action: str = None, key: typing.Optional[str] = None) -> None:
+    def __init__(self, *, key: typing.Optional[str] = None) -> None:
         self.key = key
         super().__init__(action="setKey")
 
@@ -1150,9 +1096,7 @@ class CustomerSetLastNameAction(CustomerUpdateAction):
     #: Optional :class:`str` `(Named` ``lastName`` `in Commercetools)`
     last_name: typing.Optional[str]
 
-    def __init__(
-        self, *, action: str = None, last_name: typing.Optional[str] = None
-    ) -> None:
+    def __init__(self, *, last_name: typing.Optional[str] = None) -> None:
         self.last_name = last_name
         super().__init__(action="setLastName")
 
@@ -1167,9 +1111,7 @@ class CustomerSetLocaleAction(CustomerUpdateAction):
     #: Optional :class:`str`
     locale: typing.Optional[str]
 
-    def __init__(
-        self, *, action: str = None, locale: typing.Optional[str] = None
-    ) -> None:
+    def __init__(self, *, locale: typing.Optional[str] = None) -> None:
         self.locale = locale
         super().__init__(action="setLocale")
 
@@ -1184,9 +1126,7 @@ class CustomerSetMiddleNameAction(CustomerUpdateAction):
     #: Optional :class:`str` `(Named` ``middleName`` `in Commercetools)`
     middle_name: typing.Optional[str]
 
-    def __init__(
-        self, *, action: str = None, middle_name: typing.Optional[str] = None
-    ) -> None:
+    def __init__(self, *, middle_name: typing.Optional[str] = None) -> None:
         self.middle_name = middle_name
         super().__init__(action="setMiddleName")
 
@@ -1201,9 +1141,7 @@ class CustomerSetSalutationAction(CustomerUpdateAction):
     #: Optional :class:`str`
     salutation: typing.Optional[str]
 
-    def __init__(
-        self, *, action: str = None, salutation: typing.Optional[str] = None
-    ) -> None:
+    def __init__(self, *, salutation: typing.Optional[str] = None) -> None:
         self.salutation = salutation
         super().__init__(action="setSalutation")
 
@@ -1219,10 +1157,7 @@ class CustomerSetStoresAction(CustomerUpdateAction):
     stores: typing.Optional[typing.List["StoreResourceIdentifier"]]
 
     def __init__(
-        self,
-        *,
-        action: str = None,
-        stores: typing.Optional[typing.List["StoreResourceIdentifier"]] = None
+        self, *, stores: typing.Optional[typing.List["StoreResourceIdentifier"]] = None
     ) -> None:
         self.stores = stores
         super().__init__(action="setStores")
@@ -1238,9 +1173,7 @@ class CustomerSetTitleAction(CustomerUpdateAction):
     #: Optional :class:`str`
     title: typing.Optional[str]
 
-    def __init__(
-        self, *, action: str = None, title: typing.Optional[str] = None
-    ) -> None:
+    def __init__(self, *, title: typing.Optional[str] = None) -> None:
         self.title = title
         super().__init__(action="setTitle")
 
@@ -1252,9 +1185,7 @@ class CustomerSetVatIdAction(CustomerUpdateAction):
     #: Optional :class:`str` `(Named` ``vatId`` `in Commercetools)`
     vat_id: typing.Optional[str]
 
-    def __init__(
-        self, *, action: str = None, vat_id: typing.Optional[str] = None
-    ) -> None:
+    def __init__(self, *, vat_id: typing.Optional[str] = None) -> None:
         self.vat_id = vat_id
         super().__init__(action="setVatId")
 

--- a/src/commercetools/types/_customer_group.py
+++ b/src/commercetools/types/_customer_group.py
@@ -51,14 +51,14 @@ class CustomerGroup(BaseResource):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        name: str,
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
         key: typing.Optional[str] = None,
-        name: str = None,
         custom: typing.Optional["CustomFields"] = None
     ) -> None:
         self.id = id
@@ -105,8 +105,8 @@ class CustomerGroupDraft(_BaseType):
     def __init__(
         self,
         *,
+        group_name: str,
         key: typing.Optional[str] = None,
-        group_name: str = None,
         custom: typing.Optional["CustomFields"] = None
     ) -> None:
         self.key = key
@@ -137,11 +137,11 @@ class CustomerGroupPagedQueryResponse(_BaseType):
     def __init__(
         self,
         *,
-        limit: int = None,
-        count: int = None,
-        total: typing.Optional[int] = None,
-        offset: int = None,
-        results: typing.Sequence["CustomerGroup"] = None
+        limit: int,
+        count: int,
+        offset: int,
+        results: typing.Sequence["CustomerGroup"],
+        total: typing.Optional[int] = None
     ) -> None:
         self.limit = limit
         self.count = count
@@ -162,11 +162,7 @@ class CustomerGroupReference(Reference):
     obj: typing.Optional["CustomerGroup"]
 
     def __init__(
-        self,
-        *,
-        type_id: "ReferenceTypeId" = None,
-        id: str = None,
-        obj: typing.Optional["CustomerGroup"] = None
+        self, *, id: str, obj: typing.Optional["CustomerGroup"] = None
     ) -> None:
         self.obj = obj
         super().__init__(type_id=ReferenceTypeId.CUSTOMER_GROUP, id=id)
@@ -181,11 +177,7 @@ class CustomerGroupReference(Reference):
 
 class CustomerGroupResourceIdentifier(ResourceIdentifier):
     def __init__(
-        self,
-        *,
-        type_id: typing.Optional["ReferenceTypeId"] = None,
-        id: typing.Optional[str] = None,
-        key: typing.Optional[str] = None
+        self, *, id: typing.Optional[str] = None, key: typing.Optional[str] = None
     ) -> None:
         super().__init__(type_id=ReferenceTypeId.CUSTOMER_GROUP, id=id, key=key)
 
@@ -203,7 +195,7 @@ class CustomerGroupUpdate(_BaseType):
     #: :class:`list`
     actions: list
 
-    def __init__(self, *, version: int = None, actions: list = None) -> None:
+    def __init__(self, *, version: int, actions: list) -> None:
         self.version = version
         self.actions = actions
         super().__init__()
@@ -219,7 +211,7 @@ class CustomerGroupUpdateAction(_BaseType):
     #: :class:`str`
     action: str
 
-    def __init__(self, *, action: str = None) -> None:
+    def __init__(self, *, action: str) -> None:
         self.action = action
         super().__init__()
 
@@ -231,7 +223,7 @@ class CustomerGroupChangeNameAction(CustomerGroupUpdateAction):
     #: :class:`str`
     name: str
 
-    def __init__(self, *, action: str = None, name: str = None) -> None:
+    def __init__(self, *, name: str) -> None:
         self.name = name
         super().__init__(action="changeName")
 
@@ -248,13 +240,7 @@ class CustomerGroupSetCustomFieldAction(CustomerGroupUpdateAction):
     #: Optional :class:`typing.Any`
     value: typing.Optional[typing.Any]
 
-    def __init__(
-        self,
-        *,
-        action: str = None,
-        name: str = None,
-        value: typing.Optional[typing.Any] = None
-    ) -> None:
+    def __init__(self, *, name: str, value: typing.Optional[typing.Any] = None) -> None:
         self.name = name
         self.value = value
         super().__init__(action="setCustomField")
@@ -276,7 +262,6 @@ class CustomerGroupSetCustomTypeAction(CustomerGroupUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
         type: typing.Optional["TypeResourceIdentifier"] = None,
         fields: typing.Optional["FieldContainer"] = None
     ) -> None:
@@ -296,7 +281,7 @@ class CustomerGroupSetKeyAction(CustomerGroupUpdateAction):
     #: Optional :class:`str`
     key: typing.Optional[str]
 
-    def __init__(self, *, action: str = None, key: typing.Optional[str] = None) -> None:
+    def __init__(self, *, key: typing.Optional[str] = None) -> None:
         self.key = key
         super().__init__(action="setKey")
 

--- a/src/commercetools/types/_discount_code.py
+++ b/src/commercetools/types/_discount_code.py
@@ -86,23 +86,23 @@ class DiscountCode(BaseResource):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        code: str,
+        cart_discounts: typing.List["CartDiscountReference"],
+        is_active: bool,
+        references: typing.List["Reference"],
+        groups: typing.List[str],
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
         name: typing.Optional["LocalizedString"] = None,
         description: typing.Optional["LocalizedString"] = None,
-        code: str = None,
-        cart_discounts: typing.List["CartDiscountReference"] = None,
         cart_predicate: typing.Optional[str] = None,
-        is_active: bool = None,
-        references: typing.List["Reference"] = None,
         max_applications: typing.Optional[int] = None,
         max_applications_per_customer: typing.Optional[int] = None,
         custom: typing.Optional["CustomFields"] = None,
-        groups: typing.List[str] = None,
         valid_from: typing.Optional[datetime.datetime] = None,
         valid_until: typing.Optional[datetime.datetime] = None
     ) -> None:
@@ -188,10 +188,10 @@ class DiscountCodeDraft(_BaseType):
     def __init__(
         self,
         *,
+        code: str,
+        cart_discounts: typing.List["CartDiscountResourceIdentifier"],
         name: typing.Optional["LocalizedString"] = None,
         description: typing.Optional["LocalizedString"] = None,
-        code: str = None,
-        cart_discounts: typing.List["CartDiscountResourceIdentifier"] = None,
         cart_predicate: typing.Optional[str] = None,
         is_active: typing.Optional[bool] = None,
         max_applications: typing.Optional[int] = None,
@@ -250,11 +250,11 @@ class DiscountCodePagedQueryResponse(_BaseType):
     def __init__(
         self,
         *,
-        limit: int = None,
-        count: int = None,
-        total: typing.Optional[int] = None,
-        offset: int = None,
-        results: typing.Sequence["DiscountCode"] = None
+        limit: int,
+        count: int,
+        offset: int,
+        results: typing.Sequence["DiscountCode"],
+        total: typing.Optional[int] = None
     ) -> None:
         self.limit = limit
         self.count = count
@@ -274,13 +274,7 @@ class DiscountCodeReference(Reference):
     #: Optional :class:`commercetools.types.DiscountCode`
     obj: typing.Optional["DiscountCode"]
 
-    def __init__(
-        self,
-        *,
-        type_id: "ReferenceTypeId" = None,
-        id: str = None,
-        obj: typing.Optional["DiscountCode"] = None
-    ) -> None:
+    def __init__(self, *, id: str, obj: typing.Optional["DiscountCode"] = None) -> None:
         self.obj = obj
         super().__init__(type_id=ReferenceTypeId.DISCOUNT_CODE, id=id)
 
@@ -294,11 +288,7 @@ class DiscountCodeReference(Reference):
 
 class DiscountCodeResourceIdentifier(ResourceIdentifier):
     def __init__(
-        self,
-        *,
-        type_id: typing.Optional["ReferenceTypeId"] = None,
-        id: typing.Optional[str] = None,
-        key: typing.Optional[str] = None
+        self, *, id: typing.Optional[str] = None, key: typing.Optional[str] = None
     ) -> None:
         super().__init__(type_id=ReferenceTypeId.DISCOUNT_CODE, id=id, key=key)
 
@@ -316,7 +306,7 @@ class DiscountCodeUpdate(_BaseType):
     #: :class:`list`
     actions: list
 
-    def __init__(self, *, version: int = None, actions: list = None) -> None:
+    def __init__(self, *, version: int, actions: list) -> None:
         self.version = version
         self.actions = actions
         super().__init__()
@@ -332,7 +322,7 @@ class DiscountCodeUpdateAction(_BaseType):
     #: :class:`str`
     action: str
 
-    def __init__(self, *, action: str = None) -> None:
+    def __init__(self, *, action: str) -> None:
         self.action = action
         super().__init__()
 
@@ -345,10 +335,7 @@ class DiscountCodeChangeCartDiscountsAction(DiscountCodeUpdateAction):
     cart_discounts: typing.List["CartDiscountResourceIdentifier"]
 
     def __init__(
-        self,
-        *,
-        action: str = None,
-        cart_discounts: typing.List["CartDiscountResourceIdentifier"] = None
+        self, *, cart_discounts: typing.List["CartDiscountResourceIdentifier"]
     ) -> None:
         self.cart_discounts = cart_discounts
         super().__init__(action="changeCartDiscounts")
@@ -364,7 +351,7 @@ class DiscountCodeChangeGroupsAction(DiscountCodeUpdateAction):
     #: List of :class:`str`
     groups: typing.List[str]
 
-    def __init__(self, *, action: str = None, groups: typing.List[str] = None) -> None:
+    def __init__(self, *, groups: typing.List[str]) -> None:
         self.groups = groups
         super().__init__(action="changeGroups")
 
@@ -379,7 +366,7 @@ class DiscountCodeChangeIsActiveAction(DiscountCodeUpdateAction):
     #: :class:`bool` `(Named` ``isActive`` `in Commercetools)`
     is_active: bool
 
-    def __init__(self, *, action: str = None, is_active: bool = None) -> None:
+    def __init__(self, *, is_active: bool) -> None:
         self.is_active = is_active
         super().__init__(action="changeIsActive")
 
@@ -394,9 +381,7 @@ class DiscountCodeSetCartPredicateAction(DiscountCodeUpdateAction):
     #: Optional :class:`str` `(Named` ``cartPredicate`` `in Commercetools)`
     cart_predicate: typing.Optional[str]
 
-    def __init__(
-        self, *, action: str = None, cart_predicate: typing.Optional[str] = None
-    ) -> None:
+    def __init__(self, *, cart_predicate: typing.Optional[str] = None) -> None:
         self.cart_predicate = cart_predicate
         super().__init__(action="setCartPredicate")
 
@@ -413,13 +398,7 @@ class DiscountCodeSetCustomFieldAction(DiscountCodeUpdateAction):
     #: Optional :class:`typing.Any`
     value: typing.Optional[typing.Any]
 
-    def __init__(
-        self,
-        *,
-        action: str = None,
-        name: str = None,
-        value: typing.Optional[typing.Any] = None
-    ) -> None:
+    def __init__(self, *, name: str, value: typing.Optional[typing.Any] = None) -> None:
         self.name = name
         self.value = value
         super().__init__(action="setCustomField")
@@ -441,7 +420,6 @@ class DiscountCodeSetCustomTypeAction(DiscountCodeUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
         type: typing.Optional["TypeResourceIdentifier"] = None,
         fields: typing.Optional["FieldContainer"] = None
     ) -> None:
@@ -462,10 +440,7 @@ class DiscountCodeSetDescriptionAction(DiscountCodeUpdateAction):
     description: typing.Optional["LocalizedString"]
 
     def __init__(
-        self,
-        *,
-        action: str = None,
-        description: typing.Optional["LocalizedString"] = None
+        self, *, description: typing.Optional["LocalizedString"] = None
     ) -> None:
         self.description = description
         super().__init__(action="setDescription")
@@ -481,9 +456,7 @@ class DiscountCodeSetMaxApplicationsAction(DiscountCodeUpdateAction):
     #: Optional :class:`int` `(Named` ``maxApplications`` `in Commercetools)`
     max_applications: typing.Optional[int]
 
-    def __init__(
-        self, *, action: str = None, max_applications: typing.Optional[int] = None
-    ) -> None:
+    def __init__(self, *, max_applications: typing.Optional[int] = None) -> None:
         self.max_applications = max_applications
         super().__init__(action="setMaxApplications")
 
@@ -499,10 +472,7 @@ class DiscountCodeSetMaxApplicationsPerCustomerAction(DiscountCodeUpdateAction):
     max_applications_per_customer: typing.Optional[int]
 
     def __init__(
-        self,
-        *,
-        action: str = None,
-        max_applications_per_customer: typing.Optional[int] = None
+        self, *, max_applications_per_customer: typing.Optional[int] = None
     ) -> None:
         self.max_applications_per_customer = max_applications_per_customer
         super().__init__(action="setMaxApplicationsPerCustomer")
@@ -518,9 +488,7 @@ class DiscountCodeSetNameAction(DiscountCodeUpdateAction):
     #: Optional :class:`commercetools.types.LocalizedString`
     name: typing.Optional["LocalizedString"]
 
-    def __init__(
-        self, *, action: str = None, name: typing.Optional["LocalizedString"] = None
-    ) -> None:
+    def __init__(self, *, name: typing.Optional["LocalizedString"] = None) -> None:
         self.name = name
         super().__init__(action="setName")
 
@@ -536,10 +504,7 @@ class DiscountCodeSetValidFromAction(DiscountCodeUpdateAction):
     valid_from: typing.Optional[datetime.datetime]
 
     def __init__(
-        self,
-        *,
-        action: str = None,
-        valid_from: typing.Optional[datetime.datetime] = None
+        self, *, valid_from: typing.Optional[datetime.datetime] = None
     ) -> None:
         self.valid_from = valid_from
         super().__init__(action="setValidFrom")
@@ -560,7 +525,6 @@ class DiscountCodeSetValidFromAndUntilAction(DiscountCodeUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
         valid_from: typing.Optional[datetime.datetime] = None,
         valid_until: typing.Optional[datetime.datetime] = None
     ) -> None:
@@ -580,10 +544,7 @@ class DiscountCodeSetValidUntilAction(DiscountCodeUpdateAction):
     valid_until: typing.Optional[datetime.datetime]
 
     def __init__(
-        self,
-        *,
-        action: str = None,
-        valid_until: typing.Optional[datetime.datetime] = None
+        self, *, valid_until: typing.Optional[datetime.datetime] = None
     ) -> None:
         self.valid_until = valid_until
         super().__init__(action="setValidUntil")

--- a/src/commercetools/types/_error.py
+++ b/src/commercetools/types/_error.py
@@ -56,7 +56,7 @@ class ErrorByExtension(_BaseType):
     #: Optional :class:`str`
     key: typing.Optional[str]
 
-    def __init__(self, *, id: str = None, key: typing.Optional[str] = None) -> None:
+    def __init__(self, *, id: str, key: typing.Optional[str] = None) -> None:
         self.id = id
         self.key = key
         super().__init__()
@@ -71,7 +71,7 @@ class ErrorObject(_BaseType):
     #: :class:`str`
     message: str
 
-    def __init__(self, *, code: str = None, message: str = None) -> None:
+    def __init__(self, *, code: str, message: str) -> None:
         self.code = code
         self.message = message
         super().__init__()
@@ -95,8 +95,8 @@ class ErrorResponse(_BaseType):
     def __init__(
         self,
         *,
-        status_code: int = None,
-        message: str = None,
+        status_code: int,
+        message: str,
         error: typing.Optional[str] = None,
         error_description: typing.Optional[str] = None,
         errors: typing.Optional[list] = None
@@ -132,9 +132,9 @@ class VariantValues(_BaseType):
     def __init__(
         self,
         *,
-        sku: typing.Optional[str] = None,
-        prices: typing.List["PriceDraft"] = None,
-        attributes: typing.List["Attribute"] = None
+        prices: typing.List["PriceDraft"],
+        attributes: typing.List["Attribute"],
+        sku: typing.Optional[str] = None
     ) -> None:
         self.sku = sku
         self.prices = prices
@@ -150,7 +150,7 @@ class VariantValues(_BaseType):
 
 
 class AccessDeniedError(ErrorObject):
-    def __init__(self, *, code: str = None, message: str = None) -> None:
+    def __init__(self, *, message: str) -> None:
         super().__init__(code="access_denied", message=message)
 
     def __repr__(self) -> str:
@@ -162,11 +162,7 @@ class ConcurrentModificationError(ErrorObject):
     current_version: typing.Optional[int]
 
     def __init__(
-        self,
-        *,
-        code: str = None,
-        message: str = None,
-        current_version: typing.Optional[int] = None
+        self, *, message: str, current_version: typing.Optional[int] = None
     ) -> None:
         self.current_version = current_version
         super().__init__(code="ConcurrentModification", message=message)
@@ -195,8 +191,7 @@ class DiscountCodeNonApplicableError(ErrorObject):
     def __init__(
         self,
         *,
-        code: str = None,
-        message: str = None,
+        message: str,
         discount_code: typing.Optional[str] = None,
         reason: typing.Optional[str] = None,
         dicount_code_id: typing.Optional[str] = None,
@@ -232,9 +227,7 @@ class DuplicateAttributeValueError(ErrorObject):
     #: :class:`commercetools.types.Attribute`
     attribute: "Attribute"
 
-    def __init__(
-        self, *, code: str = None, message: str = None, attribute: "Attribute" = None
-    ) -> None:
+    def __init__(self, *, message: str, attribute: "Attribute") -> None:
         self.attribute = attribute
         super().__init__(code="DuplicateAttributeValue", message=message)
 
@@ -250,13 +243,7 @@ class DuplicateAttributeValuesError(ErrorObject):
     #: List of :class:`commercetools.types.Attribute`
     attributes: typing.List["Attribute"]
 
-    def __init__(
-        self,
-        *,
-        code: str = None,
-        message: str = None,
-        attributes: typing.List["Attribute"] = None
-    ) -> None:
+    def __init__(self, *, message: str, attributes: typing.List["Attribute"]) -> None:
         self.attributes = attributes
         super().__init__(code="DuplicateAttributeValues", message=message)
 
@@ -279,8 +266,7 @@ class DuplicateFieldError(ErrorObject):
     def __init__(
         self,
         *,
-        code: str = None,
-        message: str = None,
+        message: str,
         field: typing.Optional[str] = None,
         duplicate_value: typing.Optional[typing.Any] = None,
         conflicting_resource: typing.Optional["Reference"] = None
@@ -314,11 +300,10 @@ class DuplicateFieldWithConflictingResourceError(ErrorObject):
     def __init__(
         self,
         *,
-        code: str = None,
-        message: str = None,
-        field: str = None,
-        duplicate_value: typing.Any = None,
-        conflicting_resource: "Reference" = None
+        message: str,
+        field: str,
+        duplicate_value: typing.Any,
+        conflicting_resource: "Reference"
     ) -> None:
         self.field = field
         self.duplicate_value = duplicate_value
@@ -343,11 +328,7 @@ class DuplicatePriceScopeError(ErrorObject):
     conflicting_prices: typing.List["Price"]
 
     def __init__(
-        self,
-        *,
-        code: str = None,
-        message: str = None,
-        conflicting_prices: typing.List["Price"] = None
+        self, *, message: str, conflicting_prices: typing.List["Price"]
     ) -> None:
         self.conflicting_prices = conflicting_prices
         super().__init__(code="DuplicatePriceScope", message=message)
@@ -363,13 +344,7 @@ class DuplicateVariantValuesError(ErrorObject):
     #: :class:`commercetools.types.VariantValues` `(Named` ``variantValues`` `in Commercetools)`
     variant_values: "VariantValues"
 
-    def __init__(
-        self,
-        *,
-        code: str = None,
-        message: str = None,
-        variant_values: "VariantValues" = None
-    ) -> None:
+    def __init__(self, *, message: str, variant_values: "VariantValues") -> None:
         self.variant_values = variant_values
         super().__init__(code="DuplicateVariantValues", message=message)
 
@@ -382,7 +357,7 @@ class DuplicateVariantValuesError(ErrorObject):
 
 
 class EnumValueIsUsedError(ErrorObject):
-    def __init__(self, *, code: str = None, message: str = None) -> None:
+    def __init__(self, *, message: str) -> None:
         super().__init__(code="EnumValueIsUsed", message=message)
 
     def __repr__(self) -> str:
@@ -400,11 +375,10 @@ class ExtensionBadResponseError(ErrorObject):
     def __init__(
         self,
         *,
-        code: str = None,
-        message: str = None,
+        message: str,
+        error_by_extension: "ErrorByExtension",
         localized_message: typing.Optional["LocalizedString"] = None,
-        extension_extra_info: typing.Optional[object] = None,
-        error_by_extension: "ErrorByExtension" = None
+        extension_extra_info: typing.Optional[object] = None
     ) -> None:
         self.localized_message = localized_message
         self.extension_extra_info = extension_extra_info
@@ -435,11 +409,10 @@ class ExtensionNoResponseError(ErrorObject):
     def __init__(
         self,
         *,
-        code: str = None,
-        message: str = None,
+        message: str,
+        error_by_extension: "ErrorByExtension",
         localized_message: typing.Optional["LocalizedString"] = None,
-        extension_extra_info: typing.Optional[object] = None,
-        error_by_extension: "ErrorByExtension" = None
+        extension_extra_info: typing.Optional[object] = None
     ) -> None:
         self.localized_message = localized_message
         self.extension_extra_info = extension_extra_info
@@ -470,11 +443,10 @@ class ExtensionUpdateActionsFailedError(ErrorObject):
     def __init__(
         self,
         *,
-        code: str = None,
-        message: str = None,
+        message: str,
+        error_by_extension: "ErrorByExtension",
         localized_message: typing.Optional["LocalizedString"] = None,
-        extension_extra_info: typing.Optional[object] = None,
-        error_by_extension: "ErrorByExtension" = None
+        extension_extra_info: typing.Optional[object] = None
     ) -> None:
         self.localized_message = localized_message
         self.extension_extra_info = extension_extra_info
@@ -495,7 +467,7 @@ class ExtensionUpdateActionsFailedError(ErrorObject):
 
 
 class InsufficientScopeError(ErrorObject):
-    def __init__(self, *, code: str = None, message: str = None) -> None:
+    def __init__(self, *, message: str) -> None:
         super().__init__(code="insufficient_scope", message=message)
 
     def __repr__(self) -> str:
@@ -503,7 +475,7 @@ class InsufficientScopeError(ErrorObject):
 
 
 class InvalidCredentialsError(ErrorObject):
-    def __init__(self, *, code: str = None, message: str = None) -> None:
+    def __init__(self, *, message: str) -> None:
         super().__init__(code="InvalidCredentials", message=message)
 
     def __repr__(self) -> str:
@@ -514,7 +486,7 @@ class InvalidCredentialsError(ErrorObject):
 
 
 class InvalidCurrentPasswordError(ErrorObject):
-    def __init__(self, *, code: str = None, message: str = None) -> None:
+    def __init__(self, *, message: str) -> None:
         super().__init__(code="InvalidCurrentPassword", message=message)
 
     def __repr__(self) -> str:
@@ -535,10 +507,9 @@ class InvalidFieldError(ErrorObject):
     def __init__(
         self,
         *,
-        code: str = None,
-        message: str = None,
-        field: str = None,
-        invalid_value: typing.Any = None,
+        message: str,
+        field: str,
+        invalid_value: typing.Any,
         allowed_values: typing.Optional[list] = None
     ) -> None:
         self.field = field
@@ -560,7 +531,7 @@ class InvalidFieldError(ErrorObject):
 
 
 class InvalidInputError(ErrorObject):
-    def __init__(self, *, code: str = None, message: str = None) -> None:
+    def __init__(self, *, message: str) -> None:
         super().__init__(code="InvalidInput", message=message)
 
     def __repr__(self) -> str:
@@ -573,14 +544,7 @@ class InvalidItemShippingDetailsError(ErrorObject):
     #: :class:`str` `(Named` ``itemId`` `in Commercetools)`
     item_id: str
 
-    def __init__(
-        self,
-        *,
-        code: str = None,
-        message: str = None,
-        subject: str = None,
-        item_id: str = None
-    ) -> None:
+    def __init__(self, *, message: str, subject: str, item_id: str) -> None:
         self.subject = subject
         self.item_id = item_id
         super().__init__(code="InvalidItemShippingDetails", message=message)
@@ -593,7 +557,7 @@ class InvalidItemShippingDetailsError(ErrorObject):
 
 
 class InvalidJsonInputError(ErrorObject):
-    def __init__(self, *, code: str = None, message: str = None) -> None:
+    def __init__(self, *, message: str) -> None:
         super().__init__(code="InvalidJsonInput", message=message)
 
     def __repr__(self) -> str:
@@ -601,7 +565,7 @@ class InvalidJsonInputError(ErrorObject):
 
 
 class InvalidOperationError(ErrorObject):
-    def __init__(self, *, code: str = None, message: str = None) -> None:
+    def __init__(self, *, message: str) -> None:
         super().__init__(code="InvalidOperation", message=message)
 
     def __repr__(self) -> str:
@@ -609,7 +573,7 @@ class InvalidOperationError(ErrorObject):
 
 
 class InvalidSubjectError(ErrorObject):
-    def __init__(self, *, code: str = None, message: str = None) -> None:
+    def __init__(self, *, message: str) -> None:
         super().__init__(code="InvalidSubject", message=message)
 
     def __repr__(self) -> str:
@@ -617,7 +581,7 @@ class InvalidSubjectError(ErrorObject):
 
 
 class InvalidTokenError(ErrorObject):
-    def __init__(self, *, code: str = None, message: str = None) -> None:
+    def __init__(self, *, message: str) -> None:
         super().__init__(code="invalid_token", message=message)
 
     def __repr__(self) -> str:
@@ -625,7 +589,7 @@ class InvalidTokenError(ErrorObject):
 
 
 class LanguageUsedInStoresError(ErrorObject):
-    def __init__(self, *, code: str = None, message: str = None) -> None:
+    def __init__(self, *, message: str) -> None:
         super().__init__(code="LanguageUsedInStores", message=message)
 
     def __repr__(self) -> str:
@@ -652,10 +616,9 @@ class MatchingPriceNotFoundError(ErrorObject):
     def __init__(
         self,
         *,
-        code: str = None,
-        message: str = None,
-        product_id: str = None,
-        variant_id: int = None,
+        message: str,
+        product_id: str,
+        variant_id: int,
         currency: typing.Optional[str] = None,
         country: typing.Optional[str] = None,
         customer_group: typing.Optional["CustomerGroupReference"] = None,
@@ -696,9 +659,8 @@ class MissingTaxRateForCountryError(ErrorObject):
     def __init__(
         self,
         *,
-        code: str = None,
-        message: str = None,
-        tax_category_id: str = None,
+        message: str,
+        tax_category_id: str,
         country: typing.Optional[str] = None,
         state: typing.Optional[str] = None
     ) -> None:
@@ -715,7 +677,7 @@ class MissingTaxRateForCountryError(ErrorObject):
 
 
 class NoMatchingProductDiscountFoundError(ErrorObject):
-    def __init__(self, *, code: str = None, message: str = None) -> None:
+    def __init__(self, *, message: str) -> None:
         super().__init__(code="NoMatchingProductDiscountFound", message=message)
 
     def __repr__(self) -> str:
@@ -732,12 +694,7 @@ class OutOfStockError(ErrorObject):
     skus: typing.List[str]
 
     def __init__(
-        self,
-        *,
-        code: str = None,
-        message: str = None,
-        line_items: typing.List[str] = None,
-        skus: typing.List[str] = None
+        self, *, message: str, line_items: typing.List[str], skus: typing.List[str]
     ) -> None:
         self.line_items = line_items
         self.skus = skus
@@ -759,12 +716,7 @@ class PriceChangedError(ErrorObject):
     shipping: bool
 
     def __init__(
-        self,
-        *,
-        code: str = None,
-        message: str = None,
-        line_items: typing.List[str] = None,
-        shipping: bool = None
+        self, *, message: str, line_items: typing.List[str], shipping: bool
     ) -> None:
         self.line_items = line_items
         self.shipping = shipping
@@ -784,11 +736,7 @@ class ReferenceExistsError(ErrorObject):
     referenced_by: typing.Optional["ReferenceTypeId"]
 
     def __init__(
-        self,
-        *,
-        code: str = None,
-        message: str = None,
-        referenced_by: typing.Optional["ReferenceTypeId"] = None
+        self, *, message: str, referenced_by: typing.Optional["ReferenceTypeId"] = None
     ) -> None:
         self.referenced_by = referenced_by
         super().__init__(code="ReferenceExists", message=message)
@@ -805,9 +753,7 @@ class RequiredFieldError(ErrorObject):
     #: :class:`str`
     field: str
 
-    def __init__(
-        self, *, code: str = None, message: str = None, field: str = None
-    ) -> None:
+    def __init__(self, *, message: str, field: str) -> None:
         self.field = field
         super().__init__(code="RequiredField", message=message)
 
@@ -820,7 +766,7 @@ class RequiredFieldError(ErrorObject):
 
 
 class ResourceNotFoundError(ErrorObject):
-    def __init__(self, *, code: str = None, message: str = None) -> None:
+    def __init__(self, *, message: str) -> None:
         super().__init__(code="ResourceNotFound", message=message)
 
     def __repr__(self) -> str:
@@ -828,7 +774,7 @@ class ResourceNotFoundError(ErrorObject):
 
 
 class ShippingMethodDoesNotMatchCartError(ErrorObject):
-    def __init__(self, *, code: str = None, message: str = None) -> None:
+    def __init__(self, *, message: str) -> None:
         super().__init__(code="ShippingMethodDoesNotMatchCart", message=message)
 
     def __repr__(self) -> str:

--- a/src/commercetools/types/_extension.py
+++ b/src/commercetools/types/_extension.py
@@ -56,15 +56,15 @@ class Extension(BaseResource):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        destination: "ExtensionDestination",
+        triggers: typing.List["ExtensionTrigger"],
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
         key: typing.Optional[str] = None,
-        destination: "ExtensionDestination" = None,
-        triggers: typing.List["ExtensionTrigger"] = None,
         timeout_in_ms: typing.Optional[int] = None
     ) -> None:
         self.id = id
@@ -111,7 +111,7 @@ class ExtensionDestination(_BaseType):
     #: :class:`str`
     type: str
 
-    def __init__(self, *, type: str = None) -> None:
+    def __init__(self, *, type: str) -> None:
         self.type = type
         super().__init__()
 
@@ -132,9 +132,9 @@ class ExtensionDraft(_BaseType):
     def __init__(
         self,
         *,
+        destination: "ExtensionDestination",
+        triggers: typing.List["ExtensionTrigger"],
         key: typing.Optional[str] = None,
-        destination: "ExtensionDestination" = None,
-        triggers: typing.List["ExtensionTrigger"] = None,
         timeout_in_ms: typing.Optional[int] = None
     ) -> None:
         self.key = key
@@ -154,7 +154,7 @@ class ExtensionHttpDestinationAuthentication(_BaseType):
     #: :class:`str`
     type: str
 
-    def __init__(self, *, type: str = None) -> None:
+    def __init__(self, *, type: str) -> None:
         self.type = type
         super().__init__()
 
@@ -168,9 +168,7 @@ class ExtensionInput(_BaseType):
     #: :class:`commercetools.types.Reference`
     resource: "Reference"
 
-    def __init__(
-        self, *, action: "ExtensionAction" = None, resource: "Reference" = None
-    ) -> None:
+    def __init__(self, *, action: "ExtensionAction", resource: "Reference") -> None:
         self.action = action
         self.resource = resource
         super().__init__()
@@ -194,11 +192,11 @@ class ExtensionPagedQueryResponse(_BaseType):
     def __init__(
         self,
         *,
-        limit: int = None,
-        count: int = None,
-        total: typing.Optional[int] = None,
-        offset: int = None,
-        results: typing.Sequence["Extension"] = None
+        limit: int,
+        count: int,
+        offset: int,
+        results: typing.Sequence["Extension"],
+        total: typing.Optional[int] = None
     ) -> None:
         self.limit = limit
         self.count = count
@@ -230,8 +228,8 @@ class ExtensionTrigger(_BaseType):
     def __init__(
         self,
         *,
-        resource_type_id: "ExtensionResourceTypeId" = None,
-        actions: typing.List["ExtensionAction"] = None
+        resource_type_id: "ExtensionResourceTypeId",
+        actions: typing.List["ExtensionAction"]
     ) -> None:
         self.resource_type_id = resource_type_id
         self.actions = actions
@@ -250,7 +248,7 @@ class ExtensionUpdate(_BaseType):
     #: :class:`list`
     actions: list
 
-    def __init__(self, *, version: int = None, actions: list = None) -> None:
+    def __init__(self, *, version: int, actions: list) -> None:
         self.version = version
         self.actions = actions
         super().__init__()
@@ -263,7 +261,7 @@ class ExtensionUpdateAction(_BaseType):
     #: :class:`str`
     action: str
 
-    def __init__(self, *, action: str = None) -> None:
+    def __init__(self, *, action: str) -> None:
         self.action = action
         super().__init__()
 
@@ -279,14 +277,7 @@ class ExtensionAWSLambdaDestination(ExtensionDestination):
     #: :class:`str` `(Named` ``accessSecret`` `in Commercetools)`
     access_secret: str
 
-    def __init__(
-        self,
-        *,
-        type: str = None,
-        arn: str = None,
-        access_key: str = None,
-        access_secret: str = None
-    ) -> None:
+    def __init__(self, *, arn: str, access_key: str, access_secret: str) -> None:
         self.arn = arn
         self.access_key = access_key
         self.access_secret = access_secret
@@ -305,7 +296,7 @@ class ExtensionAuthorizationHeaderAuthentication(
     #: :class:`str` `(Named` ``headerValue`` `in Commercetools)`
     header_value: str
 
-    def __init__(self, *, type: str = None, header_value: str = None) -> None:
+    def __init__(self, *, header_value: str) -> None:
         self.header_value = header_value
         super().__init__(type="AuthorizationHeader")
 
@@ -320,7 +311,7 @@ class ExtensionAzureFunctionsAuthentication(ExtensionHttpDestinationAuthenticati
     #: :class:`str`
     key: str
 
-    def __init__(self, *, type: str = None, key: str = None) -> None:
+    def __init__(self, *, key: str) -> None:
         self.key = key
         super().__init__(type="AzureFunctions")
 
@@ -335,9 +326,7 @@ class ExtensionChangeDestinationAction(ExtensionUpdateAction):
     #: :class:`commercetools.types.ExtensionDestination`
     destination: "ExtensionDestination"
 
-    def __init__(
-        self, *, action: str = None, destination: "ExtensionDestination" = None
-    ) -> None:
+    def __init__(self, *, destination: "ExtensionDestination") -> None:
         self.destination = destination
         super().__init__(action="changeDestination")
 
@@ -352,9 +341,7 @@ class ExtensionChangeTriggersAction(ExtensionUpdateAction):
     #: List of :class:`commercetools.types.ExtensionTrigger`
     triggers: typing.List["ExtensionTrigger"]
 
-    def __init__(
-        self, *, action: str = None, triggers: typing.List["ExtensionTrigger"] = None
-    ) -> None:
+    def __init__(self, *, triggers: typing.List["ExtensionTrigger"]) -> None:
         self.triggers = triggers
         super().__init__(action="changeTriggers")
 
@@ -374,8 +361,7 @@ class ExtensionHttpDestination(ExtensionDestination):
     def __init__(
         self,
         *,
-        type: str = None,
-        url: str = None,
+        url: str,
         authentication: typing.Optional["ExtensionHttpDestinationAuthentication"] = None
     ) -> None:
         self.url = url
@@ -394,7 +380,7 @@ class ExtensionSetKeyAction(ExtensionUpdateAction):
     #: Optional :class:`str`
     key: typing.Optional[str]
 
-    def __init__(self, *, action: str = None, key: typing.Optional[str] = None) -> None:
+    def __init__(self, *, key: typing.Optional[str] = None) -> None:
         self.key = key
         super().__init__(action="setKey")
 
@@ -406,9 +392,7 @@ class ExtensionSetTimeoutInMsAction(ExtensionUpdateAction):
     #: Optional :class:`int` `(Named` ``timeoutInMs`` `in Commercetools)`
     timeout_in_ms: typing.Optional[int]
 
-    def __init__(
-        self, *, action: str = None, timeout_in_ms: typing.Optional[int] = None
-    ) -> None:
+    def __init__(self, *, timeout_in_ms: typing.Optional[int] = None) -> None:
         self.timeout_in_ms = timeout_in_ms
         super().__init__(action="setTimeoutInMs")
 

--- a/src/commercetools/types/_graph_ql.py
+++ b/src/commercetools/types/_graph_ql.py
@@ -21,9 +21,7 @@ class GraphQLError(_BaseType):
     #: :class:`list`
     path: list
 
-    def __init__(
-        self, *, message: str = None, locations: list = None, path: list = None
-    ) -> None:
+    def __init__(self, *, message: str, locations: list, path: list) -> None:
         self.message = message
         self.locations = locations
         self.path = path
@@ -43,7 +41,7 @@ class GraphQLErrorLocation(_BaseType):
     #: :class:`int`
     column: int
 
-    def __init__(self, *, line: int = None, column: int = None) -> None:
+    def __init__(self, *, line: int, column: int) -> None:
         self.line = line
         self.column = column
         super().__init__()
@@ -63,7 +61,7 @@ class GraphQLRequest(_BaseType):
     def __init__(
         self,
         *,
-        query: str = None,
+        query: str,
         operation_name: typing.Optional[str] = None,
         variables: typing.Optional["GraphQLVariablesMap"] = None,
     ) -> None:

--- a/src/commercetools/types/_inventory.py
+++ b/src/commercetools/types/_inventory.py
@@ -69,16 +69,16 @@ class InventoryEntry(BaseResource):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        sku: str,
+        quantity_on_stock: int,
+        available_quantity: int,
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
-        sku: str = None,
         supply_channel: typing.Optional["ChannelResourceIdentifier"] = None,
-        quantity_on_stock: int = None,
-        available_quantity: int = None,
         restockable_in_days: typing.Optional[int] = None,
         expected_delivery: typing.Optional[datetime.datetime] = None,
         custom: typing.Optional["CustomFields"] = None
@@ -141,9 +141,9 @@ class InventoryEntryDraft(_BaseType):
     def __init__(
         self,
         *,
-        sku: str = None,
+        sku: str,
+        quantity_on_stock: int,
         supply_channel: typing.Optional["ChannelResourceIdentifier"] = None,
-        quantity_on_stock: int = None,
         restockable_in_days: typing.Optional[int] = None,
         expected_delivery: typing.Optional[datetime.datetime] = None,
         custom: typing.Optional["CustomFieldsDraft"] = None
@@ -175,11 +175,7 @@ class InventoryEntryReference(Reference):
     obj: typing.Optional["InventoryEntry"]
 
     def __init__(
-        self,
-        *,
-        type_id: "ReferenceTypeId" = None,
-        id: str = None,
-        obj: typing.Optional["InventoryEntry"] = None
+        self, *, id: str, obj: typing.Optional["InventoryEntry"] = None
     ) -> None:
         self.obj = obj
         super().__init__(type_id=ReferenceTypeId.INVENTORY_ENTRY, id=id)
@@ -194,11 +190,7 @@ class InventoryEntryReference(Reference):
 
 class InventoryEntryResourceIdentifier(ResourceIdentifier):
     def __init__(
-        self,
-        *,
-        type_id: typing.Optional["ReferenceTypeId"] = None,
-        id: typing.Optional[str] = None,
-        key: typing.Optional[str] = None
+        self, *, id: typing.Optional[str] = None, key: typing.Optional[str] = None
     ) -> None:
         super().__init__(type_id=ReferenceTypeId.INVENTORY_ENTRY, id=id, key=key)
 
@@ -216,7 +208,7 @@ class InventoryEntryUpdate(_BaseType):
     #: :class:`list`
     actions: list
 
-    def __init__(self, *, version: int = None, actions: list = None) -> None:
+    def __init__(self, *, version: int, actions: list) -> None:
         self.version = version
         self.actions = actions
         super().__init__()
@@ -232,7 +224,7 @@ class InventoryEntryUpdateAction(_BaseType):
     #: :class:`str`
     action: str
 
-    def __init__(self, *, action: str = None) -> None:
+    def __init__(self, *, action: str) -> None:
         self.action = action
         super().__init__()
 
@@ -255,11 +247,11 @@ class InventoryPagedQueryResponse(_BaseType):
     def __init__(
         self,
         *,
-        limit: int = None,
-        count: int = None,
-        total: typing.Optional[int] = None,
-        offset: int = None,
-        results: typing.Sequence["InventoryEntry"] = None
+        limit: int,
+        count: int,
+        offset: int,
+        results: typing.Sequence["InventoryEntry"],
+        total: typing.Optional[int] = None
     ) -> None:
         self.limit = limit
         self.count = count
@@ -279,7 +271,7 @@ class InventoryEntryAddQuantityAction(InventoryEntryUpdateAction):
     #: :class:`int`
     quantity: int
 
-    def __init__(self, *, action: str = None, quantity: int = None) -> None:
+    def __init__(self, *, quantity: int) -> None:
         self.quantity = quantity
         super().__init__(action="addQuantity")
 
@@ -294,7 +286,7 @@ class InventoryEntryChangeQuantityAction(InventoryEntryUpdateAction):
     #: :class:`int`
     quantity: int
 
-    def __init__(self, *, action: str = None, quantity: int = None) -> None:
+    def __init__(self, *, quantity: int) -> None:
         self.quantity = quantity
         super().__init__(action="changeQuantity")
 
@@ -309,7 +301,7 @@ class InventoryEntryRemoveQuantityAction(InventoryEntryUpdateAction):
     #: :class:`int`
     quantity: int
 
-    def __init__(self, *, action: str = None, quantity: int = None) -> None:
+    def __init__(self, *, quantity: int) -> None:
         self.quantity = quantity
         super().__init__(action="removeQuantity")
 
@@ -326,13 +318,7 @@ class InventoryEntrySetCustomFieldAction(InventoryEntryUpdateAction):
     #: Optional :class:`typing.Any`
     value: typing.Optional[typing.Any]
 
-    def __init__(
-        self,
-        *,
-        action: str = None,
-        name: str = None,
-        value: typing.Optional[typing.Any] = None
-    ) -> None:
+    def __init__(self, *, name: str, value: typing.Optional[typing.Any] = None) -> None:
         self.name = name
         self.value = value
         super().__init__(action="setCustomField")
@@ -354,7 +340,6 @@ class InventoryEntrySetCustomTypeAction(InventoryEntryUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
         type: typing.Optional["TypeResourceIdentifier"] = None,
         fields: typing.Optional["FieldContainer"] = None
     ) -> None:
@@ -375,10 +360,7 @@ class InventoryEntrySetExpectedDeliveryAction(InventoryEntryUpdateAction):
     expected_delivery: typing.Optional[datetime.datetime]
 
     def __init__(
-        self,
-        *,
-        action: str = None,
-        expected_delivery: typing.Optional[datetime.datetime] = None
+        self, *, expected_delivery: typing.Optional[datetime.datetime] = None
     ) -> None:
         self.expected_delivery = expected_delivery
         super().__init__(action="setExpectedDelivery")
@@ -394,9 +376,7 @@ class InventoryEntrySetRestockableInDaysAction(InventoryEntryUpdateAction):
     #: Optional :class:`int` `(Named` ``restockableInDays`` `in Commercetools)`
     restockable_in_days: typing.Optional[int]
 
-    def __init__(
-        self, *, action: str = None, restockable_in_days: typing.Optional[int] = None
-    ) -> None:
+    def __init__(self, *, restockable_in_days: typing.Optional[int] = None) -> None:
         self.restockable_in_days = restockable_in_days
         super().__init__(action="setRestockableInDays")
 
@@ -412,10 +392,7 @@ class InventoryEntrySetSupplyChannelAction(InventoryEntryUpdateAction):
     supply_channel: typing.Optional["ChannelResourceIdentifier"]
 
     def __init__(
-        self,
-        *,
-        action: str = None,
-        supply_channel: typing.Optional["ChannelResourceIdentifier"] = None
+        self, *, supply_channel: typing.Optional["ChannelResourceIdentifier"] = None
     ) -> None:
         self.supply_channel = supply_channel
         super().__init__(action="setSupplyChannel")

--- a/src/commercetools/types/_me.py
+++ b/src/commercetools/types/_me.py
@@ -228,27 +228,29 @@ class MyCart(BaseResource):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        line_items: typing.List["LineItem"],
+        custom_line_items: typing.List["CustomLineItem"],
+        total_price: "TypedMoney",
+        cart_state: "CartState",
+        tax_mode: "TaxMode",
+        tax_rounding_mode: "RoundingMode",
+        tax_calculation_mode: "TaxCalculationMode",
+        refused_gifts: typing.List["CartDiscountReference"],
+        origin: "CartOrigin",
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
         customer_id: typing.Optional[str] = None,
         customer_email: typing.Optional[str] = None,
         anonymous_id: typing.Optional[str] = None,
         store: typing.Optional["StoreKeyReference"] = None,
-        line_items: typing.List["LineItem"] = None,
-        custom_line_items: typing.List["CustomLineItem"] = None,
-        total_price: "TypedMoney" = None,
         taxed_price: typing.Optional["TaxedPrice"] = None,
-        cart_state: "CartState" = None,
         shipping_address: typing.Optional["Address"] = None,
         billing_address: typing.Optional["Address"] = None,
         inventory_mode: typing.Optional["InventoryMode"] = None,
-        tax_mode: "TaxMode" = None,
-        tax_rounding_mode: "RoundingMode" = None,
-        tax_calculation_mode: "TaxCalculationMode" = None,
         customer_group: typing.Optional["CustomerGroupReference"] = None,
         country: typing.Optional["str"] = None,
         shipping_info: typing.Optional["ShippingInfo"] = None,
@@ -257,8 +259,6 @@ class MyCart(BaseResource):
         payment_info: typing.Optional["PaymentInfo"] = None,
         locale: typing.Optional[str] = None,
         delete_days_after_last_modification: typing.Optional[int] = None,
-        refused_gifts: typing.List["CartDiscountReference"] = None,
-        origin: "CartOrigin" = None,
         shipping_rate_input: typing.Optional["ShippingRateInput"] = None,
         item_shipping_addresses: typing.Optional[typing.List["Address"]] = None
     ) -> None:
@@ -374,7 +374,7 @@ class MyCartDraft(_BaseType):
     def __init__(
         self,
         *,
-        currency: "str" = None,
+        currency: "str",
         customer_email: typing.Optional[str] = None,
         country: typing.Optional[str] = None,
         inventory_mode: typing.Optional["InventoryMode"] = None,
@@ -428,7 +428,7 @@ class MyCartUpdateAction(_BaseType):
     #: :class:`str`
     action: str
 
-    def __init__(self, *, action: str = None) -> None:
+    def __init__(self, *, action: str) -> None:
         self.action = action
         super().__init__()
 
@@ -499,15 +499,17 @@ class MyCustomer(BaseResource):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        email: str,
+        password: str,
+        addresses: typing.List["Address"],
+        is_email_verified: bool,
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
         customer_number: typing.Optional[str] = None,
-        email: str = None,
-        password: str = None,
         first_name: typing.Optional[str] = None,
         last_name: typing.Optional[str] = None,
         middle_name: typing.Optional[str] = None,
@@ -515,12 +517,10 @@ class MyCustomer(BaseResource):
         date_of_birth: typing.Optional[datetime.date] = None,
         company_name: typing.Optional[str] = None,
         vat_id: typing.Optional[str] = None,
-        addresses: typing.List["Address"] = None,
         default_shipping_address_id: typing.Optional[str] = None,
         shipping_address_ids: typing.Optional[typing.List[str]] = None,
         default_billing_address_id: typing.Optional[str] = None,
         billing_address_ids: typing.Optional[typing.List[str]] = None,
-        is_email_verified: bool = None,
         external_id: typing.Optional[str] = None,
         customer_group: typing.Optional["CustomerGroupReference"] = None,
         custom: typing.Optional["CustomFields"] = None,
@@ -637,8 +637,8 @@ class MyCustomerDraft(_BaseType):
     def __init__(
         self,
         *,
-        email: str = None,
-        password: str = None,
+        email: str,
+        password: str,
         first_name: typing.Optional[str] = None,
         last_name: typing.Optional[str] = None,
         middle_name: typing.Optional[str] = None,
@@ -697,7 +697,7 @@ class MyCustomerUpdateAction(_BaseType):
     #: :class:`str`
     action: str
 
-    def __init__(self, *, action: str = None) -> None:
+    def __init__(self, *, action: str) -> None:
         self.action = action
         super().__init__()
 
@@ -726,9 +726,9 @@ class MyLineItemDraft(_BaseType):
     def __init__(
         self,
         *,
-        product_id: str = None,
-        variant_id: int = None,
-        quantity: int = None,
+        product_id: str,
+        variant_id: int,
+        quantity: int,
         supply_channel: typing.Optional["ChannelResourceIdentifier"] = None,
         distribution_channel: typing.Optional["ChannelResourceIdentifier"] = None,
         custom: typing.Optional["CustomFieldsDraft"] = None,
@@ -848,10 +848,18 @@ class MyOrder(BaseResource):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        line_items: typing.List["LineItem"],
+        custom_line_items: typing.List["CustomLineItem"],
+        total_price: "TypedMoney",
+        order_state: "OrderState",
+        sync_info: typing.List["SyncInfo"],
+        last_message_sequence_number: int,
+        origin: "CartOrigin",
+        refused_gifts: typing.List["CartDiscountReference"],
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
         completed_at: typing.Optional[datetime.datetime] = None,
@@ -860,9 +868,6 @@ class MyOrder(BaseResource):
         customer_email: typing.Optional[str] = None,
         anonymous_id: typing.Optional[str] = None,
         store: typing.Optional["StoreKeyReference"] = None,
-        line_items: typing.List["LineItem"] = None,
-        custom_line_items: typing.List["CustomLineItem"] = None,
-        total_price: "TypedMoney" = None,
         taxed_price: typing.Optional["TaxedPrice"] = None,
         shipping_address: typing.Optional["Address"] = None,
         billing_address: typing.Optional["Address"] = None,
@@ -870,25 +875,20 @@ class MyOrder(BaseResource):
         tax_rounding_mode: typing.Optional["RoundingMode"] = None,
         customer_group: typing.Optional["CustomerGroupReference"] = None,
         country: typing.Optional[str] = None,
-        order_state: "OrderState" = None,
         state: typing.Optional["StateReference"] = None,
         shipment_state: typing.Optional["ShipmentState"] = None,
         payment_state: typing.Optional["PaymentState"] = None,
         shipping_info: typing.Optional["ShippingInfo"] = None,
-        sync_info: typing.List["SyncInfo"] = None,
         return_info: typing.Optional[typing.List["ReturnInfo"]] = None,
         discount_codes: typing.Optional[typing.List["DiscountCodeInfo"]] = None,
-        last_message_sequence_number: int = None,
         cart: typing.Optional["CartReference"] = None,
         custom: typing.Optional["CustomFields"] = None,
         payment_info: typing.Optional["PaymentInfo"] = None,
         locale: typing.Optional[str] = None,
         inventory_mode: typing.Optional["InventoryMode"] = None,
-        origin: "CartOrigin" = None,
         tax_calculation_mode: typing.Optional["TaxCalculationMode"] = None,
         shipping_rate_input: typing.Optional["ShippingRateInput"] = None,
-        item_shipping_addresses: typing.Optional[typing.List["Address"]] = None,
-        refused_gifts: typing.List["CartDiscountReference"] = None
+        item_shipping_addresses: typing.Optional[typing.List["Address"]] = None
     ) -> None:
         self.id = id
         self.version = version
@@ -993,7 +993,7 @@ class MyOrderFromCartDraft(_BaseType):
     #: :class:`int`
     version: int
 
-    def __init__(self, *, id: str = None, version: int = None) -> None:
+    def __init__(self, *, id: str, version: int) -> None:
         self.id = id
         self.version = version
         super().__init__()
@@ -1023,13 +1023,13 @@ class MyPayment(_BaseType):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
+        id: str,
+        version: int,
+        amount_planned: "TypedMoney",
+        payment_method_info: "PaymentMethodInfo",
+        transactions: typing.List["Transaction"],
         customer: typing.Optional["CustomerReference"] = None,
         anonymous_id: typing.Optional[str] = None,
-        amount_planned: "TypedMoney" = None,
-        payment_method_info: "PaymentMethodInfo" = None,
-        transactions: typing.List["Transaction"] = None,
         custom: typing.Optional["CustomFields"] = None
     ) -> None:
         self.id = id
@@ -1071,7 +1071,7 @@ class MyPaymentDraft(_BaseType):
     def __init__(
         self,
         *,
-        amount_planned: "Money" = None,
+        amount_planned: "Money",
         payment_method_info: typing.Optional["PaymentMethodInfo"] = None,
         custom: typing.Optional["CustomFieldsDraft"] = None,
         transaction: typing.Optional["MyTransactionDraft"] = None
@@ -1109,11 +1109,11 @@ class MyPaymentPagedQueryResponse(_BaseType):
     def __init__(
         self,
         *,
-        limit: int = None,
-        count: int = None,
-        total: typing.Optional[int] = None,
-        offset: int = None,
-        results: typing.Sequence["MyPayment"] = None
+        limit: int,
+        count: int,
+        offset: int,
+        results: typing.Sequence["MyPayment"],
+        total: typing.Optional[int] = None
     ) -> None:
         self.limit = limit
         self.count = count
@@ -1135,7 +1135,7 @@ class MyPaymentUpdate(_BaseType):
     #: :class:`list`
     actions: list
 
-    def __init__(self, *, version: int = None, actions: list = None) -> None:
+    def __init__(self, *, version: int, actions: list) -> None:
         self.version = version
         self.actions = actions
         super().__init__()
@@ -1148,7 +1148,7 @@ class MyPaymentUpdateAction(_BaseType):
     #: :class:`str`
     action: str
 
-    def __init__(self, *, action: str = None) -> None:
+    def __init__(self, *, action: str) -> None:
         self.action = action
         super().__init__()
 
@@ -1173,7 +1173,7 @@ class MyShoppingListDraft(_BaseType):
     def __init__(
         self,
         *,
-        name: "LocalizedString" = None,
+        name: "LocalizedString",
         description: typing.Optional["LocalizedString"] = None,
         line_items: typing.Optional[typing.List["ShoppingListLineItemDraft"]] = None,
         text_line_items: typing.Optional[typing.List["TextLineItemDraft"]] = None,
@@ -1208,7 +1208,7 @@ class MyShoppingListUpdate(_BaseType):
     #: :class:`list`
     actions: list
 
-    def __init__(self, *, version: int = None, actions: list = None) -> None:
+    def __init__(self, *, version: int, actions: list) -> None:
         self.version = version
         self.actions = actions
         super().__init__()
@@ -1224,7 +1224,7 @@ class MyShoppingListUpdateAction(_BaseType):
     #: :class:`str`
     action: str
 
-    def __init__(self, *, action: str = None) -> None:
+    def __init__(self, *, action: str) -> None:
         self.action = action
         super().__init__()
 
@@ -1245,9 +1245,9 @@ class MyTransactionDraft(_BaseType):
     def __init__(
         self,
         *,
+        type: "TransactionType",
+        amount: "Money",
         timestamp: typing.Optional[datetime.datetime] = None,
-        type: "TransactionType" = None,
-        amount: "Money" = None,
         interaction_id: typing.Optional[str] = None
     ) -> None:
         self.timestamp = timestamp
@@ -1267,7 +1267,7 @@ class MyCartAddDiscountCodeAction(MyCartUpdateAction):
     #: :class:`str`
     code: str
 
-    def __init__(self, *, action: str = None, code: str = None) -> None:
+    def __init__(self, *, code: str) -> None:
         self.code = code
         super().__init__(action="addDiscountCode")
 
@@ -1282,7 +1282,7 @@ class MyCartAddItemShippingAddressAction(MyCartUpdateAction):
     #: :class:`commercetools.types.Address`
     address: "Address"
 
-    def __init__(self, *, action: str = None, address: "Address" = None) -> None:
+    def __init__(self, *, address: "Address") -> None:
         self.address = address
         super().__init__(action="addItemShippingAddress")
 
@@ -1320,7 +1320,6 @@ class MyCartAddLineItemAction(MyCartUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
         custom: typing.Optional["CustomFieldsDraft"] = None,
         distribution_channel: typing.Optional["ChannelResourceIdentifier"] = None,
         external_tax_rate: typing.Optional["ExternalTaxRateDraft"] = None,
@@ -1370,9 +1369,7 @@ class MyCartAddPaymentAction(MyCartUpdateAction):
     #: :class:`commercetools.types.PaymentResourceIdentifier`
     payment: "PaymentResourceIdentifier"
 
-    def __init__(
-        self, *, action: str = None, payment: "PaymentResourceIdentifier" = None
-    ) -> None:
+    def __init__(self, *, payment: "PaymentResourceIdentifier") -> None:
         self.payment = payment
         super().__init__(action="addPayment")
 
@@ -1390,11 +1387,7 @@ class MyCartApplyDeltaToLineItemShippingDetailsTargetsAction(MyCartUpdateAction)
     targets_delta: typing.List["ItemShippingTarget"]
 
     def __init__(
-        self,
-        *,
-        action: str = None,
-        line_item_id: str = None,
-        targets_delta: typing.List["ItemShippingTarget"] = None
+        self, *, line_item_id: str, targets_delta: typing.List["ItemShippingTarget"]
     ) -> None:
         self.line_item_id = line_item_id
         self.targets_delta = targets_delta
@@ -1420,9 +1413,8 @@ class MyCartChangeLineItemQuantityAction(MyCartUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
-        line_item_id: str = None,
-        quantity: int = None,
+        line_item_id: str,
+        quantity: int,
         external_price: typing.Optional["Money"] = None,
         external_total_price: typing.Optional["ExternalLineItemTotalPrice"] = None
     ) -> None:
@@ -1449,7 +1441,7 @@ class MyCartChangeTaxModeAction(MyCartUpdateAction):
     #: :class:`commercetools.types.TaxMode` `(Named` ``taxMode`` `in Commercetools)`
     tax_mode: "TaxMode"
 
-    def __init__(self, *, action: str = None, tax_mode: "TaxMode" = None) -> None:
+    def __init__(self, *, tax_mode: "TaxMode") -> None:
         self.tax_mode = tax_mode
         super().__init__(action="changeTaxMode")
 
@@ -1464,9 +1456,7 @@ class MyCartRecalculateAction(MyCartUpdateAction):
     #: Optional :class:`bool` `(Named` ``updateProductData`` `in Commercetools)`
     update_product_data: typing.Optional[bool]
 
-    def __init__(
-        self, *, action: str = None, update_product_data: typing.Optional[bool] = None
-    ) -> None:
+    def __init__(self, *, update_product_data: typing.Optional[bool] = None) -> None:
         self.update_product_data = update_product_data
         super().__init__(action="recalculate")
 
@@ -1481,9 +1471,7 @@ class MyCartRemoveDiscountCodeAction(MyCartUpdateAction):
     #: :class:`commercetools.types.DiscountCodeReference` `(Named` ``discountCode`` `in Commercetools)`
     discount_code: "DiscountCodeReference"
 
-    def __init__(
-        self, *, action: str = None, discount_code: "DiscountCodeReference" = None
-    ) -> None:
+    def __init__(self, *, discount_code: "DiscountCodeReference") -> None:
         self.discount_code = discount_code
         super().__init__(action="removeDiscountCode")
 
@@ -1498,7 +1486,7 @@ class MyCartRemoveItemShippingAddressAction(MyCartUpdateAction):
     #: :class:`str` `(Named` ``addressKey`` `in Commercetools)`
     address_key: str
 
-    def __init__(self, *, action: str = None, address_key: str = None) -> None:
+    def __init__(self, *, address_key: str) -> None:
         self.address_key = address_key
         super().__init__(action="removeItemShippingAddress")
 
@@ -1524,8 +1512,7 @@ class MyCartRemoveLineItemAction(MyCartUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
-        line_item_id: str = None,
+        line_item_id: str,
         quantity: typing.Optional[int] = None,
         external_price: typing.Optional["Money"] = None,
         external_total_price: typing.Optional["ExternalLineItemTotalPrice"] = None,
@@ -1556,9 +1543,7 @@ class MyCartRemovePaymentAction(MyCartUpdateAction):
     #: :class:`commercetools.types.PaymentResourceIdentifier`
     payment: "PaymentResourceIdentifier"
 
-    def __init__(
-        self, *, action: str = None, payment: "PaymentResourceIdentifier" = None
-    ) -> None:
+    def __init__(self, *, payment: "PaymentResourceIdentifier") -> None:
         self.payment = payment
         super().__init__(action="removePayment")
 
@@ -1573,9 +1558,7 @@ class MyCartSetBillingAddressAction(MyCartUpdateAction):
     #: Optional :class:`commercetools.types.Address`
     address: typing.Optional["Address"]
 
-    def __init__(
-        self, *, action: str = None, address: typing.Optional["Address"] = None
-    ) -> None:
+    def __init__(self, *, address: typing.Optional["Address"] = None) -> None:
         self.address = address
         super().__init__(action="setBillingAddress")
 
@@ -1590,9 +1573,7 @@ class MyCartSetCountryAction(MyCartUpdateAction):
     #: Optional :class:`str`
     country: typing.Optional["str"]
 
-    def __init__(
-        self, *, action: str = None, country: typing.Optional["str"] = None
-    ) -> None:
+    def __init__(self, *, country: typing.Optional["str"] = None) -> None:
         self.country = country
         super().__init__(action="setCountry")
 
@@ -1609,13 +1590,7 @@ class MyCartSetCustomFieldAction(MyCartUpdateAction):
     #: Optional :class:`typing.Any`
     value: typing.Optional[typing.Any]
 
-    def __init__(
-        self,
-        *,
-        action: str = None,
-        name: str = None,
-        value: typing.Optional[typing.Any] = None
-    ) -> None:
+    def __init__(self, *, name: str, value: typing.Optional[typing.Any] = None) -> None:
         self.name = name
         self.value = value
         super().__init__(action="setCustomField")
@@ -1641,9 +1616,8 @@ class MyCartSetCustomShippingMethodAction(MyCartUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
-        shipping_method_name: str = None,
-        shipping_rate: "ShippingRateDraft" = None,
+        shipping_method_name: str,
+        shipping_rate: "ShippingRateDraft",
         tax_category: typing.Optional["TaxCategoryResourceIdentifier"] = None,
         external_tax_rate: typing.Optional["ExternalTaxRateDraft"] = None
     ) -> None:
@@ -1675,7 +1649,6 @@ class MyCartSetCustomTypeAction(MyCartUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
         type: typing.Optional["TypeResourceIdentifier"] = None,
         fields: typing.Optional["FieldContainer"] = None
     ) -> None:
@@ -1696,10 +1669,7 @@ class MyCartSetDeleteDaysAfterLastModificationAction(MyCartUpdateAction):
     delete_days_after_last_modification: typing.Optional[int]
 
     def __init__(
-        self,
-        *,
-        action: str = None,
-        delete_days_after_last_modification: typing.Optional[int] = None
+        self, *, delete_days_after_last_modification: typing.Optional[int] = None
     ) -> None:
         self.delete_days_after_last_modification = delete_days_after_last_modification
         super().__init__(action="setDeleteDaysAfterLastModification")
@@ -1720,12 +1690,7 @@ class MyCartSetLineItemCustomFieldAction(MyCartUpdateAction):
     value: typing.Optional[typing.Any]
 
     def __init__(
-        self,
-        *,
-        action: str = None,
-        line_item_id: str = None,
-        name: str = None,
-        value: typing.Optional[typing.Any] = None
+        self, *, line_item_id: str, name: str, value: typing.Optional[typing.Any] = None
     ) -> None:
         self.line_item_id = line_item_id
         self.name = name
@@ -1750,8 +1715,7 @@ class MyCartSetLineItemCustomTypeAction(MyCartUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
-        line_item_id: str = None,
+        line_item_id: str,
         type: typing.Optional["TypeResourceIdentifier"] = None,
         fields: typing.Optional["FieldContainer"] = None
     ) -> None:
@@ -1776,8 +1740,7 @@ class MyCartSetLineItemShippingDetailsAction(MyCartUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
-        line_item_id: str = None,
+        line_item_id: str,
         shipping_details: typing.Optional["ItemShippingDetailsDraft"] = None
     ) -> None:
         self.line_item_id = line_item_id
@@ -1795,9 +1758,7 @@ class MyCartSetLocaleAction(MyCartUpdateAction):
     #: Optional :class:`str`
     locale: typing.Optional[str]
 
-    def __init__(
-        self, *, action: str = None, locale: typing.Optional[str] = None
-    ) -> None:
+    def __init__(self, *, locale: typing.Optional[str] = None) -> None:
         self.locale = locale
         super().__init__(action="setLocale")
 
@@ -1812,9 +1773,7 @@ class MyCartSetShippingAddressAction(MyCartUpdateAction):
     #: Optional :class:`commercetools.types.Address`
     address: typing.Optional["Address"]
 
-    def __init__(
-        self, *, action: str = None, address: typing.Optional["Address"] = None
-    ) -> None:
+    def __init__(self, *, address: typing.Optional["Address"] = None) -> None:
         self.address = address
         super().__init__(action="setShippingAddress")
 
@@ -1834,7 +1793,6 @@ class MyCartSetShippingMethodAction(MyCartUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
         shipping_method: typing.Optional["ShippingMethodResourceIdentifier"] = None,
         external_tax_rate: typing.Optional["ExternalTaxRateDraft"] = None
     ) -> None:
@@ -1853,7 +1811,7 @@ class MyCartUpdateItemShippingAddressAction(MyCartUpdateAction):
     #: :class:`commercetools.types.Address`
     address: "Address"
 
-    def __init__(self, *, action: str = None, address: "Address" = None) -> None:
+    def __init__(self, *, address: "Address") -> None:
         self.address = address
         super().__init__(action="updateItemShippingAddress")
 
@@ -1868,7 +1826,7 @@ class MyCustomerAddAddressAction(MyCustomerUpdateAction):
     #: :class:`commercetools.types.Address`
     address: "Address"
 
-    def __init__(self, *, action: str = None, address: "Address" = None) -> None:
+    def __init__(self, *, address: "Address") -> None:
         self.address = address
         super().__init__(action="addAddress")
 
@@ -1883,7 +1841,7 @@ class MyCustomerAddBillingAddressIdAction(MyCustomerUpdateAction):
     #: :class:`str` `(Named` ``addressId`` `in Commercetools)`
     address_id: str
 
-    def __init__(self, *, action: str = None, address_id: str = None) -> None:
+    def __init__(self, *, address_id: str) -> None:
         self.address_id = address_id
         super().__init__(action="addBillingAddressId")
 
@@ -1898,7 +1856,7 @@ class MyCustomerAddShippingAddressIdAction(MyCustomerUpdateAction):
     #: :class:`str` `(Named` ``addressId`` `in Commercetools)`
     address_id: str
 
-    def __init__(self, *, action: str = None, address_id: str = None) -> None:
+    def __init__(self, *, address_id: str) -> None:
         self.address_id = address_id
         super().__init__(action="addShippingAddressId")
 
@@ -1915,9 +1873,7 @@ class MyCustomerChangeAddressAction(MyCustomerUpdateAction):
     #: :class:`commercetools.types.Address`
     address: "Address"
 
-    def __init__(
-        self, *, action: str = None, address_id: str = None, address: "Address" = None
-    ) -> None:
+    def __init__(self, *, address_id: str, address: "Address") -> None:
         self.address_id = address_id
         self.address = address
         super().__init__(action="changeAddress")
@@ -1934,7 +1890,7 @@ class MyCustomerChangeEmailAction(MyCustomerUpdateAction):
     #: :class:`str`
     email: str
 
-    def __init__(self, *, action: str = None, email: str = None) -> None:
+    def __init__(self, *, email: str) -> None:
         self.email = email
         super().__init__(action="changeEmail")
 
@@ -1949,7 +1905,7 @@ class MyCustomerRemoveAddressAction(MyCustomerUpdateAction):
     #: :class:`str` `(Named` ``addressId`` `in Commercetools)`
     address_id: str
 
-    def __init__(self, *, action: str = None, address_id: str = None) -> None:
+    def __init__(self, *, address_id: str) -> None:
         self.address_id = address_id
         super().__init__(action="removeAddress")
 
@@ -1964,7 +1920,7 @@ class MyCustomerRemoveBillingAddressIdAction(MyCustomerUpdateAction):
     #: :class:`str` `(Named` ``addressId`` `in Commercetools)`
     address_id: str
 
-    def __init__(self, *, action: str = None, address_id: str = None) -> None:
+    def __init__(self, *, address_id: str) -> None:
         self.address_id = address_id
         super().__init__(action="removeBillingAddressId")
 
@@ -1979,7 +1935,7 @@ class MyCustomerRemoveShippingAddressIdAction(MyCustomerUpdateAction):
     #: :class:`str` `(Named` ``addressId`` `in Commercetools)`
     address_id: str
 
-    def __init__(self, *, action: str = None, address_id: str = None) -> None:
+    def __init__(self, *, address_id: str) -> None:
         self.address_id = address_id
         super().__init__(action="removeShippingAddressId")
 
@@ -1994,9 +1950,7 @@ class MyCustomerSetCompanyNameAction(MyCustomerUpdateAction):
     #: Optional :class:`str` `(Named` ``companyName`` `in Commercetools)`
     company_name: typing.Optional[str]
 
-    def __init__(
-        self, *, action: str = None, company_name: typing.Optional[str] = None
-    ) -> None:
+    def __init__(self, *, company_name: typing.Optional[str] = None) -> None:
         self.company_name = company_name
         super().__init__(action="setCompanyName")
 
@@ -2013,13 +1967,7 @@ class MyCustomerSetCustomFieldAction(MyCustomerUpdateAction):
     #: Optional :class:`typing.Any`
     value: typing.Optional[typing.Any]
 
-    def __init__(
-        self,
-        *,
-        action: str = None,
-        name: str = None,
-        value: typing.Optional[typing.Any] = None
-    ) -> None:
+    def __init__(self, *, name: str, value: typing.Optional[typing.Any] = None) -> None:
         self.name = name
         self.value = value
         super().__init__(action="setCustomField")
@@ -2041,7 +1989,6 @@ class MyCustomerSetCustomTypeAction(MyCustomerUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
         type: typing.Optional["TypeResourceIdentifier"] = None,
         fields: typing.Optional["FieldContainer"] = None
     ) -> None:
@@ -2061,12 +2008,7 @@ class MyCustomerSetDateOfBirthAction(MyCustomerUpdateAction):
     #: Optional :class:`datetime.date` `(Named` ``dateOfBirth`` `in Commercetools)`
     date_of_birth: typing.Optional[datetime.date]
 
-    def __init__(
-        self,
-        *,
-        action: str = None,
-        date_of_birth: typing.Optional[datetime.date] = None
-    ) -> None:
+    def __init__(self, *, date_of_birth: typing.Optional[datetime.date] = None) -> None:
         self.date_of_birth = date_of_birth
         super().__init__(action="setDateOfBirth")
 
@@ -2081,9 +2023,7 @@ class MyCustomerSetDefaultBillingAddressAction(MyCustomerUpdateAction):
     #: Optional :class:`str` `(Named` ``addressId`` `in Commercetools)`
     address_id: typing.Optional[str]
 
-    def __init__(
-        self, *, action: str = None, address_id: typing.Optional[str] = None
-    ) -> None:
+    def __init__(self, *, address_id: typing.Optional[str] = None) -> None:
         self.address_id = address_id
         super().__init__(action="setDefaultBillingAddress")
 
@@ -2098,9 +2038,7 @@ class MyCustomerSetDefaultShippingAddressAction(MyCustomerUpdateAction):
     #: Optional :class:`str` `(Named` ``addressId`` `in Commercetools)`
     address_id: typing.Optional[str]
 
-    def __init__(
-        self, *, action: str = None, address_id: typing.Optional[str] = None
-    ) -> None:
+    def __init__(self, *, address_id: typing.Optional[str] = None) -> None:
         self.address_id = address_id
         super().__init__(action="setDefaultShippingAddress")
 
@@ -2115,9 +2053,7 @@ class MyCustomerSetFirstNameAction(MyCustomerUpdateAction):
     #: Optional :class:`str` `(Named` ``firstName`` `in Commercetools)`
     first_name: typing.Optional[str]
 
-    def __init__(
-        self, *, action: str = None, first_name: typing.Optional[str] = None
-    ) -> None:
+    def __init__(self, *, first_name: typing.Optional[str] = None) -> None:
         self.first_name = first_name
         super().__init__(action="setFirstName")
 
@@ -2132,9 +2068,7 @@ class MyCustomerSetLastNameAction(MyCustomerUpdateAction):
     #: Optional :class:`str` `(Named` ``lastName`` `in Commercetools)`
     last_name: typing.Optional[str]
 
-    def __init__(
-        self, *, action: str = None, last_name: typing.Optional[str] = None
-    ) -> None:
+    def __init__(self, *, last_name: typing.Optional[str] = None) -> None:
         self.last_name = last_name
         super().__init__(action="setLastName")
 
@@ -2149,9 +2083,7 @@ class MyCustomerSetLocaleAction(MyCustomerUpdateAction):
     #: Optional :class:`str`
     locale: typing.Optional[str]
 
-    def __init__(
-        self, *, action: str = None, locale: typing.Optional[str] = None
-    ) -> None:
+    def __init__(self, *, locale: typing.Optional[str] = None) -> None:
         self.locale = locale
         super().__init__(action="setLocale")
 
@@ -2166,9 +2098,7 @@ class MyCustomerSetMiddleNameAction(MyCustomerUpdateAction):
     #: Optional :class:`str` `(Named` ``middleName`` `in Commercetools)`
     middle_name: typing.Optional[str]
 
-    def __init__(
-        self, *, action: str = None, middle_name: typing.Optional[str] = None
-    ) -> None:
+    def __init__(self, *, middle_name: typing.Optional[str] = None) -> None:
         self.middle_name = middle_name
         super().__init__(action="setMiddleName")
 
@@ -2183,9 +2113,7 @@ class MyCustomerSetSalutationAction(MyCustomerUpdateAction):
     #: Optional :class:`str`
     salutation: typing.Optional[str]
 
-    def __init__(
-        self, *, action: str = None, salutation: typing.Optional[str] = None
-    ) -> None:
+    def __init__(self, *, salutation: typing.Optional[str] = None) -> None:
         self.salutation = salutation
         super().__init__(action="setSalutation")
 
@@ -2200,9 +2128,7 @@ class MyCustomerSetTitleAction(MyCustomerUpdateAction):
     #: Optional :class:`str`
     title: typing.Optional[str]
 
-    def __init__(
-        self, *, action: str = None, title: typing.Optional[str] = None
-    ) -> None:
+    def __init__(self, *, title: typing.Optional[str] = None) -> None:
         self.title = title
         super().__init__(action="setTitle")
 
@@ -2217,9 +2143,7 @@ class MyCustomerSetVatIdAction(MyCustomerUpdateAction):
     #: Optional :class:`str` `(Named` ``vatId`` `in Commercetools)`
     vat_id: typing.Optional[str]
 
-    def __init__(
-        self, *, action: str = None, vat_id: typing.Optional[str] = None
-    ) -> None:
+    def __init__(self, *, vat_id: typing.Optional[str] = None) -> None:
         self.vat_id = vat_id
         super().__init__(action="setVatId")
 
@@ -2234,9 +2158,7 @@ class MyPaymentAddTransactionAction(MyPaymentUpdateAction):
     #: :class:`commercetools.types.TransactionDraft`
     transaction: "TransactionDraft"
 
-    def __init__(
-        self, *, action: str = None, transaction: "TransactionDraft" = None
-    ) -> None:
+    def __init__(self, *, transaction: "TransactionDraft") -> None:
         self.transaction = transaction
         super().__init__(action="addTransaction")
 
@@ -2251,7 +2173,7 @@ class MyPaymentChangeAmountPlannedAction(MyPaymentUpdateAction):
     #: :class:`commercetools.types.Money`
     amount: "Money"
 
-    def __init__(self, *, action: str = None, amount: "Money" = None) -> None:
+    def __init__(self, *, amount: "Money") -> None:
         self.amount = amount
         super().__init__(action="changeAmountPlanned")
 
@@ -2268,13 +2190,7 @@ class MyPaymentSetCustomFieldAction(MyPaymentUpdateAction):
     #: Optional :class:`typing.Any`
     value: typing.Optional[typing.Any]
 
-    def __init__(
-        self,
-        *,
-        action: str = None,
-        name: str = None,
-        value: typing.Optional[typing.Any] = None
-    ) -> None:
+    def __init__(self, *, name: str, value: typing.Optional[typing.Any] = None) -> None:
         self.name = name
         self.value = value
         super().__init__(action="setCustomField")
@@ -2291,7 +2207,7 @@ class MyPaymentSetMethodInfoInterfaceAction(MyPaymentUpdateAction):
     #: :class:`str`
     interface: str
 
-    def __init__(self, *, action: str = None, interface: str = None) -> None:
+    def __init__(self, *, interface: str) -> None:
         self.interface = interface
         super().__init__(action="setMethodInfoInterface")
 
@@ -2306,9 +2222,7 @@ class MyPaymentSetMethodInfoMethodAction(MyPaymentUpdateAction):
     #: Optional :class:`str`
     method: typing.Optional[str]
 
-    def __init__(
-        self, *, action: str = None, method: typing.Optional[str] = None
-    ) -> None:
+    def __init__(self, *, method: typing.Optional[str] = None) -> None:
         self.method = method
         super().__init__(action="setMethodInfoMethod")
 
@@ -2323,9 +2237,7 @@ class MyPaymentSetMethodInfoNameAction(MyPaymentUpdateAction):
     #: Optional :class:`commercetools.types.LocalizedString`
     name: typing.Optional["LocalizedString"]
 
-    def __init__(
-        self, *, action: str = None, name: typing.Optional["LocalizedString"] = None
-    ) -> None:
+    def __init__(self, *, name: typing.Optional["LocalizedString"] = None) -> None:
         self.name = name
         super().__init__(action="setMethodInfoName")
 
@@ -2353,7 +2265,6 @@ class MyShoppingListAddLineItemAction(MyShoppingListUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
         sku: typing.Optional[str] = None,
         product_id: typing.Optional[str] = None,
         variant_id: typing.Optional[int] = None,
@@ -2399,8 +2310,7 @@ class MyShoppingListAddTextLineItemAction(MyShoppingListUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
-        name: "LocalizedString" = None,
+        name: "LocalizedString",
         description: typing.Optional["LocalizedString"] = None,
         quantity: typing.Optional[int] = None,
         added_at: typing.Optional[datetime.datetime] = None,
@@ -2433,9 +2343,7 @@ class MyShoppingListChangeLineItemQuantityAction(MyShoppingListUpdateAction):
     #: :class:`int`
     quantity: int
 
-    def __init__(
-        self, *, action: str = None, line_item_id: str = None, quantity: int = None
-    ) -> None:
+    def __init__(self, *, line_item_id: str, quantity: int) -> None:
         self.line_item_id = line_item_id
         self.quantity = quantity
         super().__init__(action="changeLineItemQuantity")
@@ -2451,9 +2359,7 @@ class MyShoppingListChangeLineItemsOrderAction(MyShoppingListUpdateAction):
     #: List of :class:`str` `(Named` ``lineItemOrder`` `in Commercetools)`
     line_item_order: typing.List[str]
 
-    def __init__(
-        self, *, action: str = None, line_item_order: typing.List[str] = None
-    ) -> None:
+    def __init__(self, *, line_item_order: typing.List[str]) -> None:
         self.line_item_order = line_item_order
         super().__init__(action="changeLineItemsOrder")
 
@@ -2468,7 +2374,7 @@ class MyShoppingListChangeNameAction(MyShoppingListUpdateAction):
     #: :class:`commercetools.types.LocalizedString`
     name: "LocalizedString"
 
-    def __init__(self, *, action: str = None, name: "LocalizedString" = None) -> None:
+    def __init__(self, *, name: "LocalizedString") -> None:
         self.name = name
         super().__init__(action="changeName")
 
@@ -2485,13 +2391,7 @@ class MyShoppingListChangeTextLineItemNameAction(MyShoppingListUpdateAction):
     #: :class:`commercetools.types.LocalizedString`
     name: "LocalizedString"
 
-    def __init__(
-        self,
-        *,
-        action: str = None,
-        text_line_item_id: str = None,
-        name: "LocalizedString" = None
-    ) -> None:
+    def __init__(self, *, text_line_item_id: str, name: "LocalizedString") -> None:
         self.text_line_item_id = text_line_item_id
         self.name = name
         super().__init__(action="changeTextLineItemName")
@@ -2509,9 +2409,7 @@ class MyShoppingListChangeTextLineItemQuantityAction(MyShoppingListUpdateAction)
     #: :class:`int`
     quantity: int
 
-    def __init__(
-        self, *, action: str = None, text_line_item_id: str = None, quantity: int = None
-    ) -> None:
+    def __init__(self, *, text_line_item_id: str, quantity: int) -> None:
         self.text_line_item_id = text_line_item_id
         self.quantity = quantity
         super().__init__(action="changeTextLineItemQuantity")
@@ -2527,9 +2425,7 @@ class MyShoppingListChangeTextLineItemsOrderAction(MyShoppingListUpdateAction):
     #: List of :class:`str` `(Named` ``textLineItemOrder`` `in Commercetools)`
     text_line_item_order: typing.List[str]
 
-    def __init__(
-        self, *, action: str = None, text_line_item_order: typing.List[str] = None
-    ) -> None:
+    def __init__(self, *, text_line_item_order: typing.List[str]) -> None:
         self.text_line_item_order = text_line_item_order
         super().__init__(action="changeTextLineItemsOrder")
 
@@ -2547,11 +2443,7 @@ class MyShoppingListRemoveLineItemAction(MyShoppingListUpdateAction):
     quantity: typing.Optional[int]
 
     def __init__(
-        self,
-        *,
-        action: str = None,
-        line_item_id: str = None,
-        quantity: typing.Optional[int] = None
+        self, *, line_item_id: str, quantity: typing.Optional[int] = None
     ) -> None:
         self.line_item_id = line_item_id
         self.quantity = quantity
@@ -2571,11 +2463,7 @@ class MyShoppingListRemoveTextLineItemAction(MyShoppingListUpdateAction):
     quantity: typing.Optional[int]
 
     def __init__(
-        self,
-        *,
-        action: str = None,
-        text_line_item_id: str = None,
-        quantity: typing.Optional[int] = None
+        self, *, text_line_item_id: str, quantity: typing.Optional[int] = None
     ) -> None:
         self.text_line_item_id = text_line_item_id
         self.quantity = quantity
@@ -2594,13 +2482,7 @@ class MyShoppingListSetCustomFieldAction(MyShoppingListUpdateAction):
     #: Optional :class:`typing.Any`
     value: typing.Optional[typing.Any]
 
-    def __init__(
-        self,
-        *,
-        action: str = None,
-        name: str = None,
-        value: typing.Optional[typing.Any] = None
-    ) -> None:
+    def __init__(self, *, name: str, value: typing.Optional[typing.Any] = None) -> None:
         self.name = name
         self.value = value
         super().__init__(action="setCustomField")
@@ -2622,7 +2504,6 @@ class MyShoppingListSetCustomTypeAction(MyShoppingListUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
         type: typing.Optional["TypeResourceIdentifier"] = None,
         fields: typing.Optional["FieldContainer"] = None
     ) -> None:
@@ -2645,10 +2526,7 @@ class MyShoppingListSetDeleteDaysAfterLastModificationAction(
     delete_days_after_last_modification: typing.Optional[int]
 
     def __init__(
-        self,
-        *,
-        action: str = None,
-        delete_days_after_last_modification: typing.Optional[int] = None
+        self, *, delete_days_after_last_modification: typing.Optional[int] = None
     ) -> None:
         self.delete_days_after_last_modification = delete_days_after_last_modification
         super().__init__(action="setDeleteDaysAfterLastModification")
@@ -2665,10 +2543,7 @@ class MyShoppingListSetDescriptionAction(MyShoppingListUpdateAction):
     description: typing.Optional["LocalizedString"]
 
     def __init__(
-        self,
-        *,
-        action: str = None,
-        description: typing.Optional["LocalizedString"] = None
+        self, *, description: typing.Optional["LocalizedString"] = None
     ) -> None:
         self.description = description
         super().__init__(action="setDescription")
@@ -2689,12 +2564,7 @@ class MyShoppingListSetLineItemCustomFieldAction(MyShoppingListUpdateAction):
     value: typing.Optional[typing.Any]
 
     def __init__(
-        self,
-        *,
-        action: str = None,
-        line_item_id: str = None,
-        name: str = None,
-        value: typing.Optional[typing.Any] = None
+        self, *, line_item_id: str, name: str, value: typing.Optional[typing.Any] = None
     ) -> None:
         self.line_item_id = line_item_id
         self.name = name
@@ -2719,8 +2589,7 @@ class MyShoppingListSetLineItemCustomTypeAction(MyShoppingListUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
-        line_item_id: str = None,
+        line_item_id: str,
         type: typing.Optional["TypeResourceIdentifier"] = None,
         fields: typing.Optional["FieldContainer"] = None
     ) -> None:
@@ -2747,9 +2616,8 @@ class MyShoppingListSetTextLineItemCustomFieldAction(MyShoppingListUpdateAction)
     def __init__(
         self,
         *,
-        action: str = None,
-        text_line_item_id: str = None,
-        name: str = None,
+        text_line_item_id: str,
+        name: str,
         value: typing.Optional[typing.Any] = None
     ) -> None:
         self.text_line_item_id = text_line_item_id
@@ -2775,8 +2643,7 @@ class MyShoppingListSetTextLineItemCustomTypeAction(MyShoppingListUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
-        text_line_item_id: str = None,
+        text_line_item_id: str,
         type: typing.Optional["TypeResourceIdentifier"] = None,
         fields: typing.Optional["FieldContainer"] = None
     ) -> None:
@@ -2801,8 +2668,7 @@ class MyShoppingListSetTextLineItemDescriptionAction(MyShoppingListUpdateAction)
     def __init__(
         self,
         *,
-        action: str = None,
-        text_line_item_id: str = None,
+        text_line_item_id: str,
         description: typing.Optional["LocalizedString"] = None
     ) -> None:
         self.text_line_item_id = text_line_item_id

--- a/src/commercetools/types/_message.py
+++ b/src/commercetools/types/_message.py
@@ -231,16 +231,16 @@ class Message(BaseResource):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        sequence_number: int,
+        resource: "Reference",
+        resource_version: int,
+        type: str,
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
-        sequence_number: int = None,
-        resource: "Reference" = None,
-        resource_version: int = None,
-        type: str = None,
         resource_user_provided_identifiers: typing.Optional[
             "UserProvidedIdentifiers"
         ] = None
@@ -289,10 +289,7 @@ class MessageConfiguration(_BaseType):
     delete_days_after_creation: typing.Optional[int]
 
     def __init__(
-        self,
-        *,
-        enabled: bool = None,
-        delete_days_after_creation: typing.Optional[int] = None
+        self, *, enabled: bool, delete_days_after_creation: typing.Optional[int] = None
     ) -> None:
         self.enabled = enabled
         self.delete_days_after_creation = delete_days_after_creation
@@ -311,9 +308,7 @@ class MessageConfigurationDraft(_BaseType):
     #: :class:`int` `(Named` ``deleteDaysAfterCreation`` `in Commercetools)`
     delete_days_after_creation: int
 
-    def __init__(
-        self, *, enabled: bool = None, delete_days_after_creation: int = None
-    ) -> None:
+    def __init__(self, *, enabled: bool, delete_days_after_creation: int) -> None:
         self.enabled = enabled
         self.delete_days_after_creation = delete_days_after_creation
         super().__init__()
@@ -340,11 +335,11 @@ class MessagePagedQueryResponse(_BaseType):
     def __init__(
         self,
         *,
-        limit: int = None,
-        count: int = None,
-        total: typing.Optional[int] = None,
-        offset: int = None,
-        results: typing.Sequence["Message"] = None
+        limit: int,
+        count: int,
+        offset: int,
+        results: typing.Sequence["Message"],
+        total: typing.Optional[int] = None
     ) -> None:
         self.limit = limit
         self.count = count
@@ -364,7 +359,7 @@ class MessagePayload(_BaseType):
     #: :class:`str`
     type: str
 
-    def __init__(self, *, type: str = None) -> None:
+    def __init__(self, *, type: str) -> None:
         self.type = type
         super().__init__()
 
@@ -389,12 +384,12 @@ class ProductPriceDiscountsSetUpdatedPrice(_BaseType):
     def __init__(
         self,
         *,
-        variant_id: int = None,
+        variant_id: int,
+        price_id: str,
+        staged: bool,
         variant_key: typing.Optional[str] = None,
         sku: typing.Optional[str] = None,
-        price_id: str = None,
-        discounted: typing.Optional["DiscountedPrice"] = None,
-        staged: bool = None
+        discounted: typing.Optional["DiscountedPrice"] = None
     ) -> None:
         self.variant_id = variant_id
         self.variant_key = variant_key
@@ -471,20 +466,19 @@ class CategoryCreatedMessage(Message):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        sequence_number: int,
+        resource: "Reference",
+        resource_version: int,
+        category: "Category",
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
-        sequence_number: int = None,
-        resource: "Reference" = None,
-        resource_version: int = None,
-        type: str = None,
         resource_user_provided_identifiers: typing.Optional[
             "UserProvidedIdentifiers"
-        ] = None,
-        category: "Category" = None
+        ] = None
     ) -> None:
         self.category = category
         super().__init__(
@@ -525,7 +519,7 @@ class CategoryCreatedMessagePayload(MessagePayload):
     #: :class:`commercetools.types.Category`
     category: "Category"
 
-    def __init__(self, *, type: str = None, category: "Category" = None) -> None:
+    def __init__(self, *, category: "Category") -> None:
         self.category = category
         super().__init__(type="CategoryCreated")
 
@@ -543,20 +537,19 @@ class CategorySlugChangedMessage(Message):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        sequence_number: int,
+        resource: "Reference",
+        resource_version: int,
+        slug: "LocalizedString",
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
-        sequence_number: int = None,
-        resource: "Reference" = None,
-        resource_version: int = None,
-        type: str = None,
         resource_user_provided_identifiers: typing.Optional[
             "UserProvidedIdentifiers"
-        ] = None,
-        slug: "LocalizedString" = None
+        ] = None
     ) -> None:
         self.slug = slug
         super().__init__(
@@ -597,7 +590,7 @@ class CategorySlugChangedMessagePayload(MessagePayload):
     #: :class:`commercetools.types.LocalizedString`
     slug: "LocalizedString"
 
-    def __init__(self, *, type: str = None, slug: "LocalizedString" = None) -> None:
+    def __init__(self, *, slug: "LocalizedString") -> None:
         self.slug = slug
         super().__init__(type="CategorySlugChanged")
 
@@ -623,24 +616,23 @@ class CustomLineItemStateTransitionMessage(Message):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        sequence_number: int,
+        resource: "Reference",
+        resource_version: int,
+        custom_line_item_id: str,
+        transition_date: datetime.datetime,
+        quantity: int,
+        from_state: "StateReference",
+        to_state: "StateReference",
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
-        sequence_number: int = None,
-        resource: "Reference" = None,
-        resource_version: int = None,
-        type: str = None,
         resource_user_provided_identifiers: typing.Optional[
             "UserProvidedIdentifiers"
-        ] = None,
-        custom_line_item_id: str = None,
-        transition_date: datetime.datetime = None,
-        quantity: int = None,
-        from_state: "StateReference" = None,
-        to_state: "StateReference" = None
+        ] = None
     ) -> None:
         self.custom_line_item_id = custom_line_item_id
         self.transition_date = transition_date
@@ -700,12 +692,11 @@ class CustomLineItemStateTransitionMessagePayload(MessagePayload):
     def __init__(
         self,
         *,
-        type: str = None,
-        custom_line_item_id: str = None,
-        transition_date: datetime.datetime = None,
-        quantity: int = None,
-        from_state: "StateReference" = None,
-        to_state: "StateReference" = None
+        custom_line_item_id: str,
+        transition_date: datetime.datetime,
+        quantity: int,
+        from_state: "StateReference",
+        to_state: "StateReference"
     ) -> None:
         self.custom_line_item_id = custom_line_item_id
         self.transition_date = transition_date
@@ -735,20 +726,19 @@ class CustomerAddressAddedMessage(Message):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        sequence_number: int,
+        resource: "Reference",
+        resource_version: int,
+        address: "Address",
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
-        sequence_number: int = None,
-        resource: "Reference" = None,
-        resource_version: int = None,
-        type: str = None,
         resource_user_provided_identifiers: typing.Optional[
             "UserProvidedIdentifiers"
-        ] = None,
-        address: "Address" = None
+        ] = None
     ) -> None:
         self.address = address
         super().__init__(
@@ -789,7 +779,7 @@ class CustomerAddressAddedMessagePayload(MessagePayload):
     #: :class:`commercetools.types.Address`
     address: "Address"
 
-    def __init__(self, *, type: str = None, address: "Address" = None) -> None:
+    def __init__(self, *, address: "Address") -> None:
         self.address = address
         super().__init__(type="CustomerAddressAdded")
 
@@ -807,20 +797,19 @@ class CustomerAddressChangedMessage(Message):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        sequence_number: int,
+        resource: "Reference",
+        resource_version: int,
+        address: "Address",
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
-        sequence_number: int = None,
-        resource: "Reference" = None,
-        resource_version: int = None,
-        type: str = None,
         resource_user_provided_identifiers: typing.Optional[
             "UserProvidedIdentifiers"
-        ] = None,
-        address: "Address" = None
+        ] = None
     ) -> None:
         self.address = address
         super().__init__(
@@ -861,7 +850,7 @@ class CustomerAddressChangedMessagePayload(MessagePayload):
     #: :class:`commercetools.types.Address`
     address: "Address"
 
-    def __init__(self, *, type: str = None, address: "Address" = None) -> None:
+    def __init__(self, *, address: "Address") -> None:
         self.address = address
         super().__init__(type="CustomerAddressChanged")
 
@@ -879,20 +868,19 @@ class CustomerAddressRemovedMessage(Message):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        sequence_number: int,
+        resource: "Reference",
+        resource_version: int,
+        address: "Address",
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
-        sequence_number: int = None,
-        resource: "Reference" = None,
-        resource_version: int = None,
-        type: str = None,
         resource_user_provided_identifiers: typing.Optional[
             "UserProvidedIdentifiers"
-        ] = None,
-        address: "Address" = None
+        ] = None
     ) -> None:
         self.address = address
         super().__init__(
@@ -933,7 +921,7 @@ class CustomerAddressRemovedMessagePayload(MessagePayload):
     #: :class:`commercetools.types.Address`
     address: "Address"
 
-    def __init__(self, *, type: str = None, address: "Address" = None) -> None:
+    def __init__(self, *, address: "Address") -> None:
         self.address = address
         super().__init__(type="CustomerAddressRemoved")
 
@@ -951,20 +939,19 @@ class CustomerCompanyNameSetMessage(Message):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        sequence_number: int,
+        resource: "Reference",
+        resource_version: int,
+        company_name: str,
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
-        sequence_number: int = None,
-        resource: "Reference" = None,
-        resource_version: int = None,
-        type: str = None,
         resource_user_provided_identifiers: typing.Optional[
             "UserProvidedIdentifiers"
-        ] = None,
-        company_name: str = None
+        ] = None
     ) -> None:
         self.company_name = company_name
         super().__init__(
@@ -1005,7 +992,7 @@ class CustomerCompanyNameSetMessagePayload(MessagePayload):
     #: :class:`str` `(Named` ``companyName`` `in Commercetools)`
     company_name: str
 
-    def __init__(self, *, type: str = None, company_name: str = None) -> None:
+    def __init__(self, *, company_name: str) -> None:
         self.company_name = company_name
         super().__init__(type="CustomerCompanyNameSet")
 
@@ -1023,20 +1010,19 @@ class CustomerCreatedMessage(Message):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        sequence_number: int,
+        resource: "Reference",
+        resource_version: int,
+        customer: "Customer",
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
-        sequence_number: int = None,
-        resource: "Reference" = None,
-        resource_version: int = None,
-        type: str = None,
         resource_user_provided_identifiers: typing.Optional[
             "UserProvidedIdentifiers"
-        ] = None,
-        customer: "Customer" = None
+        ] = None
     ) -> None:
         self.customer = customer
         super().__init__(
@@ -1077,7 +1063,7 @@ class CustomerCreatedMessagePayload(MessagePayload):
     #: :class:`commercetools.types.Customer`
     customer: "Customer"
 
-    def __init__(self, *, type: str = None, customer: "Customer" = None) -> None:
+    def __init__(self, *, customer: "Customer") -> None:
         self.customer = customer
         super().__init__(type="CustomerCreated")
 
@@ -1095,20 +1081,19 @@ class CustomerDateOfBirthSetMessage(Message):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        sequence_number: int,
+        resource: "Reference",
+        resource_version: int,
+        date_of_birth: datetime.date,
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
-        sequence_number: int = None,
-        resource: "Reference" = None,
-        resource_version: int = None,
-        type: str = None,
         resource_user_provided_identifiers: typing.Optional[
             "UserProvidedIdentifiers"
-        ] = None,
-        date_of_birth: datetime.date = None
+        ] = None
     ) -> None:
         self.date_of_birth = date_of_birth
         super().__init__(
@@ -1149,9 +1134,7 @@ class CustomerDateOfBirthSetMessagePayload(MessagePayload):
     #: :class:`datetime.date` `(Named` ``dateOfBirth`` `in Commercetools)`
     date_of_birth: datetime.date
 
-    def __init__(
-        self, *, type: str = None, date_of_birth: datetime.date = None
-    ) -> None:
+    def __init__(self, *, date_of_birth: datetime.date) -> None:
         self.date_of_birth = date_of_birth
         super().__init__(type="CustomerDateOfBirthSet")
 
@@ -1169,20 +1152,19 @@ class CustomerEmailChangedMessage(Message):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        sequence_number: int,
+        resource: "Reference",
+        resource_version: int,
+        email: str,
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
-        sequence_number: int = None,
-        resource: "Reference" = None,
-        resource_version: int = None,
-        type: str = None,
         resource_user_provided_identifiers: typing.Optional[
             "UserProvidedIdentifiers"
-        ] = None,
-        email: str = None
+        ] = None
     ) -> None:
         self.email = email
         super().__init__(
@@ -1223,7 +1205,7 @@ class CustomerEmailChangedMessagePayload(MessagePayload):
     #: :class:`str`
     email: str
 
-    def __init__(self, *, type: str = None, email: str = None) -> None:
+    def __init__(self, *, email: str) -> None:
         self.email = email
         super().__init__(type="CustomerEmailChanged")
 
@@ -1238,16 +1220,15 @@ class CustomerEmailVerifiedMessage(Message):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        sequence_number: int,
+        resource: "Reference",
+        resource_version: int,
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
-        sequence_number: int = None,
-        resource: "Reference" = None,
-        resource_version: int = None,
-        type: str = None,
         resource_user_provided_identifiers: typing.Optional[
             "UserProvidedIdentifiers"
         ] = None
@@ -1286,7 +1267,7 @@ class CustomerEmailVerifiedMessage(Message):
 
 
 class CustomerEmailVerifiedMessagePayload(MessagePayload):
-    def __init__(self, *, type: str = None) -> None:
+    def __init__(self) -> None:
         super().__init__(type="CustomerEmailVerified")
 
     def __repr__(self) -> str:
@@ -1300,20 +1281,19 @@ class CustomerGroupSetMessage(Message):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        sequence_number: int,
+        resource: "Reference",
+        resource_version: int,
+        customer_group: "CustomerGroupReference",
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
-        sequence_number: int = None,
-        resource: "Reference" = None,
-        resource_version: int = None,
-        type: str = None,
         resource_user_provided_identifiers: typing.Optional[
             "UserProvidedIdentifiers"
-        ] = None,
-        customer_group: "CustomerGroupReference" = None
+        ] = None
     ) -> None:
         self.customer_group = customer_group
         super().__init__(
@@ -1354,9 +1334,7 @@ class CustomerGroupSetMessagePayload(MessagePayload):
     #: :class:`commercetools.types.CustomerGroupReference` `(Named` ``customerGroup`` `in Commercetools)`
     customer_group: "CustomerGroupReference"
 
-    def __init__(
-        self, *, type: str = None, customer_group: "CustomerGroupReference" = None
-    ) -> None:
+    def __init__(self, *, customer_group: "CustomerGroupReference") -> None:
         self.customer_group = customer_group
         super().__init__(type="CustomerGroupSet")
 
@@ -1374,20 +1352,19 @@ class DeliveryAddedMessage(Message):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        sequence_number: int,
+        resource: "Reference",
+        resource_version: int,
+        delivery: "Delivery",
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
-        sequence_number: int = None,
-        resource: "Reference" = None,
-        resource_version: int = None,
-        type: str = None,
         resource_user_provided_identifiers: typing.Optional[
             "UserProvidedIdentifiers"
-        ] = None,
-        delivery: "Delivery" = None
+        ] = None
     ) -> None:
         self.delivery = delivery
         super().__init__(
@@ -1428,7 +1405,7 @@ class DeliveryAddedMessagePayload(MessagePayload):
     #: :class:`commercetools.types.Delivery`
     delivery: "Delivery"
 
-    def __init__(self, *, type: str = None, delivery: "Delivery" = None) -> None:
+    def __init__(self, *, delivery: "Delivery") -> None:
         self.delivery = delivery
         super().__init__(type="DeliveryAdded")
 
@@ -1450,20 +1427,19 @@ class DeliveryAddressSetMessage(Message):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        sequence_number: int,
+        resource: "Reference",
+        resource_version: int,
+        delivery_id: str,
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
-        sequence_number: int = None,
-        resource: "Reference" = None,
-        resource_version: int = None,
-        type: str = None,
         resource_user_provided_identifiers: typing.Optional[
             "UserProvidedIdentifiers"
         ] = None,
-        delivery_id: str = None,
         address: typing.Optional["Address"] = None,
         old_address: typing.Optional["Address"] = None
     ) -> None:
@@ -1517,8 +1493,7 @@ class DeliveryAddressSetMessagePayload(MessagePayload):
     def __init__(
         self,
         *,
-        type: str = None,
-        delivery_id: str = None,
+        delivery_id: str,
         address: typing.Optional["Address"] = None,
         old_address: typing.Optional["Address"] = None
     ) -> None:
@@ -1545,22 +1520,21 @@ class DeliveryItemsUpdatedMessage(Message):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        sequence_number: int,
+        resource: "Reference",
+        resource_version: int,
+        delivery_id: str,
+        items: typing.List["DeliveryItem"],
+        old_items: typing.List["DeliveryItem"],
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
-        sequence_number: int = None,
-        resource: "Reference" = None,
-        resource_version: int = None,
-        type: str = None,
         resource_user_provided_identifiers: typing.Optional[
             "UserProvidedIdentifiers"
-        ] = None,
-        delivery_id: str = None,
-        items: typing.List["DeliveryItem"] = None,
-        old_items: typing.List["DeliveryItem"] = None
+        ] = None
     ) -> None:
         self.delivery_id = delivery_id
         self.items = items
@@ -1612,10 +1586,9 @@ class DeliveryItemsUpdatedMessagePayload(MessagePayload):
     def __init__(
         self,
         *,
-        type: str = None,
-        delivery_id: str = None,
-        items: typing.List["DeliveryItem"] = None,
-        old_items: typing.List["DeliveryItem"] = None
+        delivery_id: str,
+        items: typing.List["DeliveryItem"],
+        old_items: typing.List["DeliveryItem"]
     ) -> None:
         self.delivery_id = delivery_id
         self.items = items
@@ -1636,20 +1609,19 @@ class DeliveryRemovedMessage(Message):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        sequence_number: int,
+        resource: "Reference",
+        resource_version: int,
+        delivery: "Delivery",
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
-        sequence_number: int = None,
-        resource: "Reference" = None,
-        resource_version: int = None,
-        type: str = None,
         resource_user_provided_identifiers: typing.Optional[
             "UserProvidedIdentifiers"
-        ] = None,
-        delivery: "Delivery" = None
+        ] = None
     ) -> None:
         self.delivery = delivery
         super().__init__(
@@ -1690,7 +1662,7 @@ class DeliveryRemovedMessagePayload(MessagePayload):
     #: :class:`commercetools.types.Delivery`
     delivery: "Delivery"
 
-    def __init__(self, *, type: str = None, delivery: "Delivery" = None) -> None:
+    def __init__(self, *, delivery: "Delivery") -> None:
         self.delivery = delivery
         super().__init__(type="DeliveryRemoved")
 
@@ -1708,20 +1680,19 @@ class InventoryEntryCreatedMessage(Message):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        sequence_number: int,
+        resource: "Reference",
+        resource_version: int,
+        inventory_entry: "InventoryEntry",
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
-        sequence_number: int = None,
-        resource: "Reference" = None,
-        resource_version: int = None,
-        type: str = None,
         resource_user_provided_identifiers: typing.Optional[
             "UserProvidedIdentifiers"
-        ] = None,
-        inventory_entry: "InventoryEntry" = None
+        ] = None
     ) -> None:
         self.inventory_entry = inventory_entry
         super().__init__(
@@ -1762,9 +1733,7 @@ class InventoryEntryCreatedMessagePayload(MessagePayload):
     #: :class:`commercetools.types.InventoryEntry` `(Named` ``inventoryEntry`` `in Commercetools)`
     inventory_entry: "InventoryEntry"
 
-    def __init__(
-        self, *, type: str = None, inventory_entry: "InventoryEntry" = None
-    ) -> None:
+    def __init__(self, *, inventory_entry: "InventoryEntry") -> None:
         self.inventory_entry = inventory_entry
         super().__init__(type="InventoryEntryCreated")
 
@@ -1784,21 +1753,20 @@ class InventoryEntryDeletedMessage(Message):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        sequence_number: int,
+        resource: "Reference",
+        resource_version: int,
+        sku: str,
+        supply_channel: "ChannelReference",
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
-        sequence_number: int = None,
-        resource: "Reference" = None,
-        resource_version: int = None,
-        type: str = None,
         resource_user_provided_identifiers: typing.Optional[
             "UserProvidedIdentifiers"
-        ] = None,
-        sku: str = None,
-        supply_channel: "ChannelReference" = None
+        ] = None
     ) -> None:
         self.sku = sku
         self.supply_channel = supply_channel
@@ -1843,13 +1811,7 @@ class InventoryEntryDeletedMessagePayload(MessagePayload):
     #: :class:`commercetools.types.ChannelReference` `(Named` ``supplyChannel`` `in Commercetools)`
     supply_channel: "ChannelReference"
 
-    def __init__(
-        self,
-        *,
-        type: str = None,
-        sku: str = None,
-        supply_channel: "ChannelReference" = None
-    ) -> None:
+    def __init__(self, *, sku: str, supply_channel: "ChannelReference") -> None:
         self.sku = sku
         self.supply_channel = supply_channel
         super().__init__(type="InventoryEntryDeleted")
@@ -1874,23 +1836,22 @@ class InventoryEntryQuantitySetMessage(Message):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        sequence_number: int,
+        resource: "Reference",
+        resource_version: int,
+        old_quantity_on_stock: int,
+        new_quantity_on_stock: int,
+        old_available_quantity: int,
+        new_available_quantity: int,
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
-        sequence_number: int = None,
-        resource: "Reference" = None,
-        resource_version: int = None,
-        type: str = None,
         resource_user_provided_identifiers: typing.Optional[
             "UserProvidedIdentifiers"
-        ] = None,
-        old_quantity_on_stock: int = None,
-        new_quantity_on_stock: int = None,
-        old_available_quantity: int = None,
-        new_available_quantity: int = None
+        ] = None
     ) -> None:
         self.old_quantity_on_stock = old_quantity_on_stock
         self.new_quantity_on_stock = new_quantity_on_stock
@@ -1946,11 +1907,10 @@ class InventoryEntryQuantitySetMessagePayload(MessagePayload):
     def __init__(
         self,
         *,
-        type: str = None,
-        old_quantity_on_stock: int = None,
-        new_quantity_on_stock: int = None,
-        old_available_quantity: int = None,
-        new_available_quantity: int = None
+        old_quantity_on_stock: int,
+        new_quantity_on_stock: int,
+        old_available_quantity: int,
+        new_available_quantity: int
     ) -> None:
         self.old_quantity_on_stock = old_quantity_on_stock
         self.new_quantity_on_stock = new_quantity_on_stock
@@ -1986,24 +1946,23 @@ class LineItemStateTransitionMessage(Message):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        sequence_number: int,
+        resource: "Reference",
+        resource_version: int,
+        line_item_id: str,
+        transition_date: datetime.datetime,
+        quantity: int,
+        from_state: "StateReference",
+        to_state: "StateReference",
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
-        sequence_number: int = None,
-        resource: "Reference" = None,
-        resource_version: int = None,
-        type: str = None,
         resource_user_provided_identifiers: typing.Optional[
             "UserProvidedIdentifiers"
-        ] = None,
-        line_item_id: str = None,
-        transition_date: datetime.datetime = None,
-        quantity: int = None,
-        from_state: "StateReference" = None,
-        to_state: "StateReference" = None
+        ] = None
     ) -> None:
         self.line_item_id = line_item_id
         self.transition_date = transition_date
@@ -2063,12 +2022,11 @@ class LineItemStateTransitionMessagePayload(MessagePayload):
     def __init__(
         self,
         *,
-        type: str = None,
-        line_item_id: str = None,
-        transition_date: datetime.datetime = None,
-        quantity: int = None,
-        from_state: "StateReference" = None,
-        to_state: "StateReference" = None
+        line_item_id: str,
+        transition_date: datetime.datetime,
+        quantity: int,
+        from_state: "StateReference",
+        to_state: "StateReference"
     ) -> None:
         self.line_item_id = line_item_id
         self.transition_date = transition_date
@@ -2100,16 +2058,15 @@ class OrderBillingAddressSetMessage(Message):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        sequence_number: int,
+        resource: "Reference",
+        resource_version: int,
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
-        sequence_number: int = None,
-        resource: "Reference" = None,
-        resource_version: int = None,
-        type: str = None,
         resource_user_provided_identifiers: typing.Optional[
             "UserProvidedIdentifiers"
         ] = None,
@@ -2162,7 +2119,6 @@ class OrderBillingAddressSetMessagePayload(MessagePayload):
     def __init__(
         self,
         *,
-        type: str = None,
         address: typing.Optional["Address"] = None,
         old_address: typing.Optional["Address"] = None
     ) -> None:
@@ -2184,20 +2140,19 @@ class OrderCreatedMessage(Message):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        sequence_number: int,
+        resource: "Reference",
+        resource_version: int,
+        order: "Order",
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
-        sequence_number: int = None,
-        resource: "Reference" = None,
-        resource_version: int = None,
-        type: str = None,
         resource_user_provided_identifiers: typing.Optional[
             "UserProvidedIdentifiers"
-        ] = None,
-        order: "Order" = None
+        ] = None
     ) -> None:
         self.order = order
         super().__init__(
@@ -2238,7 +2193,7 @@ class OrderCreatedMessagePayload(MessagePayload):
     #: :class:`commercetools.types.Order`
     order: "Order"
 
-    def __init__(self, *, type: str = None, order: "Order" = None) -> None:
+    def __init__(self, *, order: "Order") -> None:
         self.order = order
         super().__init__(type="OrderCreated")
 
@@ -2257,22 +2212,21 @@ class OrderCustomLineItemDiscountSetMessage(Message):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
-        last_modified_by: typing.Optional["LastModifiedBy"] = None,
-        created_by: typing.Optional["CreatedBy"] = None,
-        sequence_number: int = None,
-        resource: "Reference" = None,
-        resource_version: int = None,
-        type: str = None,
-        resource_user_provided_identifiers: typing.Optional[
-            "UserProvidedIdentifiers"
-        ] = None,
-        custom_line_item_id: str = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        sequence_number: int,
+        resource: "Reference",
+        resource_version: int,
+        custom_line_item_id: str,
         discounted_price_per_quantity: typing.List[
             "DiscountedLineItemPriceForQuantity"
+        ],
+        last_modified_by: typing.Optional["LastModifiedBy"] = None,
+        created_by: typing.Optional["CreatedBy"] = None,
+        resource_user_provided_identifiers: typing.Optional[
+            "UserProvidedIdentifiers"
         ] = None,
         taxed_price: typing.Optional["TaxedItemPrice"] = None
     ) -> None:
@@ -2326,11 +2280,10 @@ class OrderCustomLineItemDiscountSetMessagePayload(MessagePayload):
     def __init__(
         self,
         *,
-        type: str = None,
-        custom_line_item_id: str = None,
+        custom_line_item_id: str,
         discounted_price_per_quantity: typing.List[
             "DiscountedLineItemPriceForQuantity"
-        ] = None,
+        ],
         taxed_price: typing.Optional["TaxedItemPrice"] = None
     ) -> None:
         self.custom_line_item_id = custom_line_item_id
@@ -2359,16 +2312,15 @@ class OrderCustomerEmailSetMessage(Message):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        sequence_number: int,
+        resource: "Reference",
+        resource_version: int,
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
-        sequence_number: int = None,
-        resource: "Reference" = None,
-        resource_version: int = None,
-        type: str = None,
         resource_user_provided_identifiers: typing.Optional[
             "UserProvidedIdentifiers"
         ] = None,
@@ -2421,7 +2373,6 @@ class OrderCustomerEmailSetMessagePayload(MessagePayload):
     def __init__(
         self,
         *,
-        type: str = None,
         email: typing.Optional[str] = None,
         old_email: typing.Optional[str] = None
     ) -> None:
@@ -2445,16 +2396,15 @@ class OrderCustomerGroupSetMessage(Message):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        sequence_number: int,
+        resource: "Reference",
+        resource_version: int,
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
-        sequence_number: int = None,
-        resource: "Reference" = None,
-        resource_version: int = None,
-        type: str = None,
         resource_user_provided_identifiers: typing.Optional[
             "UserProvidedIdentifiers"
         ] = None,
@@ -2507,7 +2457,6 @@ class OrderCustomerGroupSetMessagePayload(MessagePayload):
     def __init__(
         self,
         *,
-        type: str = None,
         customer_group: typing.Optional["CustomerGroupReference"] = None,
         old_customer_group: typing.Optional["CustomerGroupReference"] = None
     ) -> None:
@@ -2535,16 +2484,15 @@ class OrderCustomerSetMessage(Message):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        sequence_number: int,
+        resource: "Reference",
+        resource_version: int,
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
-        sequence_number: int = None,
-        resource: "Reference" = None,
-        resource_version: int = None,
-        type: str = None,
         resource_user_provided_identifiers: typing.Optional[
             "UserProvidedIdentifiers"
         ] = None,
@@ -2607,7 +2555,6 @@ class OrderCustomerSetMessagePayload(MessagePayload):
     def __init__(
         self,
         *,
-        type: str = None,
         customer: typing.Optional["CustomerReference"] = None,
         customer_group: typing.Optional["CustomerGroupReference"] = None,
         old_customer: typing.Optional["CustomerReference"] = None,
@@ -2639,20 +2586,19 @@ class OrderDeletedMessage(Message):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        sequence_number: int,
+        resource: "Reference",
+        resource_version: int,
+        order: "Order",
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
-        sequence_number: int = None,
-        resource: "Reference" = None,
-        resource_version: int = None,
-        type: str = None,
         resource_user_provided_identifiers: typing.Optional[
             "UserProvidedIdentifiers"
-        ] = None,
-        order: "Order" = None
+        ] = None
     ) -> None:
         self.order = order
         super().__init__(
@@ -2693,7 +2639,7 @@ class OrderDeletedMessagePayload(MessagePayload):
     #: :class:`commercetools.types.Order`
     order: "Order"
 
-    def __init__(self, *, type: str = None, order: "Order" = None) -> None:
+    def __init__(self, *, order: "Order") -> None:
         self.order = order
         super().__init__(type="OrderDeleted")
 
@@ -2708,20 +2654,19 @@ class OrderDiscountCodeAddedMessage(Message):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        sequence_number: int,
+        resource: "Reference",
+        resource_version: int,
+        discount_code: "DiscountCodeReference",
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
-        sequence_number: int = None,
-        resource: "Reference" = None,
-        resource_version: int = None,
-        type: str = None,
         resource_user_provided_identifiers: typing.Optional[
             "UserProvidedIdentifiers"
-        ] = None,
-        discount_code: "DiscountCodeReference" = None
+        ] = None
     ) -> None:
         self.discount_code = discount_code
         super().__init__(
@@ -2762,9 +2707,7 @@ class OrderDiscountCodeAddedMessagePayload(MessagePayload):
     #: :class:`commercetools.types.DiscountCodeReference` `(Named` ``discountCode`` `in Commercetools)`
     discount_code: "DiscountCodeReference"
 
-    def __init__(
-        self, *, type: str = None, discount_code: "DiscountCodeReference" = None
-    ) -> None:
+    def __init__(self, *, discount_code: "DiscountCodeReference") -> None:
         self.discount_code = discount_code
         super().__init__(type="OrderDiscountCodeAdded")
 
@@ -2782,20 +2725,19 @@ class OrderDiscountCodeRemovedMessage(Message):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        sequence_number: int,
+        resource: "Reference",
+        resource_version: int,
+        discount_code: "DiscountCodeReference",
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
-        sequence_number: int = None,
-        resource: "Reference" = None,
-        resource_version: int = None,
-        type: str = None,
         resource_user_provided_identifiers: typing.Optional[
             "UserProvidedIdentifiers"
-        ] = None,
-        discount_code: "DiscountCodeReference" = None
+        ] = None
     ) -> None:
         self.discount_code = discount_code
         super().__init__(
@@ -2836,9 +2778,7 @@ class OrderDiscountCodeRemovedMessagePayload(MessagePayload):
     #: :class:`commercetools.types.DiscountCodeReference` `(Named` ``discountCode`` `in Commercetools)`
     discount_code: "DiscountCodeReference"
 
-    def __init__(
-        self, *, type: str = None, discount_code: "DiscountCodeReference" = None
-    ) -> None:
+    def __init__(self, *, discount_code: "DiscountCodeReference") -> None:
         self.discount_code = discount_code
         super().__init__(type="OrderDiscountCodeRemoved")
 
@@ -2860,21 +2800,20 @@ class OrderDiscountCodeStateSetMessage(Message):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        sequence_number: int,
+        resource: "Reference",
+        resource_version: int,
+        discount_code: "DiscountCodeReference",
+        state: "DiscountCodeState",
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
-        sequence_number: int = None,
-        resource: "Reference" = None,
-        resource_version: int = None,
-        type: str = None,
         resource_user_provided_identifiers: typing.Optional[
             "UserProvidedIdentifiers"
         ] = None,
-        discount_code: "DiscountCodeReference" = None,
-        state: "DiscountCodeState" = None,
         old_state: typing.Optional["DiscountCodeState"] = None
     ) -> None:
         self.discount_code = discount_code
@@ -2927,9 +2866,8 @@ class OrderDiscountCodeStateSetMessagePayload(MessagePayload):
     def __init__(
         self,
         *,
-        type: str = None,
-        discount_code: "DiscountCodeReference" = None,
-        state: "DiscountCodeState" = None,
+        discount_code: "DiscountCodeReference",
+        state: "DiscountCodeState",
         old_state: typing.Optional["DiscountCodeState"] = None
     ) -> None:
         self.discount_code = discount_code
@@ -2953,21 +2891,20 @@ class OrderEditAppliedMessage(Message):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        sequence_number: int,
+        resource: "Reference",
+        resource_version: int,
+        edit: "OrderEditReference",
+        result: "OrderEditApplied",
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
-        sequence_number: int = None,
-        resource: "Reference" = None,
-        resource_version: int = None,
-        type: str = None,
         resource_user_provided_identifiers: typing.Optional[
             "UserProvidedIdentifiers"
-        ] = None,
-        edit: "OrderEditReference" = None,
-        result: "OrderEditApplied" = None
+        ] = None
     ) -> None:
         self.edit = edit
         self.result = result
@@ -3013,11 +2950,7 @@ class OrderEditAppliedMessagePayload(MessagePayload):
     result: "OrderEditApplied"
 
     def __init__(
-        self,
-        *,
-        type: str = None,
-        edit: "OrderEditReference" = None,
-        result: "OrderEditApplied" = None
+        self, *, edit: "OrderEditReference", result: "OrderEditApplied"
     ) -> None:
         self.edit = edit
         self.result = result
@@ -3038,20 +2971,19 @@ class OrderImportedMessage(Message):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        sequence_number: int,
+        resource: "Reference",
+        resource_version: int,
+        order: "Order",
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
-        sequence_number: int = None,
-        resource: "Reference" = None,
-        resource_version: int = None,
-        type: str = None,
         resource_user_provided_identifiers: typing.Optional[
             "UserProvidedIdentifiers"
-        ] = None,
-        order: "Order" = None
+        ] = None
     ) -> None:
         self.order = order
         super().__init__(
@@ -3092,7 +3024,7 @@ class OrderImportedMessagePayload(MessagePayload):
     #: :class:`commercetools.types.Order`
     order: "Order"
 
-    def __init__(self, *, type: str = None, order: "Order" = None) -> None:
+    def __init__(self, *, order: "Order") -> None:
         self.order = order
         super().__init__(type="OrderImported")
 
@@ -3112,21 +3044,20 @@ class OrderLineItemAddedMessage(Message):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        sequence_number: int,
+        resource: "Reference",
+        resource_version: int,
+        line_item: "LineItem",
+        added_quantity: int,
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
-        sequence_number: int = None,
-        resource: "Reference" = None,
-        resource_version: int = None,
-        type: str = None,
         resource_user_provided_identifiers: typing.Optional[
             "UserProvidedIdentifiers"
-        ] = None,
-        line_item: "LineItem" = None,
-        added_quantity: int = None
+        ] = None
     ) -> None:
         self.line_item = line_item
         self.added_quantity = added_quantity
@@ -3171,13 +3102,7 @@ class OrderLineItemAddedMessagePayload(MessagePayload):
     #: :class:`int` `(Named` ``addedQuantity`` `in Commercetools)`
     added_quantity: int
 
-    def __init__(
-        self,
-        *,
-        type: str = None,
-        line_item: "LineItem" = None,
-        added_quantity: int = None
-    ) -> None:
+    def __init__(self, *, line_item: "LineItem", added_quantity: int) -> None:
         self.line_item = line_item
         self.added_quantity = added_quantity
         super().__init__(type="OrderLineItemAdded")
@@ -3202,24 +3127,23 @@ class OrderLineItemDiscountSetMessage(Message):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        sequence_number: int,
+        resource: "Reference",
+        resource_version: int,
+        line_item_id: str,
+        discounted_price_per_quantity: typing.List[
+            "DiscountedLineItemPriceForQuantity"
+        ],
+        total_price: "Money",
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
-        sequence_number: int = None,
-        resource: "Reference" = None,
-        resource_version: int = None,
-        type: str = None,
         resource_user_provided_identifiers: typing.Optional[
             "UserProvidedIdentifiers"
         ] = None,
-        line_item_id: str = None,
-        discounted_price_per_quantity: typing.List[
-            "DiscountedLineItemPriceForQuantity"
-        ] = None,
-        total_price: "Money" = None,
         taxed_price: typing.Optional["TaxedItemPrice"] = None
     ) -> None:
         self.line_item_id = line_item_id
@@ -3276,12 +3200,11 @@ class OrderLineItemDiscountSetMessagePayload(MessagePayload):
     def __init__(
         self,
         *,
-        type: str = None,
-        line_item_id: str = None,
+        line_item_id: str,
         discounted_price_per_quantity: typing.List[
             "DiscountedLineItemPriceForQuantity"
-        ] = None,
-        total_price: "Money" = None,
+        ],
+        total_price: "Money",
         taxed_price: typing.Optional["TaxedItemPrice"] = None
     ) -> None:
         self.line_item_id = line_item_id
@@ -3312,20 +3235,19 @@ class OrderPaymentStateChangedMessage(Message):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        sequence_number: int,
+        resource: "Reference",
+        resource_version: int,
+        payment_state: "PaymentState",
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
-        sequence_number: int = None,
-        resource: "Reference" = None,
-        resource_version: int = None,
-        type: str = None,
         resource_user_provided_identifiers: typing.Optional[
             "UserProvidedIdentifiers"
         ] = None,
-        payment_state: "PaymentState" = None,
         old_payment_state: typing.Optional["PaymentState"] = None
     ) -> None:
         self.payment_state = payment_state
@@ -3374,8 +3296,7 @@ class OrderPaymentStateChangedMessagePayload(MessagePayload):
     def __init__(
         self,
         *,
-        type: str = None,
-        payment_state: "PaymentState" = None,
+        payment_state: "PaymentState",
         old_payment_state: typing.Optional["PaymentState"] = None
     ) -> None:
         self.payment_state = payment_state
@@ -3396,20 +3317,19 @@ class OrderReturnInfoAddedMessage(Message):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        sequence_number: int,
+        resource: "Reference",
+        resource_version: int,
+        return_info: "ReturnInfo",
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
-        sequence_number: int = None,
-        resource: "Reference" = None,
-        resource_version: int = None,
-        type: str = None,
         resource_user_provided_identifiers: typing.Optional[
             "UserProvidedIdentifiers"
-        ] = None,
-        return_info: "ReturnInfo" = None
+        ] = None
     ) -> None:
         self.return_info = return_info
         super().__init__(
@@ -3450,7 +3370,7 @@ class OrderReturnInfoAddedMessagePayload(MessagePayload):
     #: :class:`commercetools.types.ReturnInfo` `(Named` ``returnInfo`` `in Commercetools)`
     return_info: "ReturnInfo"
 
-    def __init__(self, *, type: str = None, return_info: "ReturnInfo" = None) -> None:
+    def __init__(self, *, return_info: "ReturnInfo") -> None:
         self.return_info = return_info
         super().__init__(type="ReturnInfoAdded")
 
@@ -3470,21 +3390,20 @@ class OrderReturnShipmentStateChangedMessage(Message):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        sequence_number: int,
+        resource: "Reference",
+        resource_version: int,
+        return_item_id: str,
+        return_shipment_state: "ReturnShipmentState",
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
-        sequence_number: int = None,
-        resource: "Reference" = None,
-        resource_version: int = None,
-        type: str = None,
         resource_user_provided_identifiers: typing.Optional[
             "UserProvidedIdentifiers"
-        ] = None,
-        return_item_id: str = None,
-        return_shipment_state: "ReturnShipmentState" = None
+        ] = None
     ) -> None:
         self.return_item_id = return_item_id
         self.return_shipment_state = return_shipment_state
@@ -3530,11 +3449,7 @@ class OrderReturnShipmentStateChangedMessagePayload(MessagePayload):
     return_shipment_state: "ReturnShipmentState"
 
     def __init__(
-        self,
-        *,
-        type: str = None,
-        return_item_id: str = None,
-        return_shipment_state: "ReturnShipmentState" = None
+        self, *, return_item_id: str, return_shipment_state: "ReturnShipmentState"
     ) -> None:
         self.return_item_id = return_item_id
         self.return_shipment_state = return_shipment_state
@@ -3556,20 +3471,19 @@ class OrderShipmentStateChangedMessage(Message):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        sequence_number: int,
+        resource: "Reference",
+        resource_version: int,
+        shipment_state: "ShipmentState",
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
-        sequence_number: int = None,
-        resource: "Reference" = None,
-        resource_version: int = None,
-        type: str = None,
         resource_user_provided_identifiers: typing.Optional[
             "UserProvidedIdentifiers"
         ] = None,
-        shipment_state: "ShipmentState" = None,
         old_shipment_state: typing.Optional["ShipmentState"] = None
     ) -> None:
         self.shipment_state = shipment_state
@@ -3618,8 +3532,7 @@ class OrderShipmentStateChangedMessagePayload(MessagePayload):
     def __init__(
         self,
         *,
-        type: str = None,
-        shipment_state: "ShipmentState" = None,
+        shipment_state: "ShipmentState",
         old_shipment_state: typing.Optional["ShipmentState"] = None
     ) -> None:
         self.shipment_state = shipment_state
@@ -3642,16 +3555,15 @@ class OrderShippingAddressSetMessage(Message):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        sequence_number: int,
+        resource: "Reference",
+        resource_version: int,
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
-        sequence_number: int = None,
-        resource: "Reference" = None,
-        resource_version: int = None,
-        type: str = None,
         resource_user_provided_identifiers: typing.Optional[
             "UserProvidedIdentifiers"
         ] = None,
@@ -3704,7 +3616,6 @@ class OrderShippingAddressSetMessagePayload(MessagePayload):
     def __init__(
         self,
         *,
-        type: str = None,
         address: typing.Optional["Address"] = None,
         old_address: typing.Optional["Address"] = None
     ) -> None:
@@ -3728,16 +3639,15 @@ class OrderShippingInfoSetMessage(Message):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        sequence_number: int,
+        resource: "Reference",
+        resource_version: int,
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
-        sequence_number: int = None,
-        resource: "Reference" = None,
-        resource_version: int = None,
-        type: str = None,
         resource_user_provided_identifiers: typing.Optional[
             "UserProvidedIdentifiers"
         ] = None,
@@ -3790,7 +3700,6 @@ class OrderShippingInfoSetMessagePayload(MessagePayload):
     def __init__(
         self,
         *,
-        type: str = None,
         shipping_info: typing.Optional["ShippingInfo"] = None,
         old_shipping_info: typing.Optional["ShippingInfo"] = None
     ) -> None:
@@ -3814,16 +3723,15 @@ class OrderShippingRateInputSetMessage(Message):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        sequence_number: int,
+        resource: "Reference",
+        resource_version: int,
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
-        sequence_number: int = None,
-        resource: "Reference" = None,
-        resource_version: int = None,
-        type: str = None,
         resource_user_provided_identifiers: typing.Optional[
             "UserProvidedIdentifiers"
         ] = None,
@@ -3876,7 +3784,6 @@ class OrderShippingRateInputSetMessagePayload(MessagePayload):
     def __init__(
         self,
         *,
-        type: str = None,
         shipping_rate_input: typing.Optional["ShippingRateInput"] = None,
         old_shipping_rate_input: typing.Optional["ShippingRateInput"] = None
     ) -> None:
@@ -3900,21 +3807,20 @@ class OrderStateChangedMessage(Message):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        sequence_number: int,
+        resource: "Reference",
+        resource_version: int,
+        order_state: "OrderState",
+        old_order_state: "OrderState",
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
-        sequence_number: int = None,
-        resource: "Reference" = None,
-        resource_version: int = None,
-        type: str = None,
         resource_user_provided_identifiers: typing.Optional[
             "UserProvidedIdentifiers"
-        ] = None,
-        order_state: "OrderState" = None,
-        old_order_state: "OrderState" = None
+        ] = None
     ) -> None:
         self.order_state = order_state
         self.old_order_state = old_order_state
@@ -3960,11 +3866,7 @@ class OrderStateChangedMessagePayload(MessagePayload):
     old_order_state: "OrderState"
 
     def __init__(
-        self,
-        *,
-        type: str = None,
-        order_state: "OrderState" = None,
-        old_order_state: "OrderState" = None
+        self, *, order_state: "OrderState", old_order_state: "OrderState"
     ) -> None:
         self.order_state = order_state
         self.old_order_state = old_order_state
@@ -3986,21 +3888,20 @@ class OrderStateTransitionMessage(Message):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        sequence_number: int,
+        resource: "Reference",
+        resource_version: int,
+        state: "StateReference",
+        force: bool,
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
-        sequence_number: int = None,
-        resource: "Reference" = None,
-        resource_version: int = None,
-        type: str = None,
         resource_user_provided_identifiers: typing.Optional[
             "UserProvidedIdentifiers"
-        ] = None,
-        state: "StateReference" = None,
-        force: bool = None
+        ] = None
     ) -> None:
         self.state = state
         self.force = force
@@ -4045,9 +3946,7 @@ class OrderStateTransitionMessagePayload(MessagePayload):
     #: :class:`bool`
     force: bool
 
-    def __init__(
-        self, *, type: str = None, state: "StateReference" = None, force: bool = None
-    ) -> None:
+    def __init__(self, *, state: "StateReference", force: bool) -> None:
         self.state = state
         self.force = force
         super().__init__(type="OrderStateTransition")
@@ -4067,20 +3966,19 @@ class OrderStoreSetMessage(Message):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        sequence_number: int,
+        resource: "Reference",
+        resource_version: int,
+        store: "StoreKeyReference",
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
-        sequence_number: int = None,
-        resource: "Reference" = None,
-        resource_version: int = None,
-        type: str = None,
         resource_user_provided_identifiers: typing.Optional[
             "UserProvidedIdentifiers"
-        ] = None,
-        store: "StoreKeyReference" = None
+        ] = None
     ) -> None:
         self.store = store
         super().__init__(
@@ -4121,7 +4019,7 @@ class OrderStoreSetMessagePayload(MessagePayload):
     #: :class:`commercetools.types.StoreKeyReference`
     store: "StoreKeyReference"
 
-    def __init__(self, *, type: str = None, store: "StoreKeyReference" = None) -> None:
+    def __init__(self, *, store: "StoreKeyReference") -> None:
         self.store = store
         super().__init__(type="OrderStoreSet")
 
@@ -4141,21 +4039,20 @@ class ParcelAddedToDeliveryMessage(Message):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        sequence_number: int,
+        resource: "Reference",
+        resource_version: int,
+        delivery: "Delivery",
+        parcel: "Parcel",
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
-        sequence_number: int = None,
-        resource: "Reference" = None,
-        resource_version: int = None,
-        type: str = None,
         resource_user_provided_identifiers: typing.Optional[
             "UserProvidedIdentifiers"
-        ] = None,
-        delivery: "Delivery" = None,
-        parcel: "Parcel" = None
+        ] = None
     ) -> None:
         self.delivery = delivery
         self.parcel = parcel
@@ -4200,9 +4097,7 @@ class ParcelAddedToDeliveryMessagePayload(MessagePayload):
     #: :class:`commercetools.types.Parcel`
     parcel: "Parcel"
 
-    def __init__(
-        self, *, type: str = None, delivery: "Delivery" = None, parcel: "Parcel" = None
-    ) -> None:
+    def __init__(self, *, delivery: "Delivery", parcel: "Parcel") -> None:
         self.delivery = delivery
         self.parcel = parcel
         super().__init__(type="ParcelAddedToDelivery")
@@ -4227,23 +4122,22 @@ class ParcelItemsUpdatedMessage(Message):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        sequence_number: int,
+        resource: "Reference",
+        resource_version: int,
+        parcel_id: str,
+        items: typing.List["DeliveryItem"],
+        old_items: typing.List["DeliveryItem"],
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
-        sequence_number: int = None,
-        resource: "Reference" = None,
-        resource_version: int = None,
-        type: str = None,
         resource_user_provided_identifiers: typing.Optional[
             "UserProvidedIdentifiers"
         ] = None,
-        parcel_id: str = None,
-        delivery_id: typing.Optional[str] = None,
-        items: typing.List["DeliveryItem"] = None,
-        old_items: typing.List["DeliveryItem"] = None
+        delivery_id: typing.Optional[str] = None
     ) -> None:
         self.parcel_id = parcel_id
         self.delivery_id = delivery_id
@@ -4299,11 +4193,10 @@ class ParcelItemsUpdatedMessagePayload(MessagePayload):
     def __init__(
         self,
         *,
-        type: str = None,
-        parcel_id: str = None,
-        delivery_id: typing.Optional[str] = None,
-        items: typing.List["DeliveryItem"] = None,
-        old_items: typing.List["DeliveryItem"] = None
+        parcel_id: str,
+        items: typing.List["DeliveryItem"],
+        old_items: typing.List["DeliveryItem"],
+        delivery_id: typing.Optional[str] = None
     ) -> None:
         self.parcel_id = parcel_id
         self.delivery_id = delivery_id
@@ -4329,21 +4222,20 @@ class ParcelMeasurementsUpdatedMessage(Message):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        sequence_number: int,
+        resource: "Reference",
+        resource_version: int,
+        delivery_id: str,
+        parcel_id: str,
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
-        sequence_number: int = None,
-        resource: "Reference" = None,
-        resource_version: int = None,
-        type: str = None,
         resource_user_provided_identifiers: typing.Optional[
             "UserProvidedIdentifiers"
         ] = None,
-        delivery_id: str = None,
-        parcel_id: str = None,
         measurements: typing.Optional["ParcelMeasurements"] = None
     ) -> None:
         self.delivery_id = delivery_id
@@ -4396,9 +4288,8 @@ class ParcelMeasurementsUpdatedMessagePayload(MessagePayload):
     def __init__(
         self,
         *,
-        type: str = None,
-        delivery_id: str = None,
-        parcel_id: str = None,
+        delivery_id: str,
+        parcel_id: str,
         measurements: typing.Optional["ParcelMeasurements"] = None
     ) -> None:
         self.delivery_id = delivery_id
@@ -4422,21 +4313,20 @@ class ParcelRemovedFromDeliveryMessage(Message):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        sequence_number: int,
+        resource: "Reference",
+        resource_version: int,
+        delivery_id: str,
+        parcel: "Parcel",
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
-        sequence_number: int = None,
-        resource: "Reference" = None,
-        resource_version: int = None,
-        type: str = None,
         resource_user_provided_identifiers: typing.Optional[
             "UserProvidedIdentifiers"
-        ] = None,
-        delivery_id: str = None,
-        parcel: "Parcel" = None
+        ] = None
     ) -> None:
         self.delivery_id = delivery_id
         self.parcel = parcel
@@ -4481,9 +4371,7 @@ class ParcelRemovedFromDeliveryMessagePayload(MessagePayload):
     #: :class:`commercetools.types.Parcel`
     parcel: "Parcel"
 
-    def __init__(
-        self, *, type: str = None, delivery_id: str = None, parcel: "Parcel" = None
-    ) -> None:
+    def __init__(self, *, delivery_id: str, parcel: "Parcel") -> None:
         self.delivery_id = delivery_id
         self.parcel = parcel
         super().__init__(type="ParcelRemovedFromDelivery")
@@ -4506,21 +4394,20 @@ class ParcelTrackingDataUpdatedMessage(Message):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        sequence_number: int,
+        resource: "Reference",
+        resource_version: int,
+        delivery_id: str,
+        parcel_id: str,
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
-        sequence_number: int = None,
-        resource: "Reference" = None,
-        resource_version: int = None,
-        type: str = None,
         resource_user_provided_identifiers: typing.Optional[
             "UserProvidedIdentifiers"
         ] = None,
-        delivery_id: str = None,
-        parcel_id: str = None,
         tracking_data: typing.Optional["TrackingData"] = None
     ) -> None:
         self.delivery_id = delivery_id
@@ -4573,9 +4460,8 @@ class ParcelTrackingDataUpdatedMessagePayload(MessagePayload):
     def __init__(
         self,
         *,
-        type: str = None,
-        delivery_id: str = None,
-        parcel_id: str = None,
+        delivery_id: str,
+        parcel_id: str,
         tracking_data: typing.Optional["TrackingData"] = None
     ) -> None:
         self.delivery_id = delivery_id
@@ -4597,20 +4483,19 @@ class PaymentCreatedMessage(Message):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        sequence_number: int,
+        resource: "Reference",
+        resource_version: int,
+        payment: "Payment",
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
-        sequence_number: int = None,
-        resource: "Reference" = None,
-        resource_version: int = None,
-        type: str = None,
         resource_user_provided_identifiers: typing.Optional[
             "UserProvidedIdentifiers"
-        ] = None,
-        payment: "Payment" = None
+        ] = None
     ) -> None:
         self.payment = payment
         super().__init__(
@@ -4651,7 +4536,7 @@ class PaymentCreatedMessagePayload(MessagePayload):
     #: :class:`commercetools.types.Payment`
     payment: "Payment"
 
-    def __init__(self, *, type: str = None, payment: "Payment" = None) -> None:
+    def __init__(self, *, payment: "Payment") -> None:
         self.payment = payment
         super().__init__(type="PaymentCreated")
 
@@ -4669,20 +4554,19 @@ class PaymentInteractionAddedMessage(Message):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        sequence_number: int,
+        resource: "Reference",
+        resource_version: int,
+        interaction: "CustomFields",
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
-        sequence_number: int = None,
-        resource: "Reference" = None,
-        resource_version: int = None,
-        type: str = None,
         resource_user_provided_identifiers: typing.Optional[
             "UserProvidedIdentifiers"
-        ] = None,
-        interaction: "CustomFields" = None
+        ] = None
     ) -> None:
         self.interaction = interaction
         super().__init__(
@@ -4723,7 +4607,7 @@ class PaymentInteractionAddedMessagePayload(MessagePayload):
     #: :class:`commercetools.types.CustomFields`
     interaction: "CustomFields"
 
-    def __init__(self, *, type: str = None, interaction: "CustomFields" = None) -> None:
+    def __init__(self, *, interaction: "CustomFields") -> None:
         self.interaction = interaction
         super().__init__(type="PaymentInteractionAdded")
 
@@ -4743,21 +4627,20 @@ class PaymentStatusInterfaceCodeSetMessage(Message):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        sequence_number: int,
+        resource: "Reference",
+        resource_version: int,
+        payment_id: str,
+        interface_code: str,
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
-        sequence_number: int = None,
-        resource: "Reference" = None,
-        resource_version: int = None,
-        type: str = None,
         resource_user_provided_identifiers: typing.Optional[
             "UserProvidedIdentifiers"
-        ] = None,
-        payment_id: str = None,
-        interface_code: str = None
+        ] = None
     ) -> None:
         self.payment_id = payment_id
         self.interface_code = interface_code
@@ -4802,9 +4685,7 @@ class PaymentStatusInterfaceCodeSetMessagePayload(MessagePayload):
     #: :class:`str` `(Named` ``interfaceCode`` `in Commercetools)`
     interface_code: str
 
-    def __init__(
-        self, *, type: str = None, payment_id: str = None, interface_code: str = None
-    ) -> None:
+    def __init__(self, *, payment_id: str, interface_code: str) -> None:
         self.payment_id = payment_id
         self.interface_code = interface_code
         super().__init__(type="PaymentStatusInterfaceCodeSet")
@@ -4825,21 +4706,20 @@ class PaymentStatusStateTransitionMessage(Message):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        sequence_number: int,
+        resource: "Reference",
+        resource_version: int,
+        state: "StateReference",
+        force: bool,
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
-        sequence_number: int = None,
-        resource: "Reference" = None,
-        resource_version: int = None,
-        type: str = None,
         resource_user_provided_identifiers: typing.Optional[
             "UserProvidedIdentifiers"
-        ] = None,
-        state: "StateReference" = None,
-        force: bool = None
+        ] = None
     ) -> None:
         self.state = state
         self.force = force
@@ -4884,9 +4764,7 @@ class PaymentStatusStateTransitionMessagePayload(MessagePayload):
     #: :class:`bool`
     force: bool
 
-    def __init__(
-        self, *, type: str = None, state: "StateReference" = None, force: bool = None
-    ) -> None:
+    def __init__(self, *, state: "StateReference", force: bool) -> None:
         self.state = state
         self.force = force
         super().__init__(type="PaymentStatusStateTransition")
@@ -4905,20 +4783,19 @@ class PaymentTransactionAddedMessage(Message):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        sequence_number: int,
+        resource: "Reference",
+        resource_version: int,
+        transaction: "Transaction",
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
-        sequence_number: int = None,
-        resource: "Reference" = None,
-        resource_version: int = None,
-        type: str = None,
         resource_user_provided_identifiers: typing.Optional[
             "UserProvidedIdentifiers"
-        ] = None,
-        transaction: "Transaction" = None
+        ] = None
     ) -> None:
         self.transaction = transaction
         super().__init__(
@@ -4959,7 +4836,7 @@ class PaymentTransactionAddedMessagePayload(MessagePayload):
     #: :class:`commercetools.types.Transaction`
     transaction: "Transaction"
 
-    def __init__(self, *, type: str = None, transaction: "Transaction" = None) -> None:
+    def __init__(self, *, transaction: "Transaction") -> None:
         self.transaction = transaction
         super().__init__(type="PaymentTransactionAdded")
 
@@ -4979,21 +4856,20 @@ class PaymentTransactionStateChangedMessage(Message):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        sequence_number: int,
+        resource: "Reference",
+        resource_version: int,
+        transaction_id: str,
+        state: "TransactionState",
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
-        sequence_number: int = None,
-        resource: "Reference" = None,
-        resource_version: int = None,
-        type: str = None,
         resource_user_provided_identifiers: typing.Optional[
             "UserProvidedIdentifiers"
-        ] = None,
-        transaction_id: str = None,
-        state: "TransactionState" = None
+        ] = None
     ) -> None:
         self.transaction_id = transaction_id
         self.state = state
@@ -5038,13 +4914,7 @@ class PaymentTransactionStateChangedMessagePayload(MessagePayload):
     #: :class:`commercetools.types.TransactionState`
     state: "TransactionState"
 
-    def __init__(
-        self,
-        *,
-        type: str = None,
-        transaction_id: str = None,
-        state: "TransactionState" = None
-    ) -> None:
+    def __init__(self, *, transaction_id: str, state: "TransactionState") -> None:
         self.transaction_id = transaction_id
         self.state = state
         super().__init__(type="PaymentTransactionStateChanged")
@@ -5065,21 +4935,20 @@ class ProductAddedToCategoryMessage(Message):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        sequence_number: int,
+        resource: "Reference",
+        resource_version: int,
+        category: "CategoryReference",
+        staged: bool,
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
-        sequence_number: int = None,
-        resource: "Reference" = None,
-        resource_version: int = None,
-        type: str = None,
         resource_user_provided_identifiers: typing.Optional[
             "UserProvidedIdentifiers"
-        ] = None,
-        category: "CategoryReference" = None,
-        staged: bool = None
+        ] = None
     ) -> None:
         self.category = category
         self.staged = staged
@@ -5124,13 +4993,7 @@ class ProductAddedToCategoryMessagePayload(MessagePayload):
     #: :class:`bool`
     staged: bool
 
-    def __init__(
-        self,
-        *,
-        type: str = None,
-        category: "CategoryReference" = None,
-        staged: bool = None
-    ) -> None:
+    def __init__(self, *, category: "CategoryReference", staged: bool) -> None:
         self.category = category
         self.staged = staged
         super().__init__(type="ProductAddedToCategory")
@@ -5149,20 +5012,19 @@ class ProductCreatedMessage(Message):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        sequence_number: int,
+        resource: "Reference",
+        resource_version: int,
+        product_projection: "ProductProjection",
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
-        sequence_number: int = None,
-        resource: "Reference" = None,
-        resource_version: int = None,
-        type: str = None,
         resource_user_provided_identifiers: typing.Optional[
             "UserProvidedIdentifiers"
-        ] = None,
-        product_projection: "ProductProjection" = None
+        ] = None
     ) -> None:
         self.product_projection = product_projection
         super().__init__(
@@ -5203,9 +5065,7 @@ class ProductCreatedMessagePayload(MessagePayload):
     #: :class:`commercetools.types.ProductProjection` `(Named` ``productProjection`` `in Commercetools)`
     product_projection: "ProductProjection"
 
-    def __init__(
-        self, *, type: str = None, product_projection: "ProductProjection" = None
-    ) -> None:
+    def __init__(self, *, product_projection: "ProductProjection") -> None:
         self.product_projection = product_projection
         super().__init__(type="ProductCreated")
 
@@ -5225,21 +5085,20 @@ class ProductDeletedMessage(Message):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        sequence_number: int,
+        resource: "Reference",
+        resource_version: int,
+        removed_image_urls: list,
+        current_projection: "ProductProjection",
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
-        sequence_number: int = None,
-        resource: "Reference" = None,
-        resource_version: int = None,
-        type: str = None,
         resource_user_provided_identifiers: typing.Optional[
             "UserProvidedIdentifiers"
-        ] = None,
-        removed_image_urls: list = None,
-        current_projection: "ProductProjection" = None
+        ] = None
     ) -> None:
         self.removed_image_urls = removed_image_urls
         self.current_projection = current_projection
@@ -5285,11 +5144,7 @@ class ProductDeletedMessagePayload(MessagePayload):
     current_projection: "ProductProjection"
 
     def __init__(
-        self,
-        *,
-        type: str = None,
-        removed_image_urls: list = None,
-        current_projection: "ProductProjection" = None
+        self, *, removed_image_urls: list, current_projection: "ProductProjection"
     ) -> None:
         self.removed_image_urls = removed_image_urls
         self.current_projection = current_projection
@@ -5313,22 +5168,21 @@ class ProductImageAddedMessage(Message):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        sequence_number: int,
+        resource: "Reference",
+        resource_version: int,
+        variant_id: int,
+        image: "Image",
+        staged: bool,
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
-        sequence_number: int = None,
-        resource: "Reference" = None,
-        resource_version: int = None,
-        type: str = None,
         resource_user_provided_identifiers: typing.Optional[
             "UserProvidedIdentifiers"
-        ] = None,
-        variant_id: int = None,
-        image: "Image" = None,
-        staged: bool = None
+        ] = None
     ) -> None:
         self.variant_id = variant_id
         self.image = image
@@ -5377,14 +5231,7 @@ class ProductImageAddedMessagePayload(MessagePayload):
     #: :class:`bool`
     staged: bool
 
-    def __init__(
-        self,
-        *,
-        type: str = None,
-        variant_id: int = None,
-        image: "Image" = None,
-        staged: bool = None
-    ) -> None:
+    def __init__(self, *, variant_id: int, image: "Image", staged: bool) -> None:
         self.variant_id = variant_id
         self.image = image
         self.staged = staged
@@ -5404,20 +5251,19 @@ class ProductPriceDiscountsSetMessage(Message):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        sequence_number: int,
+        resource: "Reference",
+        resource_version: int,
+        updated_prices: typing.List["ProductPriceDiscountsSetUpdatedPrice"],
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
-        sequence_number: int = None,
-        resource: "Reference" = None,
-        resource_version: int = None,
-        type: str = None,
         resource_user_provided_identifiers: typing.Optional[
             "UserProvidedIdentifiers"
-        ] = None,
-        updated_prices: typing.List["ProductPriceDiscountsSetUpdatedPrice"] = None
+        ] = None
     ) -> None:
         self.updated_prices = updated_prices
         super().__init__(
@@ -5459,10 +5305,7 @@ class ProductPriceDiscountsSetMessagePayload(MessagePayload):
     updated_prices: typing.List["ProductPriceDiscountsSetUpdatedPrice"]
 
     def __init__(
-        self,
-        *,
-        type: str = None,
-        updated_prices: typing.List["ProductPriceDiscountsSetUpdatedPrice"] = None
+        self, *, updated_prices: typing.List["ProductPriceDiscountsSetUpdatedPrice"]
     ) -> None:
         self.updated_prices = updated_prices
         super().__init__(type="ProductPriceDiscountsSet")
@@ -5491,25 +5334,24 @@ class ProductPriceExternalDiscountSetMessage(Message):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        sequence_number: int,
+        resource: "Reference",
+        resource_version: int,
+        variant_id: int,
+        price_id: str,
+        staged: bool,
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
-        sequence_number: int = None,
-        resource: "Reference" = None,
-        resource_version: int = None,
-        type: str = None,
         resource_user_provided_identifiers: typing.Optional[
             "UserProvidedIdentifiers"
         ] = None,
-        variant_id: int = None,
         variant_key: typing.Optional[str] = None,
         sku: typing.Optional[str] = None,
-        price_id: str = None,
-        discounted: typing.Optional["DiscountedPrice"] = None,
-        staged: bool = None
+        discounted: typing.Optional["DiscountedPrice"] = None
     ) -> None:
         self.variant_id = variant_id
         self.variant_key = variant_key
@@ -5573,13 +5415,12 @@ class ProductPriceExternalDiscountSetMessagePayload(MessagePayload):
     def __init__(
         self,
         *,
-        type: str = None,
-        variant_id: int = None,
+        variant_id: int,
+        price_id: str,
+        staged: bool,
         variant_key: typing.Optional[str] = None,
         sku: typing.Optional[str] = None,
-        price_id: str = None,
-        discounted: typing.Optional["DiscountedPrice"] = None,
-        staged: bool = None
+        discounted: typing.Optional["DiscountedPrice"] = None
     ) -> None:
         self.variant_id = variant_id
         self.variant_key = variant_key
@@ -5615,22 +5456,21 @@ class ProductPublishedMessage(Message):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        sequence_number: int,
+        resource: "Reference",
+        resource_version: int,
+        removed_image_urls: list,
+        product_projection: "ProductProjection",
+        scope: "ProductPublishScope",
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
-        sequence_number: int = None,
-        resource: "Reference" = None,
-        resource_version: int = None,
-        type: str = None,
         resource_user_provided_identifiers: typing.Optional[
             "UserProvidedIdentifiers"
-        ] = None,
-        removed_image_urls: list = None,
-        product_projection: "ProductProjection" = None,
-        scope: "ProductPublishScope" = None
+        ] = None
     ) -> None:
         self.removed_image_urls = removed_image_urls
         self.product_projection = product_projection
@@ -5682,10 +5522,9 @@ class ProductPublishedMessagePayload(MessagePayload):
     def __init__(
         self,
         *,
-        type: str = None,
-        removed_image_urls: list = None,
-        product_projection: "ProductProjection" = None,
-        scope: "ProductPublishScope" = None
+        removed_image_urls: list,
+        product_projection: "ProductProjection",
+        scope: "ProductPublishScope"
     ) -> None:
         self.removed_image_urls = removed_image_urls
         self.product_projection = product_projection
@@ -5708,21 +5547,20 @@ class ProductRemovedFromCategoryMessage(Message):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        sequence_number: int,
+        resource: "Reference",
+        resource_version: int,
+        category: "CategoryReference",
+        staged: bool,
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
-        sequence_number: int = None,
-        resource: "Reference" = None,
-        resource_version: int = None,
-        type: str = None,
         resource_user_provided_identifiers: typing.Optional[
             "UserProvidedIdentifiers"
-        ] = None,
-        category: "CategoryReference" = None,
-        staged: bool = None
+        ] = None
     ) -> None:
         self.category = category
         self.staged = staged
@@ -5767,13 +5605,7 @@ class ProductRemovedFromCategoryMessagePayload(MessagePayload):
     #: :class:`bool`
     staged: bool
 
-    def __init__(
-        self,
-        *,
-        type: str = None,
-        category: "CategoryReference" = None,
-        staged: bool = None
-    ) -> None:
+    def __init__(self, *, category: "CategoryReference", staged: bool) -> None:
         self.category = category
         self.staged = staged
         super().__init__(type="ProductRemovedFromCategory")
@@ -5792,20 +5624,19 @@ class ProductRevertedStagedChangesMessage(Message):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        sequence_number: int,
+        resource: "Reference",
+        resource_version: int,
+        removed_image_urls: list,
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
-        sequence_number: int = None,
-        resource: "Reference" = None,
-        resource_version: int = None,
-        type: str = None,
         resource_user_provided_identifiers: typing.Optional[
             "UserProvidedIdentifiers"
-        ] = None,
-        removed_image_urls: list = None
+        ] = None
     ) -> None:
         self.removed_image_urls = removed_image_urls
         super().__init__(
@@ -5846,7 +5677,7 @@ class ProductRevertedStagedChangesMessagePayload(MessagePayload):
     #: :class:`list` `(Named` ``removedImageUrls`` `in Commercetools)`
     removed_image_urls: list
 
-    def __init__(self, *, type: str = None, removed_image_urls: list = None) -> None:
+    def __init__(self, *, removed_image_urls: list) -> None:
         self.removed_image_urls = removed_image_urls
         super().__init__(type="ProductRevertedStagedChanges")
 
@@ -5864,20 +5695,19 @@ class ProductSlugChangedMessage(Message):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        sequence_number: int,
+        resource: "Reference",
+        resource_version: int,
+        slug: "LocalizedString",
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
-        sequence_number: int = None,
-        resource: "Reference" = None,
-        resource_version: int = None,
-        type: str = None,
         resource_user_provided_identifiers: typing.Optional[
             "UserProvidedIdentifiers"
-        ] = None,
-        slug: "LocalizedString" = None
+        ] = None
     ) -> None:
         self.slug = slug
         super().__init__(
@@ -5918,7 +5748,7 @@ class ProductSlugChangedMessagePayload(MessagePayload):
     #: :class:`commercetools.types.LocalizedString`
     slug: "LocalizedString"
 
-    def __init__(self, *, type: str = None, slug: "LocalizedString" = None) -> None:
+    def __init__(self, *, slug: "LocalizedString") -> None:
         self.slug = slug
         super().__init__(type="ProductSlugChanged")
 
@@ -5938,21 +5768,20 @@ class ProductStateTransitionMessage(Message):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        sequence_number: int,
+        resource: "Reference",
+        resource_version: int,
+        state: "StateReference",
+        force: bool,
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
-        sequence_number: int = None,
-        resource: "Reference" = None,
-        resource_version: int = None,
-        type: str = None,
         resource_user_provided_identifiers: typing.Optional[
             "UserProvidedIdentifiers"
-        ] = None,
-        state: "StateReference" = None,
-        force: bool = None
+        ] = None
     ) -> None:
         self.state = state
         self.force = force
@@ -5997,9 +5826,7 @@ class ProductStateTransitionMessagePayload(MessagePayload):
     #: :class:`bool`
     force: bool
 
-    def __init__(
-        self, *, type: str = None, state: "StateReference" = None, force: bool = None
-    ) -> None:
+    def __init__(self, *, state: "StateReference", force: bool) -> None:
         self.state = state
         self.force = force
         super().__init__(type="ProductStateTransition")
@@ -6016,16 +5843,15 @@ class ProductUnpublishedMessage(Message):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        sequence_number: int,
+        resource: "Reference",
+        resource_version: int,
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
-        sequence_number: int = None,
-        resource: "Reference" = None,
-        resource_version: int = None,
-        type: str = None,
         resource_user_provided_identifiers: typing.Optional[
             "UserProvidedIdentifiers"
         ] = None
@@ -6064,7 +5890,7 @@ class ProductUnpublishedMessage(Message):
 
 
 class ProductUnpublishedMessagePayload(MessagePayload):
-    def __init__(self, *, type: str = None) -> None:
+    def __init__(self) -> None:
         super().__init__(type="ProductUnpublished")
 
     def __repr__(self) -> str:
@@ -6080,21 +5906,20 @@ class ProductVariantDeletedMessage(Message):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        sequence_number: int,
+        resource: "Reference",
+        resource_version: int,
+        variant: "ProductVariant",
+        removed_image_urls: list,
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
-        sequence_number: int = None,
-        resource: "Reference" = None,
-        resource_version: int = None,
-        type: str = None,
         resource_user_provided_identifiers: typing.Optional[
             "UserProvidedIdentifiers"
-        ] = None,
-        variant: "ProductVariant" = None,
-        removed_image_urls: list = None
+        ] = None
     ) -> None:
         self.variant = variant
         self.removed_image_urls = removed_image_urls
@@ -6139,13 +5964,7 @@ class ProductVariantDeletedMessagePayload(MessagePayload):
     #: :class:`list` `(Named` ``removedImageUrls`` `in Commercetools)`
     removed_image_urls: list
 
-    def __init__(
-        self,
-        *,
-        type: str = None,
-        variant: "ProductVariant" = None,
-        removed_image_urls: list = None
-    ) -> None:
+    def __init__(self, *, variant: "ProductVariant", removed_image_urls: list) -> None:
         self.variant = variant
         self.removed_image_urls = removed_image_urls
         super().__init__(type="ProductVariantDeleted")
@@ -6164,20 +5983,19 @@ class ReviewCreatedMessage(Message):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        sequence_number: int,
+        resource: "Reference",
+        resource_version: int,
+        review: "Review",
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
-        sequence_number: int = None,
-        resource: "Reference" = None,
-        resource_version: int = None,
-        type: str = None,
         resource_user_provided_identifiers: typing.Optional[
             "UserProvidedIdentifiers"
-        ] = None,
-        review: "Review" = None
+        ] = None
     ) -> None:
         self.review = review
         super().__init__(
@@ -6218,7 +6036,7 @@ class ReviewCreatedMessagePayload(MessagePayload):
     #: :class:`commercetools.types.Review`
     review: "Review"
 
-    def __init__(self, *, type: str = None, review: "Review" = None) -> None:
+    def __init__(self, *, review: "Review") -> None:
         self.review = review
         super().__init__(type="ReviewCreated")
 
@@ -6242,22 +6060,21 @@ class ReviewRatingSetMessage(Message):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        sequence_number: int,
+        resource: "Reference",
+        resource_version: int,
+        included_in_statistics: bool,
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
-        sequence_number: int = None,
-        resource: "Reference" = None,
-        resource_version: int = None,
-        type: str = None,
         resource_user_provided_identifiers: typing.Optional[
             "UserProvidedIdentifiers"
         ] = None,
         old_rating: typing.Optional[int] = None,
         new_rating: typing.Optional[int] = None,
-        included_in_statistics: bool = None,
         target: typing.Optional["Reference"] = None
     ) -> None:
         self.old_rating = old_rating
@@ -6314,10 +6131,9 @@ class ReviewRatingSetMessagePayload(MessagePayload):
     def __init__(
         self,
         *,
-        type: str = None,
+        included_in_statistics: bool,
         old_rating: typing.Optional[int] = None,
         new_rating: typing.Optional[int] = None,
-        included_in_statistics: bool = None,
         target: typing.Optional["Reference"] = None
     ) -> None:
         self.old_rating = old_rating
@@ -6356,25 +6172,24 @@ class ReviewStateTransitionMessage(Message):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        sequence_number: int,
+        resource: "Reference",
+        resource_version: int,
+        old_state: "StateReference",
+        new_state: "StateReference",
+        old_included_in_statistics: bool,
+        new_included_in_statistics: bool,
+        target: "Reference",
+        force: bool,
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
-        sequence_number: int = None,
-        resource: "Reference" = None,
-        resource_version: int = None,
-        type: str = None,
         resource_user_provided_identifiers: typing.Optional[
             "UserProvidedIdentifiers"
-        ] = None,
-        old_state: "StateReference" = None,
-        new_state: "StateReference" = None,
-        old_included_in_statistics: bool = None,
-        new_included_in_statistics: bool = None,
-        target: "Reference" = None,
-        force: bool = None
+        ] = None
     ) -> None:
         self.old_state = old_state
         self.new_state = new_state
@@ -6438,13 +6253,12 @@ class ReviewStateTransitionMessagePayload(MessagePayload):
     def __init__(
         self,
         *,
-        type: str = None,
-        old_state: "StateReference" = None,
-        new_state: "StateReference" = None,
-        old_included_in_statistics: bool = None,
-        new_included_in_statistics: bool = None,
-        target: "Reference" = None,
-        force: bool = None
+        old_state: "StateReference",
+        new_state: "StateReference",
+        old_included_in_statistics: bool,
+        new_included_in_statistics: bool,
+        target: "Reference",
+        force: bool
     ) -> None:
         self.old_state = old_state
         self.new_state = new_state

--- a/src/commercetools/types/_order.py
+++ b/src/commercetools/types/_order.py
@@ -149,10 +149,10 @@ class Delivery(_BaseType):
     def __init__(
         self,
         *,
-        id: str = None,
-        created_at: datetime.datetime = None,
-        items: typing.List["DeliveryItem"] = None,
-        parcels: typing.List["Parcel"] = None,
+        id: str,
+        created_at: datetime.datetime,
+        items: typing.List["DeliveryItem"],
+        parcels: typing.List["Parcel"],
         address: typing.Optional["Address"] = None
     ) -> None:
         self.id = id
@@ -178,7 +178,7 @@ class DeliveryItem(_BaseType):
     #: :class:`int`
     quantity: int
 
-    def __init__(self, *, id: str = None, quantity: int = None) -> None:
+    def __init__(self, *, id: str, quantity: int) -> None:
         self.id = id
         self.quantity = quantity
         super().__init__()
@@ -196,8 +196,8 @@ class DiscountedLineItemPriceDraft(_BaseType):
     def __init__(
         self,
         *,
-        value: "Money" = None,
-        included_discounts: typing.List["DiscountedLineItemPortion"] = None
+        value: "Money",
+        included_discounts: typing.List["DiscountedLineItemPortion"]
     ) -> None:
         self.value = value
         self.included_discounts = included_discounts
@@ -216,7 +216,7 @@ class ItemState(_BaseType):
     #: :class:`commercetools.types.StateReference`
     state: "StateReference"
 
-    def __init__(self, *, quantity: int = None, state: "StateReference" = None) -> None:
+    def __init__(self, *, quantity: int, state: "StateReference") -> None:
         self.quantity = quantity
         self.state = state
         super().__init__()
@@ -252,11 +252,11 @@ class LineItemImportDraft(_BaseType):
     def __init__(
         self,
         *,
+        name: "LocalizedString",
+        variant: "ProductVariantImportDraft",
+        price: "PriceDraft",
+        quantity: int,
         product_id: typing.Optional[str] = None,
-        name: "LocalizedString" = None,
-        variant: "ProductVariantImportDraft" = None,
-        price: "PriceDraft" = None,
-        quantity: int = None,
         state: typing.Optional[typing.List["ItemState"]] = None,
         supply_channel: typing.Optional["ChannelResourceIdentifier"] = None,
         distribution_channel: typing.Optional["ChannelResourceIdentifier"] = None,
@@ -383,10 +383,18 @@ class Order(BaseResource):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        line_items: typing.List["LineItem"],
+        custom_line_items: typing.List["CustomLineItem"],
+        total_price: "TypedMoney",
+        order_state: "OrderState",
+        sync_info: typing.List["SyncInfo"],
+        last_message_sequence_number: int,
+        origin: "CartOrigin",
+        refused_gifts: typing.List["CartDiscountReference"],
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
         completed_at: typing.Optional[datetime.datetime] = None,
@@ -395,9 +403,6 @@ class Order(BaseResource):
         customer_email: typing.Optional[str] = None,
         anonymous_id: typing.Optional[str] = None,
         store: typing.Optional["StoreKeyReference"] = None,
-        line_items: typing.List["LineItem"] = None,
-        custom_line_items: typing.List["CustomLineItem"] = None,
-        total_price: "TypedMoney" = None,
         taxed_price: typing.Optional["TaxedPrice"] = None,
         shipping_address: typing.Optional["Address"] = None,
         billing_address: typing.Optional["Address"] = None,
@@ -405,25 +410,20 @@ class Order(BaseResource):
         tax_rounding_mode: typing.Optional["RoundingMode"] = None,
         customer_group: typing.Optional["CustomerGroupReference"] = None,
         country: typing.Optional[str] = None,
-        order_state: "OrderState" = None,
         state: typing.Optional["StateReference"] = None,
         shipment_state: typing.Optional["ShipmentState"] = None,
         payment_state: typing.Optional["PaymentState"] = None,
         shipping_info: typing.Optional["ShippingInfo"] = None,
-        sync_info: typing.List["SyncInfo"] = None,
         return_info: typing.Optional[typing.List["ReturnInfo"]] = None,
         discount_codes: typing.Optional[typing.List["DiscountCodeInfo"]] = None,
-        last_message_sequence_number: int = None,
         cart: typing.Optional["CartReference"] = None,
         custom: typing.Optional["CustomFields"] = None,
         payment_info: typing.Optional["PaymentInfo"] = None,
         locale: typing.Optional[str] = None,
         inventory_mode: typing.Optional["InventoryMode"] = None,
-        origin: "CartOrigin" = None,
         tax_calculation_mode: typing.Optional["TaxCalculationMode"] = None,
         shipping_rate_input: typing.Optional["ShippingRateInput"] = None,
-        item_shipping_addresses: typing.Optional[typing.List["Address"]] = None,
-        refused_gifts: typing.List["CartDiscountReference"] = None
+        item_shipping_addresses: typing.Optional[typing.List["Address"]] = None
     ) -> None:
         self.id = id
         self.version = version
@@ -541,8 +541,8 @@ class OrderFromCartDraft(_BaseType):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
+        id: str,
+        version: int,
         order_number: typing.Optional[str] = None,
         payment_state: typing.Optional["PaymentState"] = None,
         shipment_state: typing.Optional["ShipmentState"] = None,
@@ -622,12 +622,12 @@ class OrderImportDraft(_BaseType):
     def __init__(
         self,
         *,
+        total_price: "Money",
         order_number: typing.Optional[str] = None,
         customer_id: typing.Optional[str] = None,
         customer_email: typing.Optional[str] = None,
         line_items: typing.Optional[typing.List["LineItemImportDraft"]] = None,
         custom_line_items: typing.Optional[typing.List["CustomLineItemDraft"]] = None,
-        total_price: "Money" = None,
         taxed_price: typing.Optional["TaxedPriceDraft"] = None,
         shipping_address: typing.Optional["Address"] = None,
         billing_address: typing.Optional["Address"] = None,
@@ -714,11 +714,11 @@ class OrderPagedQueryResponse(_BaseType):
     def __init__(
         self,
         *,
-        limit: int = None,
-        count: int = None,
-        total: typing.Optional[int] = None,
-        offset: int = None,
-        results: typing.Sequence["Order"] = None
+        limit: int,
+        count: int,
+        offset: int,
+        results: typing.Sequence["Order"],
+        total: typing.Optional[int] = None
     ) -> None:
         self.limit = limit
         self.count = count
@@ -738,13 +738,7 @@ class OrderReference(Reference):
     #: Optional :class:`commercetools.types.Order`
     obj: typing.Optional["Order"]
 
-    def __init__(
-        self,
-        *,
-        type_id: "ReferenceTypeId" = None,
-        id: str = None,
-        obj: typing.Optional["Order"] = None
-    ) -> None:
+    def __init__(self, *, id: str, obj: typing.Optional["Order"] = None) -> None:
         self.obj = obj
         super().__init__(type_id=ReferenceTypeId.ORDER, id=id)
 
@@ -758,11 +752,7 @@ class OrderReference(Reference):
 
 class OrderResourceIdentifier(ResourceIdentifier):
     def __init__(
-        self,
-        *,
-        type_id: typing.Optional["ReferenceTypeId"] = None,
-        id: typing.Optional[str] = None,
-        key: typing.Optional[str] = None
+        self, *, id: typing.Optional[str] = None, key: typing.Optional[str] = None
     ) -> None:
         super().__init__(type_id=ReferenceTypeId.ORDER, id=id, key=key)
 
@@ -787,7 +777,7 @@ class OrderUpdate(_BaseType):
     #: :class:`list`
     actions: list
 
-    def __init__(self, *, version: int = None, actions: list = None) -> None:
+    def __init__(self, *, version: int, actions: list) -> None:
         self.version = version
         self.actions = actions
         super().__init__()
@@ -800,7 +790,7 @@ class OrderUpdateAction(_BaseType):
     #: :class:`str`
     action: str
 
-    def __init__(self, *, action: str = None) -> None:
+    def __init__(self, *, action: str) -> None:
         self.action = action
         super().__init__()
 
@@ -823,8 +813,8 @@ class Parcel(_BaseType):
     def __init__(
         self,
         *,
-        id: str = None,
-        created_at: datetime.datetime = None,
+        id: str,
+        created_at: datetime.datetime,
         measurements: typing.Optional["ParcelMeasurements"] = None,
         tracking_data: typing.Optional["TrackingData"] = None,
         items: typing.Optional[typing.List["DeliveryItem"]] = None
@@ -917,7 +907,7 @@ class PaymentInfo(_BaseType):
     #: List of :class:`commercetools.types.PaymentReference`
     payments: typing.List["PaymentReference"]
 
-    def __init__(self, *, payments: typing.List["PaymentReference"] = None) -> None:
+    def __init__(self, *, payments: typing.List["PaymentReference"]) -> None:
         self.payments = payments
         super().__init__()
 
@@ -979,7 +969,7 @@ class ReturnInfo(_BaseType):
     def __init__(
         self,
         *,
-        items: typing.List["ReturnItem"] = None,
+        items: typing.List["ReturnItem"],
         return_tracking_id: typing.Optional[str] = None,
         return_date: typing.Optional[datetime.datetime] = None
     ) -> None:
@@ -1017,14 +1007,14 @@ class ReturnItem(_BaseType):
     def __init__(
         self,
         *,
-        id: str = None,
-        quantity: int = None,
-        type: str = None,
-        comment: typing.Optional[str] = None,
-        shipment_state: "ReturnShipmentState" = None,
-        payment_state: "ReturnPaymentState" = None,
-        last_modified_at: datetime.datetime = None,
-        created_at: datetime.datetime = None
+        id: str,
+        quantity: int,
+        type: str,
+        shipment_state: "ReturnShipmentState",
+        payment_state: "ReturnPaymentState",
+        last_modified_at: datetime.datetime,
+        created_at: datetime.datetime,
+        comment: typing.Optional[str] = None
     ) -> None:
         self.id = id
         self.quantity = quantity
@@ -1067,11 +1057,11 @@ class ReturnItemDraft(_BaseType):
     def __init__(
         self,
         *,
-        quantity: int = None,
+        quantity: int,
+        shipment_state: "ReturnShipmentState",
         line_item_id: typing.Optional[str] = None,
         custom_line_item_id: typing.Optional[str] = None,
-        comment: typing.Optional[str] = None,
-        shipment_state: "ReturnShipmentState" = None
+        comment: typing.Optional[str] = None
     ) -> None:
         self.quantity = quantity
         self.line_item_id = line_item_id
@@ -1139,9 +1129,9 @@ class ShippingInfoImportDraft(_BaseType):
     def __init__(
         self,
         *,
-        shipping_method_name: str = None,
-        price: "Money" = None,
-        shipping_rate: "ShippingRateDraft" = None,
+        shipping_method_name: str,
+        price: "Money",
+        shipping_rate: "ShippingRateDraft",
         tax_rate: typing.Optional["TaxRate"] = None,
         tax_category: typing.Optional["TaxCategoryResourceIdentifier"] = None,
         shipping_method: typing.Optional["ShippingMethodResourceIdentifier"] = None,
@@ -1181,7 +1171,7 @@ class StagedOrderUpdateAction(_BaseType):
     #: :class:`str`
     action: str
 
-    def __init__(self, *, action: str = None) -> None:
+    def __init__(self, *, action: str) -> None:
         self.action = action
         super().__init__()
 
@@ -1200,9 +1190,9 @@ class SyncInfo(_BaseType):
     def __init__(
         self,
         *,
-        channel: "ChannelReference" = None,
-        external_id: typing.Optional[str] = None,
-        synced_at: datetime.datetime = None
+        channel: "ChannelReference",
+        synced_at: datetime.datetime,
+        external_id: typing.Optional[str] = None
     ) -> None:
         self.channel = channel
         self.external_id = external_id
@@ -1223,9 +1213,7 @@ class TaxedItemPriceDraft(_BaseType):
     #: :class:`commercetools.types.Money` `(Named` ``totalGross`` `in Commercetools)`
     total_gross: "Money"
 
-    def __init__(
-        self, *, total_net: "Money" = None, total_gross: "Money" = None
-    ) -> None:
+    def __init__(self, *, total_net: "Money", total_gross: "Money") -> None:
         self.total_net = total_net
         self.total_gross = total_gross
         super().__init__()
@@ -1285,15 +1273,14 @@ class CustomLineItemReturnItem(ReturnItem):
     def __init__(
         self,
         *,
-        id: str = None,
-        quantity: int = None,
-        type: str = None,
-        comment: typing.Optional[str] = None,
-        shipment_state: "ReturnShipmentState" = None,
-        payment_state: "ReturnPaymentState" = None,
-        last_modified_at: datetime.datetime = None,
-        created_at: datetime.datetime = None,
-        custom_line_item_id: str = None
+        id: str,
+        quantity: int,
+        shipment_state: "ReturnShipmentState",
+        payment_state: "ReturnPaymentState",
+        last_modified_at: datetime.datetime,
+        created_at: datetime.datetime,
+        custom_line_item_id: str,
+        comment: typing.Optional[str] = None
     ) -> None:
         self.custom_line_item_id = custom_line_item_id
         super().__init__(
@@ -1331,15 +1318,14 @@ class LineItemReturnItem(ReturnItem):
     def __init__(
         self,
         *,
-        id: str = None,
-        quantity: int = None,
-        type: str = None,
-        comment: typing.Optional[str] = None,
-        shipment_state: "ReturnShipmentState" = None,
-        payment_state: "ReturnPaymentState" = None,
-        last_modified_at: datetime.datetime = None,
-        created_at: datetime.datetime = None,
-        line_item_id: str = None
+        id: str,
+        quantity: int,
+        shipment_state: "ReturnShipmentState",
+        payment_state: "ReturnPaymentState",
+        last_modified_at: datetime.datetime,
+        created_at: datetime.datetime,
+        line_item_id: str,
+        comment: typing.Optional[str] = None
     ) -> None:
         self.line_item_id = line_item_id
         super().__init__(
@@ -1381,7 +1367,6 @@ class OrderAddDeliveryAction(OrderUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
         items: typing.Optional[typing.List["DeliveryItem"]] = None,
         address: typing.Optional["Address"] = None,
         parcels: typing.Optional[typing.List["ParcelDraft"]] = None
@@ -1404,7 +1389,7 @@ class OrderAddItemShippingAddressAction(OrderUpdateAction):
     #: :class:`commercetools.types.Address`
     address: "Address"
 
-    def __init__(self, *, action: str = None, address: "Address" = None) -> None:
+    def __init__(self, *, address: "Address") -> None:
         self.address = address
         super().__init__(action="addItemShippingAddress")
 
@@ -1428,8 +1413,7 @@ class OrderAddParcelToDeliveryAction(OrderUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
-        delivery_id: str = None,
+        delivery_id: str,
         measurements: typing.Optional["ParcelMeasurements"] = None,
         tracking_data: typing.Optional["TrackingData"] = None,
         items: typing.Optional[typing.List["DeliveryItem"]] = None
@@ -1457,9 +1441,7 @@ class OrderAddPaymentAction(OrderUpdateAction):
     #: :class:`commercetools.types.PaymentResourceIdentifier`
     payment: "PaymentResourceIdentifier"
 
-    def __init__(
-        self, *, action: str = None, payment: "PaymentResourceIdentifier" = None
-    ) -> None:
+    def __init__(self, *, payment: "PaymentResourceIdentifier") -> None:
         self.payment = payment
         super().__init__(action="addPayment")
 
@@ -1481,9 +1463,8 @@ class OrderAddReturnInfoAction(OrderUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
+        items: typing.List["ReturnItemDraft"],
         return_tracking_id: typing.Optional[str] = None,
-        items: typing.List["ReturnItemDraft"] = None,
         return_date: typing.Optional[datetime.datetime] = None
     ) -> None:
         self.return_tracking_id = return_tracking_id
@@ -1502,7 +1483,7 @@ class OrderChangeOrderStateAction(OrderUpdateAction):
     #: :class:`commercetools.types.OrderState` `(Named` ``orderState`` `in Commercetools)`
     order_state: "OrderState"
 
-    def __init__(self, *, action: str = None, order_state: "OrderState" = None) -> None:
+    def __init__(self, *, order_state: "OrderState") -> None:
         self.order_state = order_state
         super().__init__(action="changeOrderState")
 
@@ -1518,10 +1499,7 @@ class OrderChangePaymentStateAction(OrderUpdateAction):
     payment_state: typing.Optional["PaymentState"]
 
     def __init__(
-        self,
-        *,
-        action: str = None,
-        payment_state: typing.Optional["PaymentState"] = None
+        self, *, payment_state: typing.Optional["PaymentState"] = None
     ) -> None:
         self.payment_state = payment_state
         super().__init__(action="changePaymentState")
@@ -1538,10 +1516,7 @@ class OrderChangeShipmentStateAction(OrderUpdateAction):
     shipment_state: typing.Optional["ShipmentState"]
 
     def __init__(
-        self,
-        *,
-        action: str = None,
-        shipment_state: typing.Optional["ShipmentState"] = None
+        self, *, shipment_state: typing.Optional["ShipmentState"] = None
     ) -> None:
         self.shipment_state = shipment_state
         super().__init__(action="changeShipmentState")
@@ -1560,11 +1535,7 @@ class OrderImportCustomLineItemStateAction(OrderUpdateAction):
     state: typing.List["ItemState"]
 
     def __init__(
-        self,
-        *,
-        action: str = None,
-        custom_line_item_id: str = None,
-        state: typing.List["ItemState"] = None
+        self, *, custom_line_item_id: str, state: typing.List["ItemState"]
     ) -> None:
         self.custom_line_item_id = custom_line_item_id
         self.state = state
@@ -1583,13 +1554,7 @@ class OrderImportLineItemStateAction(OrderUpdateAction):
     #: List of :class:`commercetools.types.ItemState`
     state: typing.List["ItemState"]
 
-    def __init__(
-        self,
-        *,
-        action: str = None,
-        line_item_id: str = None,
-        state: typing.List["ItemState"] = None
-    ) -> None:
+    def __init__(self, *, line_item_id: str, state: typing.List["ItemState"]) -> None:
         self.line_item_id = line_item_id
         self.state = state
         super().__init__(action="importLineItemState")
@@ -1605,7 +1570,7 @@ class OrderRemoveDeliveryAction(OrderUpdateAction):
     #: :class:`str` `(Named` ``deliveryId`` `in Commercetools)`
     delivery_id: str
 
-    def __init__(self, *, action: str = None, delivery_id: str = None) -> None:
+    def __init__(self, *, delivery_id: str) -> None:
         self.delivery_id = delivery_id
         super().__init__(action="removeDelivery")
 
@@ -1620,7 +1585,7 @@ class OrderRemoveItemShippingAddressAction(OrderUpdateAction):
     #: :class:`str` `(Named` ``addressKey`` `in Commercetools)`
     address_key: str
 
-    def __init__(self, *, action: str = None, address_key: str = None) -> None:
+    def __init__(self, *, address_key: str) -> None:
         self.address_key = address_key
         super().__init__(action="removeItemShippingAddress")
 
@@ -1635,7 +1600,7 @@ class OrderRemoveParcelFromDeliveryAction(OrderUpdateAction):
     #: :class:`str` `(Named` ``parcelId`` `in Commercetools)`
     parcel_id: str
 
-    def __init__(self, *, action: str = None, parcel_id: str = None) -> None:
+    def __init__(self, *, parcel_id: str) -> None:
         self.parcel_id = parcel_id
         super().__init__(action="removeParcelFromDelivery")
 
@@ -1650,9 +1615,7 @@ class OrderRemovePaymentAction(OrderUpdateAction):
     #: :class:`commercetools.types.PaymentResourceIdentifier`
     payment: "PaymentResourceIdentifier"
 
-    def __init__(
-        self, *, action: str = None, payment: "PaymentResourceIdentifier" = None
-    ) -> None:
+    def __init__(self, *, payment: "PaymentResourceIdentifier") -> None:
         self.payment = payment
         super().__init__(action="removePayment")
 
@@ -1667,9 +1630,7 @@ class OrderSetBillingAddressAction(OrderUpdateAction):
     #: Optional :class:`commercetools.types.Address`
     address: typing.Optional["Address"]
 
-    def __init__(
-        self, *, action: str = None, address: typing.Optional["Address"] = None
-    ) -> None:
+    def __init__(self, *, address: typing.Optional["Address"] = None) -> None:
         self.address = address
         super().__init__(action="setBillingAddress")
 
@@ -1686,13 +1647,7 @@ class OrderSetCustomFieldAction(OrderUpdateAction):
     #: Optional :class:`typing.Any`
     value: typing.Optional[typing.Any]
 
-    def __init__(
-        self,
-        *,
-        action: str = None,
-        name: str = None,
-        value: typing.Optional[typing.Any] = None
-    ) -> None:
+    def __init__(self, *, name: str, value: typing.Optional[typing.Any] = None) -> None:
         self.name = name
         self.value = value
         super().__init__(action="setCustomField")
@@ -1716,9 +1671,8 @@ class OrderSetCustomLineItemCustomFieldAction(OrderUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
-        custom_line_item_id: str = None,
-        name: str = None,
+        custom_line_item_id: str,
+        name: str,
         value: typing.Optional[typing.Any] = None
     ) -> None:
         self.custom_line_item_id = custom_line_item_id
@@ -1744,8 +1698,7 @@ class OrderSetCustomLineItemCustomTypeAction(OrderUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
-        custom_line_item_id: str = None,
+        custom_line_item_id: str,
         type: typing.Optional["TypeResourceIdentifier"] = None,
         fields: typing.Optional["FieldContainer"] = None
     ) -> None:
@@ -1770,8 +1723,7 @@ class OrderSetCustomLineItemShippingDetailsAction(OrderUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
-        custom_line_item_id: str = None,
+        custom_line_item_id: str,
         shipping_details: typing.Optional["ItemShippingDetailsDraft"] = None
     ) -> None:
         self.custom_line_item_id = custom_line_item_id
@@ -1794,7 +1746,6 @@ class OrderSetCustomTypeAction(OrderUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
         type: typing.Optional["TypeResourceIdentifier"] = None,
         fields: typing.Optional["FieldContainer"] = None
     ) -> None:
@@ -1814,9 +1765,7 @@ class OrderSetCustomerEmailAction(OrderUpdateAction):
     #: Optional :class:`str`
     email: typing.Optional[str]
 
-    def __init__(
-        self, *, action: str = None, email: typing.Optional[str] = None
-    ) -> None:
+    def __init__(self, *, email: typing.Optional[str] = None) -> None:
         self.email = email
         super().__init__(action="setCustomerEmail")
 
@@ -1831,9 +1780,7 @@ class OrderSetCustomerIdAction(OrderUpdateAction):
     #: Optional :class:`str` `(Named` ``customerId`` `in Commercetools)`
     customer_id: typing.Optional[str]
 
-    def __init__(
-        self, *, action: str = None, customer_id: typing.Optional[str] = None
-    ) -> None:
+    def __init__(self, *, customer_id: typing.Optional[str] = None) -> None:
         self.customer_id = customer_id
         super().__init__(action="setCustomerId")
 
@@ -1851,11 +1798,7 @@ class OrderSetDeliveryAddressAction(OrderUpdateAction):
     address: typing.Optional["Address"]
 
     def __init__(
-        self,
-        *,
-        action: str = None,
-        delivery_id: str = None,
-        address: typing.Optional["Address"] = None
+        self, *, delivery_id: str, address: typing.Optional["Address"] = None
     ) -> None:
         self.delivery_id = delivery_id
         self.address = address
@@ -1874,13 +1817,7 @@ class OrderSetDeliveryItemsAction(OrderUpdateAction):
     #: List of :class:`commercetools.types.DeliveryItem`
     items: typing.List["DeliveryItem"]
 
-    def __init__(
-        self,
-        *,
-        action: str = None,
-        delivery_id: str = None,
-        items: typing.List["DeliveryItem"] = None
-    ) -> None:
+    def __init__(self, *, delivery_id: str, items: typing.List["DeliveryItem"]) -> None:
         self.delivery_id = delivery_id
         self.items = items
         super().__init__(action="setDeliveryItems")
@@ -1902,12 +1839,7 @@ class OrderSetLineItemCustomFieldAction(OrderUpdateAction):
     value: typing.Optional[typing.Any]
 
     def __init__(
-        self,
-        *,
-        action: str = None,
-        line_item_id: str = None,
-        name: str = None,
-        value: typing.Optional[typing.Any] = None
+        self, *, line_item_id: str, name: str, value: typing.Optional[typing.Any] = None
     ) -> None:
         self.line_item_id = line_item_id
         self.name = name
@@ -1932,8 +1864,7 @@ class OrderSetLineItemCustomTypeAction(OrderUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
-        line_item_id: str = None,
+        line_item_id: str,
         type: typing.Optional["TypeResourceIdentifier"] = None,
         fields: typing.Optional["FieldContainer"] = None
     ) -> None:
@@ -1958,8 +1889,7 @@ class OrderSetLineItemShippingDetailsAction(OrderUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
-        line_item_id: str = None,
+        line_item_id: str,
         shipping_details: typing.Optional["ItemShippingDetailsDraft"] = None
     ) -> None:
         self.line_item_id = line_item_id
@@ -1977,9 +1907,7 @@ class OrderSetLocaleAction(OrderUpdateAction):
     #: Optional :class:`str`
     locale: typing.Optional[str]
 
-    def __init__(
-        self, *, action: str = None, locale: typing.Optional[str] = None
-    ) -> None:
+    def __init__(self, *, locale: typing.Optional[str] = None) -> None:
         self.locale = locale
         super().__init__(action="setLocale")
 
@@ -1991,9 +1919,7 @@ class OrderSetOrderNumberAction(OrderUpdateAction):
     #: Optional :class:`str` `(Named` ``orderNumber`` `in Commercetools)`
     order_number: typing.Optional[str]
 
-    def __init__(
-        self, *, action: str = None, order_number: typing.Optional[str] = None
-    ) -> None:
+    def __init__(self, *, order_number: typing.Optional[str] = None) -> None:
         self.order_number = order_number
         super().__init__(action="setOrderNumber")
 
@@ -2010,13 +1936,7 @@ class OrderSetParcelItemsAction(OrderUpdateAction):
     #: List of :class:`commercetools.types.DeliveryItem`
     items: typing.List["DeliveryItem"]
 
-    def __init__(
-        self,
-        *,
-        action: str = None,
-        parcel_id: str = None,
-        items: typing.List["DeliveryItem"] = None
-    ) -> None:
+    def __init__(self, *, parcel_id: str, items: typing.List["DeliveryItem"]) -> None:
         self.parcel_id = parcel_id
         self.items = items
         super().__init__(action="setParcelItems")
@@ -2038,8 +1958,7 @@ class OrderSetParcelMeasurementsAction(OrderUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
-        parcel_id: str = None,
+        parcel_id: str,
         measurements: typing.Optional["ParcelMeasurements"] = None
     ) -> None:
         self.parcel_id = parcel_id
@@ -2060,11 +1979,7 @@ class OrderSetParcelTrackingDataAction(OrderUpdateAction):
     tracking_data: typing.Optional["TrackingData"]
 
     def __init__(
-        self,
-        *,
-        action: str = None,
-        parcel_id: str = None,
-        tracking_data: typing.Optional["TrackingData"] = None
+        self, *, parcel_id: str, tracking_data: typing.Optional["TrackingData"] = None
     ) -> None:
         self.parcel_id = parcel_id
         self.tracking_data = tracking_data
@@ -2084,11 +1999,7 @@ class OrderSetReturnPaymentStateAction(OrderUpdateAction):
     payment_state: "ReturnPaymentState"
 
     def __init__(
-        self,
-        *,
-        action: str = None,
-        return_item_id: str = None,
-        payment_state: "ReturnPaymentState" = None
+        self, *, return_item_id: str, payment_state: "ReturnPaymentState"
     ) -> None:
         self.return_item_id = return_item_id
         self.payment_state = payment_state
@@ -2108,11 +2019,7 @@ class OrderSetReturnShipmentStateAction(OrderUpdateAction):
     shipment_state: "ReturnShipmentState"
 
     def __init__(
-        self,
-        *,
-        action: str = None,
-        return_item_id: str = None,
-        shipment_state: "ReturnShipmentState" = None
+        self, *, return_item_id: str, shipment_state: "ReturnShipmentState"
     ) -> None:
         self.return_item_id = return_item_id
         self.shipment_state = shipment_state
@@ -2129,9 +2036,7 @@ class OrderSetShippingAddressAction(OrderUpdateAction):
     #: Optional :class:`commercetools.types.Address`
     address: typing.Optional["Address"]
 
-    def __init__(
-        self, *, action: str = None, address: typing.Optional["Address"] = None
-    ) -> None:
+    def __init__(self, *, address: typing.Optional["Address"] = None) -> None:
         self.address = address
         super().__init__(action="setShippingAddress")
 
@@ -2147,10 +2052,7 @@ class OrderSetStoreAction(OrderUpdateAction):
     store: typing.Optional["StoreResourceIdentifier"]
 
     def __init__(
-        self,
-        *,
-        action: str = None,
-        store: typing.Optional["StoreResourceIdentifier"] = None
+        self, *, store: typing.Optional["StoreResourceIdentifier"] = None
     ) -> None:
         self.store = store
         super().__init__(action="setStore")
@@ -2174,11 +2076,10 @@ class OrderTransitionCustomLineItemStateAction(OrderUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
-        custom_line_item_id: str = None,
-        quantity: int = None,
-        from_state: "StateResourceIdentifier" = None,
-        to_state: "StateResourceIdentifier" = None,
+        custom_line_item_id: str,
+        quantity: int,
+        from_state: "StateResourceIdentifier",
+        to_state: "StateResourceIdentifier",
         actual_transition_date: typing.Optional[datetime.datetime] = None
     ) -> None:
         self.custom_line_item_id = custom_line_item_id
@@ -2217,11 +2118,10 @@ class OrderTransitionLineItemStateAction(OrderUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
-        line_item_id: str = None,
-        quantity: int = None,
-        from_state: "StateResourceIdentifier" = None,
-        to_state: "StateResourceIdentifier" = None,
+        line_item_id: str,
+        quantity: int,
+        from_state: "StateResourceIdentifier",
+        to_state: "StateResourceIdentifier",
         actual_transition_date: typing.Optional[datetime.datetime] = None
     ) -> None:
         self.line_item_id = line_item_id
@@ -2252,11 +2152,7 @@ class OrderTransitionStateAction(OrderUpdateAction):
     force: typing.Optional[bool]
 
     def __init__(
-        self,
-        *,
-        action: str = None,
-        state: "StateResourceIdentifier" = None,
-        force: typing.Optional[bool] = None
+        self, *, state: "StateResourceIdentifier", force: typing.Optional[bool] = None
     ) -> None:
         self.state = state
         self.force = force
@@ -2274,7 +2170,7 @@ class OrderUpdateItemShippingAddressAction(OrderUpdateAction):
     #: :class:`commercetools.types.Address`
     address: "Address"
 
-    def __init__(self, *, action: str = None, address: "Address" = None) -> None:
+    def __init__(self, *, address: "Address") -> None:
         self.address = address
         super().__init__(action="updateItemShippingAddress")
 
@@ -2296,8 +2192,7 @@ class OrderUpdateSyncInfoAction(OrderUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
-        channel: "ChannelResourceIdentifier" = None,
+        channel: "ChannelResourceIdentifier",
         external_id: typing.Optional[str] = None,
         synced_at: typing.Optional[datetime.datetime] = None
     ) -> None:

--- a/src/commercetools/types/_order_edit.py
+++ b/src/commercetools/types/_order_edit.py
@@ -198,17 +198,17 @@ class OrderEdit(BaseResource):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        resource: "OrderReference",
+        staged_actions: typing.List["StagedOrderUpdateAction"],
+        result: "OrderEditResult",
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
         key: typing.Optional[str] = None,
-        resource: "OrderReference" = None,
-        staged_actions: typing.List["StagedOrderUpdateAction"] = None,
         custom: typing.Optional["CustomFields"] = None,
-        result: "OrderEditResult" = None,
         comment: typing.Optional[str] = None
     ) -> None:
         self.id = id
@@ -256,9 +256,7 @@ class OrderEditApply(_BaseType):
     #: :class:`int` `(Named` ``resourceVersion`` `in Commercetools)`
     resource_version: int
 
-    def __init__(
-        self, *, edit_version: int = None, resource_version: int = None
-    ) -> None:
+    def __init__(self, *, edit_version: int, resource_version: int) -> None:
         self.edit_version = edit_version
         self.resource_version = resource_version
         super().__init__()
@@ -287,8 +285,8 @@ class OrderEditDraft(_BaseType):
     def __init__(
         self,
         *,
+        resource: "OrderReference",
         key: typing.Optional[str] = None,
-        resource: "OrderReference" = None,
         staged_actions: typing.Optional[typing.List["StagedOrderUpdateAction"]] = None,
         custom: typing.Optional["CustomFieldsDraft"] = None,
         comment: typing.Optional[str] = None,
@@ -331,11 +329,11 @@ class OrderEditPagedQueryResponse(_BaseType):
     def __init__(
         self,
         *,
-        limit: int = None,
-        count: int = None,
-        total: typing.Optional[int] = None,
-        offset: int = None,
-        results: typing.Sequence["OrderEdit"] = None
+        limit: int,
+        count: int,
+        offset: int,
+        results: typing.Sequence["OrderEdit"],
+        total: typing.Optional[int] = None
     ) -> None:
         self.limit = limit
         self.count = count
@@ -355,13 +353,7 @@ class OrderEditReference(Reference):
     #: Optional :class:`commercetools.types.OrderEdit`
     obj: typing.Optional["OrderEdit"]
 
-    def __init__(
-        self,
-        *,
-        type_id: "ReferenceTypeId" = None,
-        id: str = None,
-        obj: typing.Optional["OrderEdit"] = None
-    ) -> None:
+    def __init__(self, *, id: str, obj: typing.Optional["OrderEdit"] = None) -> None:
         self.obj = obj
         super().__init__(type_id=ReferenceTypeId.ORDER_EDIT, id=id)
 
@@ -375,11 +367,7 @@ class OrderEditReference(Reference):
 
 class OrderEditResourceIdentifier(ResourceIdentifier):
     def __init__(
-        self,
-        *,
-        type_id: typing.Optional["ReferenceTypeId"] = None,
-        id: typing.Optional[str] = None,
-        key: typing.Optional[str] = None
+        self, *, id: typing.Optional[str] = None, key: typing.Optional[str] = None
     ) -> None:
         super().__init__(type_id=ReferenceTypeId.ORDER_EDIT, id=id, key=key)
 
@@ -395,7 +383,7 @@ class OrderEditResult(_BaseType):
     #: :class:`str`
     type: str
 
-    def __init__(self, *, type: str = None) -> None:
+    def __init__(self, *, type: str) -> None:
         self.type = type
         super().__init__()
 
@@ -414,8 +402,8 @@ class OrderEditUpdate(_BaseType):
     def __init__(
         self,
         *,
-        version: int = None,
-        actions: typing.List["OrderEditUpdateAction"] = None,
+        version: int,
+        actions: typing.List["OrderEditUpdateAction"],
         dry_run: typing.Optional[bool] = None
     ) -> None:
         self.version = version
@@ -435,7 +423,7 @@ class OrderEditUpdateAction(_BaseType):
     #: :class:`str`
     action: str
 
-    def __init__(self, *, action: str = None) -> None:
+    def __init__(self, *, action: str) -> None:
         self.action = action
         super().__init__()
 
@@ -454,9 +442,9 @@ class OrderExcerpt(_BaseType):
     def __init__(
         self,
         *,
-        total_price: "TypedMoney" = None,
-        taxed_price: typing.Optional["TaxedPrice"] = None,
-        version: int = None
+        total_price: "TypedMoney",
+        version: int,
+        taxed_price: typing.Optional["TaxedPrice"] = None
     ) -> None:
         self.total_price = total_price
         self.taxed_price = taxed_price
@@ -475,10 +463,18 @@ class StagedOrder(Order):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        line_items: typing.List["LineItem"],
+        custom_line_items: typing.List["CustomLineItem"],
+        total_price: "TypedMoney",
+        order_state: "OrderState",
+        sync_info: typing.List["SyncInfo"],
+        last_message_sequence_number: int,
+        origin: "CartOrigin",
+        refused_gifts: typing.List["CartDiscountReference"],
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
         completed_at: typing.Optional[datetime.datetime] = None,
@@ -487,9 +483,6 @@ class StagedOrder(Order):
         customer_email: typing.Optional[str] = None,
         anonymous_id: typing.Optional[str] = None,
         store: typing.Optional["StoreKeyReference"] = None,
-        line_items: typing.List["LineItem"] = None,
-        custom_line_items: typing.List["CustomLineItem"] = None,
-        total_price: "TypedMoney" = None,
         taxed_price: typing.Optional["TaxedPrice"] = None,
         shipping_address: typing.Optional["Address"] = None,
         billing_address: typing.Optional["Address"] = None,
@@ -497,25 +490,20 @@ class StagedOrder(Order):
         tax_rounding_mode: typing.Optional["RoundingMode"] = None,
         customer_group: typing.Optional["CustomerGroupReference"] = None,
         country: typing.Optional[str] = None,
-        order_state: "OrderState" = None,
         state: typing.Optional["StateReference"] = None,
         shipment_state: typing.Optional["ShipmentState"] = None,
         payment_state: typing.Optional["PaymentState"] = None,
         shipping_info: typing.Optional["ShippingInfo"] = None,
-        sync_info: typing.List["SyncInfo"] = None,
         return_info: typing.Optional[typing.List["ReturnInfo"]] = None,
         discount_codes: typing.Optional[typing.List["DiscountCodeInfo"]] = None,
-        last_message_sequence_number: int = None,
         cart: typing.Optional["CartReference"] = None,
         custom: typing.Optional["CustomFields"] = None,
         payment_info: typing.Optional["PaymentInfo"] = None,
         locale: typing.Optional[str] = None,
         inventory_mode: typing.Optional["InventoryMode"] = None,
-        origin: "CartOrigin" = None,
         tax_calculation_mode: typing.Optional["TaxCalculationMode"] = None,
         shipping_rate_input: typing.Optional["ShippingRateInput"] = None,
-        item_shipping_addresses: typing.Optional[typing.List["Address"]] = None,
-        refused_gifts: typing.List["CartDiscountReference"] = None
+        item_shipping_addresses: typing.Optional[typing.List["Address"]] = None
     ) -> None:
         super().__init__(
             id=id,
@@ -629,11 +617,10 @@ class StagedOrderAddCustomLineItemAction(StagedOrderUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
-        money: "Money" = None,
-        name: "LocalizedString" = None,
+        money: "Money",
+        name: "LocalizedString",
+        slug: str,
         quantity: typing.Optional[int] = None,
-        slug: str = None,
         tax_category: typing.Optional["TaxCategoryResourceIdentifier"] = None,
         custom: typing.Optional["CustomFieldsDraft"] = None,
         external_tax_rate: typing.Optional["ExternalTaxRateDraft"] = None
@@ -674,7 +661,6 @@ class StagedOrderAddDeliveryAction(StagedOrderUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
         items: typing.Optional[typing.List["DeliveryItem"]] = None,
         address: typing.Optional["Address"] = None,
         parcels: typing.Optional[typing.List["ParcelDraft"]] = None
@@ -695,7 +681,7 @@ class StagedOrderAddDiscountCodeAction(StagedOrderUpdateAction):
     #: :class:`str`
     code: str
 
-    def __init__(self, *, action: str = None, code: str = None) -> None:
+    def __init__(self, *, code: str) -> None:
         self.code = code
         super().__init__(action="addDiscountCode")
 
@@ -710,7 +696,7 @@ class StagedOrderAddItemShippingAddressAction(StagedOrderUpdateAction):
     #: :class:`commercetools.types.Address`
     address: "Address"
 
-    def __init__(self, *, action: str = None, address: "Address" = None) -> None:
+    def __init__(self, *, address: "Address") -> None:
         self.address = address
         super().__init__(action="addItemShippingAddress")
 
@@ -748,7 +734,6 @@ class StagedOrderAddLineItemAction(StagedOrderUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
         custom: typing.Optional["CustomFieldsDraft"] = None,
         distribution_channel: typing.Optional["ChannelResourceIdentifier"] = None,
         external_tax_rate: typing.Optional["ExternalTaxRateDraft"] = None,
@@ -807,8 +792,7 @@ class StagedOrderAddParcelToDeliveryAction(StagedOrderUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
-        delivery_id: str = None,
+        delivery_id: str,
         measurements: typing.Optional["ParcelMeasurements"] = None,
         tracking_data: typing.Optional["TrackingData"] = None,
         items: typing.Optional[typing.List["DeliveryItem"]] = None
@@ -836,9 +820,7 @@ class StagedOrderAddPaymentAction(StagedOrderUpdateAction):
     #: :class:`commercetools.types.PaymentResourceIdentifier`
     payment: "PaymentResourceIdentifier"
 
-    def __init__(
-        self, *, action: str = None, payment: "PaymentResourceIdentifier" = None
-    ) -> None:
+    def __init__(self, *, payment: "PaymentResourceIdentifier") -> None:
         self.payment = payment
         super().__init__(action="addPayment")
 
@@ -860,9 +842,8 @@ class StagedOrderAddReturnInfoAction(StagedOrderUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
+        items: typing.List["ReturnItemDraft"],
         return_tracking_id: typing.Optional[str] = None,
-        items: typing.List["ReturnItemDraft"] = None,
         return_date: typing.Optional[datetime.datetime] = None
     ) -> None:
         self.return_tracking_id = return_tracking_id
@@ -888,8 +869,7 @@ class StagedOrderAddShoppingListAction(StagedOrderUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
-        shopping_list: "ShoppingListResourceIdentifier" = None,
+        shopping_list: "ShoppingListResourceIdentifier",
         supply_channel: typing.Optional["ChannelResourceIdentifier"] = None,
         distribution_channel: typing.Optional["ChannelResourceIdentifier"] = None
     ) -> None:
@@ -916,13 +896,7 @@ class StagedOrderChangeCustomLineItemMoneyAction(StagedOrderUpdateAction):
     #: :class:`commercetools.types.Money`
     money: "Money"
 
-    def __init__(
-        self,
-        *,
-        action: str = None,
-        custom_line_item_id: str = None,
-        money: "Money" = None
-    ) -> None:
+    def __init__(self, *, custom_line_item_id: str, money: "Money") -> None:
         self.custom_line_item_id = custom_line_item_id
         self.money = money
         super().__init__(action="changeCustomLineItemMoney")
@@ -940,13 +914,7 @@ class StagedOrderChangeCustomLineItemQuantityAction(StagedOrderUpdateAction):
     #: :class:`int`
     quantity: int
 
-    def __init__(
-        self,
-        *,
-        action: str = None,
-        custom_line_item_id: str = None,
-        quantity: int = None
-    ) -> None:
+    def __init__(self, *, custom_line_item_id: str, quantity: int) -> None:
         self.custom_line_item_id = custom_line_item_id
         self.quantity = quantity
         super().__init__(action="changeCustomLineItemQuantity")
@@ -971,9 +939,8 @@ class StagedOrderChangeLineItemQuantityAction(StagedOrderUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
-        line_item_id: str = None,
-        quantity: int = None,
+        line_item_id: str,
+        quantity: int,
         external_price: typing.Optional["Money"] = None,
         external_total_price: typing.Optional["ExternalLineItemTotalPrice"] = None
     ) -> None:
@@ -1000,7 +967,7 @@ class StagedOrderChangeOrderStateAction(StagedOrderUpdateAction):
     #: :class:`commercetools.types.OrderState` `(Named` ``orderState`` `in Commercetools)`
     order_state: "OrderState"
 
-    def __init__(self, *, action: str = None, order_state: "OrderState" = None) -> None:
+    def __init__(self, *, order_state: "OrderState") -> None:
         self.order_state = order_state
         super().__init__(action="changeOrderState")
 
@@ -1016,10 +983,7 @@ class StagedOrderChangePaymentStateAction(StagedOrderUpdateAction):
     payment_state: typing.Optional["PaymentState"]
 
     def __init__(
-        self,
-        *,
-        action: str = None,
-        payment_state: typing.Optional["PaymentState"] = None
+        self, *, payment_state: typing.Optional["PaymentState"] = None
     ) -> None:
         self.payment_state = payment_state
         super().__init__(action="changePaymentState")
@@ -1036,10 +1000,7 @@ class StagedOrderChangeShipmentStateAction(StagedOrderUpdateAction):
     shipment_state: typing.Optional["ShipmentState"]
 
     def __init__(
-        self,
-        *,
-        action: str = None,
-        shipment_state: typing.Optional["ShipmentState"] = None
+        self, *, shipment_state: typing.Optional["ShipmentState"] = None
     ) -> None:
         self.shipment_state = shipment_state
         super().__init__(action="changeShipmentState")
@@ -1055,9 +1016,7 @@ class StagedOrderChangeTaxCalculationModeAction(StagedOrderUpdateAction):
     #: :class:`commercetools.types.TaxCalculationMode` `(Named` ``taxCalculationMode`` `in Commercetools)`
     tax_calculation_mode: "TaxCalculationMode"
 
-    def __init__(
-        self, *, action: str = None, tax_calculation_mode: "TaxCalculationMode" = None
-    ) -> None:
+    def __init__(self, *, tax_calculation_mode: "TaxCalculationMode") -> None:
         self.tax_calculation_mode = tax_calculation_mode
         super().__init__(action="changeTaxCalculationMode")
 
@@ -1072,7 +1031,7 @@ class StagedOrderChangeTaxModeAction(StagedOrderUpdateAction):
     #: :class:`commercetools.types.TaxMode` `(Named` ``taxMode`` `in Commercetools)`
     tax_mode: "TaxMode"
 
-    def __init__(self, *, action: str = None, tax_mode: "TaxMode" = None) -> None:
+    def __init__(self, *, tax_mode: "TaxMode") -> None:
         self.tax_mode = tax_mode
         super().__init__(action="changeTaxMode")
 
@@ -1087,9 +1046,7 @@ class StagedOrderChangeTaxRoundingModeAction(StagedOrderUpdateAction):
     #: :class:`commercetools.types.RoundingMode` `(Named` ``taxRoundingMode`` `in Commercetools)`
     tax_rounding_mode: "RoundingMode"
 
-    def __init__(
-        self, *, action: str = None, tax_rounding_mode: "RoundingMode" = None
-    ) -> None:
+    def __init__(self, *, tax_rounding_mode: "RoundingMode") -> None:
         self.tax_rounding_mode = tax_rounding_mode
         super().__init__(action="changeTaxRoundingMode")
 
@@ -1107,11 +1064,7 @@ class StagedOrderImportCustomLineItemStateAction(StagedOrderUpdateAction):
     state: typing.List["ItemState"]
 
     def __init__(
-        self,
-        *,
-        action: str = None,
-        custom_line_item_id: str = None,
-        state: typing.List["ItemState"] = None
+        self, *, custom_line_item_id: str, state: typing.List["ItemState"]
     ) -> None:
         self.custom_line_item_id = custom_line_item_id
         self.state = state
@@ -1130,13 +1083,7 @@ class StagedOrderImportLineItemStateAction(StagedOrderUpdateAction):
     #: List of :class:`commercetools.types.ItemState`
     state: typing.List["ItemState"]
 
-    def __init__(
-        self,
-        *,
-        action: str = None,
-        line_item_id: str = None,
-        state: typing.List["ItemState"] = None
-    ) -> None:
+    def __init__(self, *, line_item_id: str, state: typing.List["ItemState"]) -> None:
         self.line_item_id = line_item_id
         self.state = state
         super().__init__(action="importLineItemState")
@@ -1152,7 +1099,7 @@ class StagedOrderRemoveCustomLineItemAction(StagedOrderUpdateAction):
     #: :class:`str` `(Named` ``customLineItemId`` `in Commercetools)`
     custom_line_item_id: str
 
-    def __init__(self, *, action: str = None, custom_line_item_id: str = None) -> None:
+    def __init__(self, *, custom_line_item_id: str) -> None:
         self.custom_line_item_id = custom_line_item_id
         super().__init__(action="removeCustomLineItem")
 
@@ -1167,7 +1114,7 @@ class StagedOrderRemoveDeliveryAction(StagedOrderUpdateAction):
     #: :class:`str` `(Named` ``deliveryId`` `in Commercetools)`
     delivery_id: str
 
-    def __init__(self, *, action: str = None, delivery_id: str = None) -> None:
+    def __init__(self, *, delivery_id: str) -> None:
         self.delivery_id = delivery_id
         super().__init__(action="removeDelivery")
 
@@ -1182,9 +1129,7 @@ class StagedOrderRemoveDiscountCodeAction(StagedOrderUpdateAction):
     #: :class:`commercetools.types.DiscountCodeReference` `(Named` ``discountCode`` `in Commercetools)`
     discount_code: "DiscountCodeReference"
 
-    def __init__(
-        self, *, action: str = None, discount_code: "DiscountCodeReference" = None
-    ) -> None:
+    def __init__(self, *, discount_code: "DiscountCodeReference") -> None:
         self.discount_code = discount_code
         super().__init__(action="removeDiscountCode")
 
@@ -1199,7 +1144,7 @@ class StagedOrderRemoveItemShippingAddressAction(StagedOrderUpdateAction):
     #: :class:`str` `(Named` ``addressKey`` `in Commercetools)`
     address_key: str
 
-    def __init__(self, *, action: str = None, address_key: str = None) -> None:
+    def __init__(self, *, address_key: str) -> None:
         self.address_key = address_key
         super().__init__(action="removeItemShippingAddress")
 
@@ -1225,8 +1170,7 @@ class StagedOrderRemoveLineItemAction(StagedOrderUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
-        line_item_id: str = None,
+        line_item_id: str,
         quantity: typing.Optional[int] = None,
         external_price: typing.Optional["Money"] = None,
         external_total_price: typing.Optional["ExternalLineItemTotalPrice"] = None,
@@ -1257,7 +1201,7 @@ class StagedOrderRemoveParcelFromDeliveryAction(StagedOrderUpdateAction):
     #: :class:`str` `(Named` ``parcelId`` `in Commercetools)`
     parcel_id: str
 
-    def __init__(self, *, action: str = None, parcel_id: str = None) -> None:
+    def __init__(self, *, parcel_id: str) -> None:
         self.parcel_id = parcel_id
         super().__init__(action="removeParcelFromDelivery")
 
@@ -1272,9 +1216,7 @@ class StagedOrderRemovePaymentAction(StagedOrderUpdateAction):
     #: :class:`commercetools.types.PaymentResourceIdentifier`
     payment: "PaymentResourceIdentifier"
 
-    def __init__(
-        self, *, action: str = None, payment: "PaymentResourceIdentifier" = None
-    ) -> None:
+    def __init__(self, *, payment: "PaymentResourceIdentifier") -> None:
         self.payment = payment
         super().__init__(action="removePayment")
 
@@ -1289,9 +1231,7 @@ class StagedOrderSetBillingAddressAction(StagedOrderUpdateAction):
     #: Optional :class:`commercetools.types.Address`
     address: typing.Optional["Address"]
 
-    def __init__(
-        self, *, action: str = None, address: typing.Optional["Address"] = None
-    ) -> None:
+    def __init__(self, *, address: typing.Optional["Address"] = None) -> None:
         self.address = address
         super().__init__(action="setBillingAddress")
 
@@ -1306,9 +1246,7 @@ class StagedOrderSetCountryAction(StagedOrderUpdateAction):
     #: Optional :class:`str`
     country: typing.Optional[str]
 
-    def __init__(
-        self, *, action: str = None, country: typing.Optional[str] = None
-    ) -> None:
+    def __init__(self, *, country: typing.Optional[str] = None) -> None:
         self.country = country
         super().__init__(action="setCountry")
 
@@ -1325,13 +1263,7 @@ class StagedOrderSetCustomFieldAction(StagedOrderUpdateAction):
     #: Optional :class:`typing.Any`
     value: typing.Optional[typing.Any]
 
-    def __init__(
-        self,
-        *,
-        action: str = None,
-        name: str = None,
-        value: typing.Optional[typing.Any] = None
-    ) -> None:
+    def __init__(self, *, name: str, value: typing.Optional[typing.Any] = None) -> None:
         self.name = name
         self.value = value
         super().__init__(action="setCustomField")
@@ -1355,9 +1287,8 @@ class StagedOrderSetCustomLineItemCustomFieldAction(StagedOrderUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
-        custom_line_item_id: str = None,
-        name: str = None,
+        custom_line_item_id: str,
+        name: str,
         value: typing.Optional[typing.Any] = None
     ) -> None:
         self.custom_line_item_id = custom_line_item_id
@@ -1383,8 +1314,7 @@ class StagedOrderSetCustomLineItemCustomTypeAction(StagedOrderUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
-        custom_line_item_id: str = None,
+        custom_line_item_id: str,
         type: typing.Optional["TypeResourceIdentifier"] = None,
         fields: typing.Optional["FieldContainer"] = None
     ) -> None:
@@ -1409,8 +1339,7 @@ class StagedOrderSetCustomLineItemShippingDetailsAction(StagedOrderUpdateAction)
     def __init__(
         self,
         *,
-        action: str = None,
-        custom_line_item_id: str = None,
+        custom_line_item_id: str,
         shipping_details: typing.Optional["ItemShippingDetailsDraft"] = None
     ) -> None:
         self.custom_line_item_id = custom_line_item_id
@@ -1433,8 +1362,7 @@ class StagedOrderSetCustomLineItemTaxAmountAction(StagedOrderUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
-        custom_line_item_id: str = None,
+        custom_line_item_id: str,
         external_tax_amount: typing.Optional["ExternalTaxAmountDraft"] = None
     ) -> None:
         self.custom_line_item_id = custom_line_item_id
@@ -1457,8 +1385,7 @@ class StagedOrderSetCustomLineItemTaxRateAction(StagedOrderUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
-        custom_line_item_id: str = None,
+        custom_line_item_id: str,
         external_tax_rate: typing.Optional["ExternalTaxRateDraft"] = None
     ) -> None:
         self.custom_line_item_id = custom_line_item_id
@@ -1485,9 +1412,8 @@ class StagedOrderSetCustomShippingMethodAction(StagedOrderUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
-        shipping_method_name: str = None,
-        shipping_rate: "ShippingRateDraft" = None,
+        shipping_method_name: str,
+        shipping_rate: "ShippingRateDraft",
         tax_category: typing.Optional["TaxCategoryResourceIdentifier"] = None,
         external_tax_rate: typing.Optional["ExternalTaxRateDraft"] = None
     ) -> None:
@@ -1519,7 +1445,6 @@ class StagedOrderSetCustomTypeAction(StagedOrderUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
         type: typing.Optional["TypeResourceIdentifier"] = None,
         fields: typing.Optional["FieldContainer"] = None
     ) -> None:
@@ -1539,9 +1464,7 @@ class StagedOrderSetCustomerEmailAction(StagedOrderUpdateAction):
     #: Optional :class:`str`
     email: typing.Optional[str]
 
-    def __init__(
-        self, *, action: str = None, email: typing.Optional[str] = None
-    ) -> None:
+    def __init__(self, *, email: typing.Optional[str] = None) -> None:
         self.email = email
         super().__init__(action="setCustomerEmail")
 
@@ -1559,7 +1482,6 @@ class StagedOrderSetCustomerGroupAction(StagedOrderUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
         customer_group: typing.Optional["CustomerGroupResourceIdentifier"] = None
     ) -> None:
         self.customer_group = customer_group
@@ -1576,9 +1498,7 @@ class StagedOrderSetCustomerIdAction(StagedOrderUpdateAction):
     #: Optional :class:`str` `(Named` ``customerId`` `in Commercetools)`
     customer_id: typing.Optional[str]
 
-    def __init__(
-        self, *, action: str = None, customer_id: typing.Optional[str] = None
-    ) -> None:
+    def __init__(self, *, customer_id: typing.Optional[str] = None) -> None:
         self.customer_id = customer_id
         super().__init__(action="setCustomerId")
 
@@ -1596,11 +1516,7 @@ class StagedOrderSetDeliveryAddressAction(StagedOrderUpdateAction):
     address: typing.Optional["Address"]
 
     def __init__(
-        self,
-        *,
-        action: str = None,
-        delivery_id: str = None,
-        address: typing.Optional["Address"] = None
+        self, *, delivery_id: str, address: typing.Optional["Address"] = None
     ) -> None:
         self.delivery_id = delivery_id
         self.address = address
@@ -1619,13 +1535,7 @@ class StagedOrderSetDeliveryItemsAction(StagedOrderUpdateAction):
     #: List of :class:`commercetools.types.DeliveryItem`
     items: typing.List["DeliveryItem"]
 
-    def __init__(
-        self,
-        *,
-        action: str = None,
-        delivery_id: str = None,
-        items: typing.List["DeliveryItem"] = None
-    ) -> None:
+    def __init__(self, *, delivery_id: str, items: typing.List["DeliveryItem"]) -> None:
         self.delivery_id = delivery_id
         self.items = items
         super().__init__(action="setDeliveryItems")
@@ -1646,12 +1556,7 @@ class StagedOrderSetLineItemCustomFieldAction(StagedOrderUpdateAction):
     value: typing.Optional[typing.Any]
 
     def __init__(
-        self,
-        *,
-        action: str = None,
-        line_item_id: str = None,
-        name: str = None,
-        value: typing.Optional[typing.Any] = None
+        self, *, line_item_id: str, name: str, value: typing.Optional[typing.Any] = None
     ) -> None:
         self.line_item_id = line_item_id
         self.name = name
@@ -1676,8 +1581,7 @@ class StagedOrderSetLineItemCustomTypeAction(StagedOrderUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
-        line_item_id: str = None,
+        line_item_id: str,
         type: typing.Optional["TypeResourceIdentifier"] = None,
         fields: typing.Optional["FieldContainer"] = None
     ) -> None:
@@ -1700,11 +1604,7 @@ class StagedOrderSetLineItemPriceAction(StagedOrderUpdateAction):
     external_price: typing.Optional["Money"]
 
     def __init__(
-        self,
-        *,
-        action: str = None,
-        line_item_id: str = None,
-        external_price: typing.Optional["Money"] = None
+        self, *, line_item_id: str, external_price: typing.Optional["Money"] = None
     ) -> None:
         self.line_item_id = line_item_id
         self.external_price = external_price
@@ -1726,8 +1626,7 @@ class StagedOrderSetLineItemShippingDetailsAction(StagedOrderUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
-        line_item_id: str = None,
+        line_item_id: str,
         shipping_details: typing.Optional["ItemShippingDetailsDraft"] = None
     ) -> None:
         self.line_item_id = line_item_id
@@ -1750,8 +1649,7 @@ class StagedOrderSetLineItemTaxAmountAction(StagedOrderUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
-        line_item_id: str = None,
+        line_item_id: str,
         external_tax_amount: typing.Optional["ExternalTaxAmountDraft"] = None
     ) -> None:
         self.line_item_id = line_item_id
@@ -1774,8 +1672,7 @@ class StagedOrderSetLineItemTaxRateAction(StagedOrderUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
-        line_item_id: str = None,
+        line_item_id: str,
         external_tax_rate: typing.Optional["ExternalTaxRateDraft"] = None
     ) -> None:
         self.line_item_id = line_item_id
@@ -1798,8 +1695,7 @@ class StagedOrderSetLineItemTotalPriceAction(StagedOrderUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
-        line_item_id: str = None,
+        line_item_id: str,
         external_total_price: typing.Optional["ExternalLineItemTotalPrice"] = None
     ) -> None:
         self.line_item_id = line_item_id
@@ -1817,9 +1713,7 @@ class StagedOrderSetLocaleAction(StagedOrderUpdateAction):
     #: Optional :class:`str`
     locale: typing.Optional[str]
 
-    def __init__(
-        self, *, action: str = None, locale: typing.Optional[str] = None
-    ) -> None:
+    def __init__(self, *, locale: typing.Optional[str] = None) -> None:
         self.locale = locale
         super().__init__(action="setLocale")
 
@@ -1834,9 +1728,7 @@ class StagedOrderSetOrderNumberAction(StagedOrderUpdateAction):
     #: Optional :class:`str` `(Named` ``orderNumber`` `in Commercetools)`
     order_number: typing.Optional[str]
 
-    def __init__(
-        self, *, action: str = None, order_number: typing.Optional[str] = None
-    ) -> None:
+    def __init__(self, *, order_number: typing.Optional[str] = None) -> None:
         self.order_number = order_number
         super().__init__(action="setOrderNumber")
 
@@ -1856,8 +1748,7 @@ class StagedOrderSetOrderTotalTaxAction(StagedOrderUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
-        external_total_gross: "Money" = None,
+        external_total_gross: "Money",
         external_tax_portions: typing.Optional[typing.List["TaxPortionDraft"]] = None
     ) -> None:
         self.external_total_gross = external_total_gross
@@ -1877,13 +1768,7 @@ class StagedOrderSetParcelItemsAction(StagedOrderUpdateAction):
     #: List of :class:`commercetools.types.DeliveryItem`
     items: typing.List["DeliveryItem"]
 
-    def __init__(
-        self,
-        *,
-        action: str = None,
-        parcel_id: str = None,
-        items: typing.List["DeliveryItem"] = None
-    ) -> None:
+    def __init__(self, *, parcel_id: str, items: typing.List["DeliveryItem"]) -> None:
         self.parcel_id = parcel_id
         self.items = items
         super().__init__(action="setParcelItems")
@@ -1905,8 +1790,7 @@ class StagedOrderSetParcelMeasurementsAction(StagedOrderUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
-        parcel_id: str = None,
+        parcel_id: str,
         measurements: typing.Optional["ParcelMeasurements"] = None
     ) -> None:
         self.parcel_id = parcel_id
@@ -1927,11 +1811,7 @@ class StagedOrderSetParcelTrackingDataAction(StagedOrderUpdateAction):
     tracking_data: typing.Optional["TrackingData"]
 
     def __init__(
-        self,
-        *,
-        action: str = None,
-        parcel_id: str = None,
-        tracking_data: typing.Optional["TrackingData"] = None
+        self, *, parcel_id: str, tracking_data: typing.Optional["TrackingData"] = None
     ) -> None:
         self.parcel_id = parcel_id
         self.tracking_data = tracking_data
@@ -1951,11 +1831,7 @@ class StagedOrderSetReturnPaymentStateAction(StagedOrderUpdateAction):
     payment_state: "ReturnPaymentState"
 
     def __init__(
-        self,
-        *,
-        action: str = None,
-        return_item_id: str = None,
-        payment_state: "ReturnPaymentState" = None
+        self, *, return_item_id: str, payment_state: "ReturnPaymentState"
     ) -> None:
         self.return_item_id = return_item_id
         self.payment_state = payment_state
@@ -1975,11 +1851,7 @@ class StagedOrderSetReturnShipmentStateAction(StagedOrderUpdateAction):
     shipment_state: "ReturnShipmentState"
 
     def __init__(
-        self,
-        *,
-        action: str = None,
-        return_item_id: str = None,
-        shipment_state: "ReturnShipmentState" = None
+        self, *, return_item_id: str, shipment_state: "ReturnShipmentState"
     ) -> None:
         self.return_item_id = return_item_id
         self.shipment_state = shipment_state
@@ -1996,9 +1868,7 @@ class StagedOrderSetShippingAddressAction(StagedOrderUpdateAction):
     #: Optional :class:`commercetools.types.Address`
     address: typing.Optional["Address"]
 
-    def __init__(
-        self, *, action: str = None, address: typing.Optional["Address"] = None
-    ) -> None:
+    def __init__(self, *, address: typing.Optional["Address"] = None) -> None:
         self.address = address
         super().__init__(action="setShippingAddress")
 
@@ -2026,10 +1896,9 @@ class StagedOrderSetShippingAddressAndCustomShippingMethodAction(
     def __init__(
         self,
         *,
-        action: str = None,
-        address: "Address" = None,
-        shipping_method_name: str = None,
-        shipping_rate: "ShippingRateDraft" = None,
+        address: "Address",
+        shipping_method_name: str,
+        shipping_rate: "ShippingRateDraft",
         tax_category: typing.Optional["TaxCategoryResourceIdentifier"] = None,
         external_tax_rate: typing.Optional["ExternalTaxRateDraft"] = None
     ) -> None:
@@ -2065,8 +1934,7 @@ class StagedOrderSetShippingAddressAndShippingMethodAction(StagedOrderUpdateActi
     def __init__(
         self,
         *,
-        action: str = None,
-        address: "Address" = None,
+        address: "Address",
         shipping_method: typing.Optional["ShippingMethodResourceIdentifier"] = None,
         external_tax_rate: typing.Optional["ExternalTaxRateDraft"] = None
     ) -> None:
@@ -2091,7 +1959,6 @@ class StagedOrderSetShippingMethodAction(StagedOrderUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
         shipping_method: typing.Optional["ShippingMethodResourceIdentifier"] = None,
         external_tax_rate: typing.Optional["ExternalTaxRateDraft"] = None
     ) -> None:
@@ -2111,10 +1978,7 @@ class StagedOrderSetShippingMethodTaxAmountAction(StagedOrderUpdateAction):
     external_tax_amount: typing.Optional["ExternalTaxAmountDraft"]
 
     def __init__(
-        self,
-        *,
-        action: str = None,
-        external_tax_amount: typing.Optional["ExternalTaxAmountDraft"] = None
+        self, *, external_tax_amount: typing.Optional["ExternalTaxAmountDraft"] = None
     ) -> None:
         self.external_tax_amount = external_tax_amount
         super().__init__(action="setShippingMethodTaxAmount")
@@ -2131,10 +1995,7 @@ class StagedOrderSetShippingMethodTaxRateAction(StagedOrderUpdateAction):
     external_tax_rate: typing.Optional["ExternalTaxRateDraft"]
 
     def __init__(
-        self,
-        *,
-        action: str = None,
-        external_tax_rate: typing.Optional["ExternalTaxRateDraft"] = None
+        self, *, external_tax_rate: typing.Optional["ExternalTaxRateDraft"] = None
     ) -> None:
         self.external_tax_rate = external_tax_rate
         super().__init__(action="setShippingMethodTaxRate")
@@ -2151,10 +2012,7 @@ class StagedOrderSetShippingRateInputAction(StagedOrderUpdateAction):
     shipping_rate_input: typing.Optional["ShippingRateInputDraft"]
 
     def __init__(
-        self,
-        *,
-        action: str = None,
-        shipping_rate_input: typing.Optional["ShippingRateInputDraft"] = None
+        self, *, shipping_rate_input: typing.Optional["ShippingRateInputDraft"] = None
     ) -> None:
         self.shipping_rate_input = shipping_rate_input
         super().__init__(action="setShippingRateInput")
@@ -2181,11 +2039,10 @@ class StagedOrderTransitionCustomLineItemStateAction(StagedOrderUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
-        custom_line_item_id: str = None,
-        quantity: int = None,
-        from_state: "StateResourceIdentifier" = None,
-        to_state: "StateResourceIdentifier" = None,
+        custom_line_item_id: str,
+        quantity: int,
+        from_state: "StateResourceIdentifier",
+        to_state: "StateResourceIdentifier",
         actual_transition_date: typing.Optional[datetime.datetime] = None
     ) -> None:
         self.custom_line_item_id = custom_line_item_id
@@ -2224,11 +2081,10 @@ class StagedOrderTransitionLineItemStateAction(StagedOrderUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
-        line_item_id: str = None,
-        quantity: int = None,
-        from_state: "StateResourceIdentifier" = None,
-        to_state: "StateResourceIdentifier" = None,
+        line_item_id: str,
+        quantity: int,
+        from_state: "StateResourceIdentifier",
+        to_state: "StateResourceIdentifier",
         actual_transition_date: typing.Optional[datetime.datetime] = None
     ) -> None:
         self.line_item_id = line_item_id
@@ -2259,11 +2115,7 @@ class StagedOrderTransitionStateAction(StagedOrderUpdateAction):
     force: typing.Optional[bool]
 
     def __init__(
-        self,
-        *,
-        action: str = None,
-        state: "StateResourceIdentifier" = None,
-        force: typing.Optional[bool] = None
+        self, *, state: "StateResourceIdentifier", force: typing.Optional[bool] = None
     ) -> None:
         self.state = state
         self.force = force
@@ -2281,7 +2133,7 @@ class StagedOrderUpdateItemShippingAddressAction(StagedOrderUpdateAction):
     #: :class:`commercetools.types.Address`
     address: "Address"
 
-    def __init__(self, *, action: str = None, address: "Address" = None) -> None:
+    def __init__(self, *, address: "Address") -> None:
         self.address = address
         super().__init__(action="updateItemShippingAddress")
 
@@ -2303,8 +2155,7 @@ class StagedOrderUpdateSyncInfoAction(StagedOrderUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
-        channel: "ChannelResourceIdentifier" = None,
+        channel: "ChannelResourceIdentifier",
         external_id: typing.Optional[str] = None,
         synced_at: typing.Optional[datetime.datetime] = None
     ) -> None:
@@ -2324,9 +2175,7 @@ class OrderEditAddStagedActionAction(OrderEditUpdateAction):
     #: :class:`commercetools.types.StagedOrderUpdateAction` `(Named` ``stagedAction`` `in Commercetools)`
     staged_action: "StagedOrderUpdateAction"
 
-    def __init__(
-        self, *, action: str = None, staged_action: "StagedOrderUpdateAction" = None
-    ) -> None:
+    def __init__(self, *, staged_action: "StagedOrderUpdateAction") -> None:
         self.staged_action = staged_action
         super().__init__(action="addStagedAction")
 
@@ -2348,10 +2197,9 @@ class OrderEditApplied(OrderEditResult):
     def __init__(
         self,
         *,
-        type: str = None,
-        applied_at: datetime.datetime = None,
-        excerpt_before_edit: "OrderExcerpt" = None,
-        excerpt_after_edit: "OrderExcerpt" = None
+        applied_at: datetime.datetime,
+        excerpt_before_edit: "OrderExcerpt",
+        excerpt_after_edit: "OrderExcerpt"
     ) -> None:
         self.applied_at = applied_at
         self.excerpt_before_edit = excerpt_before_edit
@@ -2371,7 +2219,7 @@ class OrderEditApplied(OrderEditResult):
 
 
 class OrderEditNotProcessed(OrderEditResult):
-    def __init__(self, *, type: str = None) -> None:
+    def __init__(self) -> None:
         super().__init__(type="NotProcessed")
 
     def __repr__(self) -> str:
@@ -2382,9 +2230,7 @@ class OrderEditPreviewFailure(OrderEditResult):
     #: List of :class:`commercetools.types.ErrorObject`
     errors: typing.List["ErrorObject"]
 
-    def __init__(
-        self, *, type: str = None, errors: typing.List["ErrorObject"] = None
-    ) -> None:
+    def __init__(self, *, errors: typing.List["ErrorObject"]) -> None:
         self.errors = errors
         super().__init__(type="PreviewFailure")
 
@@ -2399,11 +2245,7 @@ class OrderEditPreviewSuccess(OrderEditResult):
     message_payloads: typing.List["MessagePayload"]
 
     def __init__(
-        self,
-        *,
-        type: str = None,
-        preview: "StagedOrder" = None,
-        message_payloads: typing.List["MessagePayload"] = None
+        self, *, preview: "StagedOrder", message_payloads: typing.List["MessagePayload"]
     ) -> None:
         self.preview = preview
         self.message_payloads = message_payloads
@@ -2421,9 +2263,7 @@ class OrderEditSetCommentAction(OrderEditUpdateAction):
     #: Optional :class:`str`
     comment: typing.Optional[str]
 
-    def __init__(
-        self, *, action: str = None, comment: typing.Optional[str] = None
-    ) -> None:
+    def __init__(self, *, comment: typing.Optional[str] = None) -> None:
         self.comment = comment
         super().__init__(action="setComment")
 
@@ -2440,13 +2280,7 @@ class OrderEditSetCustomFieldAction(OrderEditUpdateAction):
     #: Optional :class:`typing.Any`
     value: typing.Optional[typing.Any]
 
-    def __init__(
-        self,
-        *,
-        action: str = None,
-        name: str = None,
-        value: typing.Optional[typing.Any] = None
-    ) -> None:
+    def __init__(self, *, name: str, value: typing.Optional[typing.Any] = None) -> None:
         self.name = name
         self.value = value
         super().__init__(action="setCustomField")
@@ -2468,7 +2302,6 @@ class OrderEditSetCustomTypeAction(OrderEditUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
         type: typing.Optional["TypeResourceIdentifier"] = None,
         fields: typing.Optional[object] = None
     ) -> None:
@@ -2488,7 +2321,7 @@ class OrderEditSetKeyAction(OrderEditUpdateAction):
     #: Optional :class:`str`
     key: typing.Optional[str]
 
-    def __init__(self, *, action: str = None, key: typing.Optional[str] = None) -> None:
+    def __init__(self, *, key: typing.Optional[str] = None) -> None:
         self.key = key
         super().__init__(action="setKey")
 
@@ -2501,10 +2334,7 @@ class OrderEditSetStagedActionsAction(OrderEditUpdateAction):
     staged_actions: typing.List["StagedOrderUpdateAction"]
 
     def __init__(
-        self,
-        *,
-        action: str = None,
-        staged_actions: typing.List["StagedOrderUpdateAction"] = None
+        self, *, staged_actions: typing.List["StagedOrderUpdateAction"]
     ) -> None:
         self.staged_actions = staged_actions
         super().__init__(action="setStagedActions")

--- a/src/commercetools/types/_payment.py
+++ b/src/commercetools/types/_payment.py
@@ -108,25 +108,25 @@ class Payment(BaseResource):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        amount_planned: "TypedMoney",
+        payment_method_info: "PaymentMethodInfo",
+        payment_status: "PaymentStatus",
+        transactions: typing.List["Transaction"],
+        interface_interactions: typing.List["CustomFields"],
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
         customer: typing.Optional["CustomerReference"] = None,
         anonymous_id: typing.Optional[str] = None,
         external_id: typing.Optional[str] = None,
         interface_id: typing.Optional[str] = None,
-        amount_planned: "TypedMoney" = None,
         amount_authorized: typing.Optional["TypedMoney"] = None,
         authorized_until: typing.Optional[str] = None,
         amount_paid: typing.Optional["TypedMoney"] = None,
         amount_refunded: typing.Optional["TypedMoney"] = None,
-        payment_method_info: "PaymentMethodInfo" = None,
-        payment_status: "PaymentStatus" = None,
-        transactions: typing.List["Transaction"] = None,
-        interface_interactions: typing.List["CustomFields"] = None,
         custom: typing.Optional["CustomFields"] = None,
         key: typing.Optional[str] = None
     ) -> None:
@@ -222,11 +222,11 @@ class PaymentDraft(_BaseType):
     def __init__(
         self,
         *,
+        amount_planned: "Money",
         customer: typing.Optional["CustomerResourceIdentifier"] = None,
         anonymous_id: typing.Optional[str] = None,
         external_id: typing.Optional[str] = None,
         interface_id: typing.Optional[str] = None,
-        amount_planned: "Money" = None,
         amount_authorized: typing.Optional["Money"] = None,
         authorized_until: typing.Optional[str] = None,
         amount_paid: typing.Optional["Money"] = None,
@@ -323,11 +323,11 @@ class PaymentPagedQueryResponse(_BaseType):
     def __init__(
         self,
         *,
-        limit: int = None,
-        count: int = None,
-        total: typing.Optional[int] = None,
-        offset: int = None,
-        results: typing.Sequence["Payment"] = None
+        limit: int,
+        count: int,
+        offset: int,
+        results: typing.Sequence["Payment"],
+        total: typing.Optional[int] = None
     ) -> None:
         self.limit = limit
         self.count = count
@@ -347,13 +347,7 @@ class PaymentReference(Reference):
     #: Optional :class:`commercetools.types.Payment`
     obj: typing.Optional["Payment"]
 
-    def __init__(
-        self,
-        *,
-        type_id: "ReferenceTypeId" = None,
-        id: str = None,
-        obj: typing.Optional["Payment"] = None
-    ) -> None:
+    def __init__(self, *, id: str, obj: typing.Optional["Payment"] = None) -> None:
         self.obj = obj
         super().__init__(type_id=ReferenceTypeId.PAYMENT, id=id)
 
@@ -367,11 +361,7 @@ class PaymentReference(Reference):
 
 class PaymentResourceIdentifier(ResourceIdentifier):
     def __init__(
-        self,
-        *,
-        type_id: typing.Optional["ReferenceTypeId"] = None,
-        id: typing.Optional[str] = None,
-        key: typing.Optional[str] = None
+        self, *, id: typing.Optional[str] = None, key: typing.Optional[str] = None
     ) -> None:
         super().__init__(type_id=ReferenceTypeId.PAYMENT, id=id, key=key)
 
@@ -445,7 +435,7 @@ class PaymentUpdate(_BaseType):
     #: :class:`list`
     actions: list
 
-    def __init__(self, *, version: int = None, actions: list = None) -> None:
+    def __init__(self, *, version: int, actions: list) -> None:
         self.version = version
         self.actions = actions
         super().__init__()
@@ -458,7 +448,7 @@ class PaymentUpdateAction(_BaseType):
     #: :class:`str`
     action: str
 
-    def __init__(self, *, action: str = None) -> None:
+    def __init__(self, *, action: str) -> None:
         self.action = action
         super().__init__()
 
@@ -483,10 +473,10 @@ class Transaction(_BaseType):
     def __init__(
         self,
         *,
-        id: str = None,
+        id: str,
+        type: "TransactionType",
+        amount: "TypedMoney",
         timestamp: typing.Optional[datetime.datetime] = None,
-        type: "TransactionType" = None,
-        amount: "TypedMoney" = None,
         interaction_id: typing.Optional[str] = None,
         state: typing.Optional["TransactionState"] = None
     ) -> None:
@@ -527,9 +517,9 @@ class TransactionDraft(_BaseType):
     def __init__(
         self,
         *,
+        type: "TransactionType",
+        amount: "Money",
         timestamp: typing.Optional[datetime.datetime] = None,
-        type: "TransactionType" = None,
-        amount: "Money" = None,
         interaction_id: typing.Optional[str] = None,
         state: typing.Optional["TransactionState"] = None
     ) -> None:
@@ -571,8 +561,7 @@ class PaymentAddInterfaceInteractionAction(PaymentUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
-        type: "TypeResourceIdentifier" = None,
+        type: "TypeResourceIdentifier",
         fields: typing.Optional["FieldContainer"] = None
     ) -> None:
         self.type = type
@@ -591,9 +580,7 @@ class PaymentAddTransactionAction(PaymentUpdateAction):
     #: :class:`commercetools.types.TransactionDraft`
     transaction: "TransactionDraft"
 
-    def __init__(
-        self, *, action: str = None, transaction: "TransactionDraft" = None
-    ) -> None:
+    def __init__(self, *, transaction: "TransactionDraft") -> None:
         self.transaction = transaction
         super().__init__(action="addTransaction")
 
@@ -608,7 +595,7 @@ class PaymentChangeAmountPlannedAction(PaymentUpdateAction):
     #: :class:`commercetools.types.Money`
     amount: "Money"
 
-    def __init__(self, *, action: str = None, amount: "Money" = None) -> None:
+    def __init__(self, *, amount: "Money") -> None:
         self.amount = amount
         super().__init__(action="changeAmountPlanned")
 
@@ -625,13 +612,7 @@ class PaymentChangeTransactionInteractionIdAction(PaymentUpdateAction):
     #: :class:`str` `(Named` ``interactionId`` `in Commercetools)`
     interaction_id: str
 
-    def __init__(
-        self,
-        *,
-        action: str = None,
-        transaction_id: str = None,
-        interaction_id: str = None
-    ) -> None:
+    def __init__(self, *, transaction_id: str, interaction_id: str) -> None:
         self.transaction_id = transaction_id
         self.interaction_id = interaction_id
         super().__init__(action="changeTransactionInteractionId")
@@ -649,13 +630,7 @@ class PaymentChangeTransactionStateAction(PaymentUpdateAction):
     #: :class:`commercetools.types.TransactionState`
     state: "TransactionState"
 
-    def __init__(
-        self,
-        *,
-        action: str = None,
-        transaction_id: str = None,
-        state: "TransactionState" = None
-    ) -> None:
+    def __init__(self, *, transaction_id: str, state: "TransactionState") -> None:
         self.transaction_id = transaction_id
         self.state = state
         super().__init__(action="changeTransactionState")
@@ -673,13 +648,7 @@ class PaymentChangeTransactionTimestampAction(PaymentUpdateAction):
     #: :class:`datetime.datetime`
     timestamp: datetime.datetime
 
-    def __init__(
-        self,
-        *,
-        action: str = None,
-        transaction_id: str = None,
-        timestamp: datetime.datetime = None
-    ) -> None:
+    def __init__(self, *, transaction_id: str, timestamp: datetime.datetime) -> None:
         self.transaction_id = transaction_id
         self.timestamp = timestamp
         super().__init__(action="changeTransactionTimestamp")
@@ -695,9 +664,7 @@ class PaymentSetAmountPaidAction(PaymentUpdateAction):
     #: Optional :class:`commercetools.types.Money`
     amount: typing.Optional["Money"]
 
-    def __init__(
-        self, *, action: str = None, amount: typing.Optional["Money"] = None
-    ) -> None:
+    def __init__(self, *, amount: typing.Optional["Money"] = None) -> None:
         self.amount = amount
         super().__init__(action="setAmountPaid")
 
@@ -712,9 +679,7 @@ class PaymentSetAmountRefundedAction(PaymentUpdateAction):
     #: Optional :class:`commercetools.types.Money`
     amount: typing.Optional["Money"]
 
-    def __init__(
-        self, *, action: str = None, amount: typing.Optional["Money"] = None
-    ) -> None:
+    def __init__(self, *, amount: typing.Optional["Money"] = None) -> None:
         self.amount = amount
         super().__init__(action="setAmountRefunded")
 
@@ -729,9 +694,7 @@ class PaymentSetAnonymousIdAction(PaymentUpdateAction):
     #: Optional :class:`str` `(Named` ``anonymousId`` `in Commercetools)`
     anonymous_id: typing.Optional[str]
 
-    def __init__(
-        self, *, action: str = None, anonymous_id: typing.Optional[str] = None
-    ) -> None:
+    def __init__(self, *, anonymous_id: typing.Optional[str] = None) -> None:
         self.anonymous_id = anonymous_id
         super().__init__(action="setAnonymousId")
 
@@ -751,7 +714,6 @@ class PaymentSetAuthorizationAction(PaymentUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
         amount: typing.Optional["Money"] = None,
         until: typing.Optional[datetime.datetime] = None
     ) -> None:
@@ -773,13 +735,7 @@ class PaymentSetCustomFieldAction(PaymentUpdateAction):
     #: Optional :class:`typing.Any`
     value: typing.Optional[typing.Any]
 
-    def __init__(
-        self,
-        *,
-        action: str = None,
-        name: str = None,
-        value: typing.Optional[typing.Any] = None
-    ) -> None:
+    def __init__(self, *, name: str, value: typing.Optional[typing.Any] = None) -> None:
         self.name = name
         self.value = value
         super().__init__(action="setCustomField")
@@ -801,7 +757,6 @@ class PaymentSetCustomTypeAction(PaymentUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
         type: typing.Optional["TypeResourceIdentifier"] = None,
         fields: typing.Optional["FieldContainer"] = None
     ) -> None:
@@ -822,10 +777,7 @@ class PaymentSetCustomerAction(PaymentUpdateAction):
     customer: typing.Optional["CustomerResourceIdentifier"]
 
     def __init__(
-        self,
-        *,
-        action: str = None,
-        customer: typing.Optional["CustomerResourceIdentifier"] = None
+        self, *, customer: typing.Optional["CustomerResourceIdentifier"] = None
     ) -> None:
         self.customer = customer
         super().__init__(action="setCustomer")
@@ -841,9 +793,7 @@ class PaymentSetExternalIdAction(PaymentUpdateAction):
     #: Optional :class:`str` `(Named` ``externalId`` `in Commercetools)`
     external_id: typing.Optional[str]
 
-    def __init__(
-        self, *, action: str = None, external_id: typing.Optional[str] = None
-    ) -> None:
+    def __init__(self, *, external_id: typing.Optional[str] = None) -> None:
         self.external_id = external_id
         super().__init__(action="setExternalId")
 
@@ -858,7 +808,7 @@ class PaymentSetInterfaceIdAction(PaymentUpdateAction):
     #: :class:`str` `(Named` ``interfaceId`` `in Commercetools)`
     interface_id: str
 
-    def __init__(self, *, action: str = None, interface_id: str = None) -> None:
+    def __init__(self, *, interface_id: str) -> None:
         self.interface_id = interface_id
         super().__init__(action="setInterfaceId")
 
@@ -873,7 +823,7 @@ class PaymentSetKeyAction(PaymentUpdateAction):
     #: Optional :class:`str`
     key: typing.Optional[str]
 
-    def __init__(self, *, action: str = None, key: typing.Optional[str] = None) -> None:
+    def __init__(self, *, key: typing.Optional[str] = None) -> None:
         self.key = key
         super().__init__(action="setKey")
 
@@ -885,7 +835,7 @@ class PaymentSetMethodInfoInterfaceAction(PaymentUpdateAction):
     #: :class:`str`
     interface: str
 
-    def __init__(self, *, action: str = None, interface: str = None) -> None:
+    def __init__(self, *, interface: str) -> None:
         self.interface = interface
         super().__init__(action="setMethodInfoInterface")
 
@@ -900,9 +850,7 @@ class PaymentSetMethodInfoMethodAction(PaymentUpdateAction):
     #: Optional :class:`str`
     method: typing.Optional[str]
 
-    def __init__(
-        self, *, action: str = None, method: typing.Optional[str] = None
-    ) -> None:
+    def __init__(self, *, method: typing.Optional[str] = None) -> None:
         self.method = method
         super().__init__(action="setMethodInfoMethod")
 
@@ -917,9 +865,7 @@ class PaymentSetMethodInfoNameAction(PaymentUpdateAction):
     #: Optional :class:`commercetools.types.LocalizedString`
     name: typing.Optional["LocalizedString"]
 
-    def __init__(
-        self, *, action: str = None, name: typing.Optional["LocalizedString"] = None
-    ) -> None:
+    def __init__(self, *, name: typing.Optional["LocalizedString"] = None) -> None:
         self.name = name
         super().__init__(action="setMethodInfoName")
 
@@ -934,9 +880,7 @@ class PaymentSetStatusInterfaceCodeAction(PaymentUpdateAction):
     #: Optional :class:`str` `(Named` ``interfaceCode`` `in Commercetools)`
     interface_code: typing.Optional[str]
 
-    def __init__(
-        self, *, action: str = None, interface_code: typing.Optional[str] = None
-    ) -> None:
+    def __init__(self, *, interface_code: typing.Optional[str] = None) -> None:
         self.interface_code = interface_code
         super().__init__(action="setStatusInterfaceCode")
 
@@ -951,7 +895,7 @@ class PaymentSetStatusInterfaceTextAction(PaymentUpdateAction):
     #: :class:`str` `(Named` ``interfaceText`` `in Commercetools)`
     interface_text: str
 
-    def __init__(self, *, action: str = None, interface_text: str = None) -> None:
+    def __init__(self, *, interface_text: str) -> None:
         self.interface_text = interface_text
         super().__init__(action="setStatusInterfaceText")
 
@@ -969,11 +913,7 @@ class PaymentTransitionStateAction(PaymentUpdateAction):
     force: typing.Optional[bool]
 
     def __init__(
-        self,
-        *,
-        action: str = None,
-        state: "StateResourceIdentifier" = None,
-        force: typing.Optional[bool] = None
+        self, *, state: "StateResourceIdentifier", force: typing.Optional[bool] = None
     ) -> None:
         self.state = state
         self.force = force

--- a/src/commercetools/types/_product.py
+++ b/src/commercetools/types/_product.py
@@ -124,7 +124,7 @@ class Attribute(_BaseType):
     #: :class:`typing.Any`
     value: typing.Any
 
-    def __init__(self, *, name: str = None, value: typing.Any = None) -> None:
+    def __init__(self, *, name: str, value: typing.Any) -> None:
         self.name = name
         self.value = value
         super().__init__()
@@ -152,7 +152,7 @@ class FacetResult(_BaseType):
     #: :class:`commercetools.types.FacetTypes`
     type: "FacetTypes"
 
-    def __init__(self, *, type: "FacetTypes" = None) -> None:
+    def __init__(self, *, type: "FacetTypes") -> None:
         self.type = type
         super().__init__()
 
@@ -185,16 +185,16 @@ class FacetResultRange(_BaseType):
     def __init__(
         self,
         *,
-        from_: int = None,
-        from_str: str = None,
-        to: int = None,
-        to_str: str = None,
-        count: int = None,
+        from_: int,
+        from_str: str,
+        to: int,
+        to_str: str,
+        count: int,
+        total: int,
+        min: int,
+        max: int,
+        mean: int,
         product_count: typing.Optional[int] = None,
-        total: int = None,
-        min: int = None,
-        max: int = None,
-        mean: int = None,
     ) -> None:
         self.from_ = from_
         self.from_str = from_str
@@ -237,8 +237,8 @@ class FacetResultTerm(_BaseType):
     def __init__(
         self,
         *,
-        term: typing.Any = None,
-        count: int = None,
+        term: typing.Any,
+        count: int,
         product_count: typing.Optional[int] = None,
     ) -> None:
         self.term = term
@@ -294,15 +294,15 @@ class Product(BaseResource):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        product_type: "ProductTypeReference",
+        master_data: "ProductCatalogData",
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
         key: typing.Optional[str] = None,
-        product_type: "ProductTypeReference" = None,
-        master_data: "ProductCatalogData" = None,
         tax_category: typing.Optional["TaxCategoryReference"] = None,
         state: typing.Optional["StateReference"] = None,
         review_rating_statistics: typing.Optional["ReviewRatingStatistics"] = None,
@@ -359,10 +359,10 @@ class ProductCatalogData(_BaseType):
     def __init__(
         self,
         *,
-        published: bool = None,
-        current: "ProductData" = None,
-        staged: "ProductData" = None,
-        has_staged_changes: bool = None,
+        published: bool,
+        current: "ProductData",
+        staged: "ProductData",
+        has_staged_changes: bool,
     ) -> None:
         self.published = published
         self.current = current
@@ -404,17 +404,17 @@ class ProductData(_BaseType):
     def __init__(
         self,
         *,
-        name: "LocalizedString" = None,
-        categories: typing.List["CategoryReference"] = None,
+        name: "LocalizedString",
+        categories: typing.List["CategoryReference"],
+        slug: "LocalizedString",
+        master_variant: "ProductVariant",
+        variants: typing.List["ProductVariant"],
+        search_keywords: "SearchKeywords",
         category_order_hints: typing.Optional["CategoryOrderHints"] = None,
         description: typing.Optional["LocalizedString"] = None,
-        slug: "LocalizedString" = None,
         meta_title: typing.Optional["LocalizedString"] = None,
         meta_description: typing.Optional["LocalizedString"] = None,
         meta_keywords: typing.Optional["LocalizedString"] = None,
-        master_variant: "ProductVariant" = None,
-        variants: typing.List["ProductVariant"] = None,
-        search_keywords: "SearchKeywords" = None,
     ) -> None:
         self.name = name
         self.categories = categories
@@ -485,9 +485,9 @@ class ProductDraft(_BaseType):
     def __init__(
         self,
         *,
-        product_type: "ProductTypeResourceIdentifier" = None,
-        name: "LocalizedString" = None,
-        slug: "LocalizedString" = None,
+        product_type: "ProductTypeResourceIdentifier",
+        name: "LocalizedString",
+        slug: "LocalizedString",
         key: typing.Optional[str] = None,
         description: typing.Optional["LocalizedString"] = None,
         categories: typing.Optional[typing.List["CategoryResourceIdentifier"]] = None,
@@ -559,11 +559,11 @@ class ProductPagedQueryResponse(_BaseType):
     def __init__(
         self,
         *,
-        limit: int = None,
-        count: int = None,
+        limit: int,
+        count: int,
+        offset: int,
+        results: typing.Sequence["Product"],
         total: typing.Optional[int] = None,
-        offset: int = None,
-        results: typing.Sequence["Product"] = None,
     ) -> None:
         self.limit = limit
         self.count = count
@@ -624,16 +624,18 @@ class ProductProjection(BaseResource):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        product_type: "ProductTypeReference",
+        name: "LocalizedString",
+        slug: "LocalizedString",
+        categories: typing.List["CategoryReference"],
+        master_variant: "ProductVariant",
+        variants: typing.List["ProductVariant"],
         key: typing.Optional[str] = None,
-        product_type: "ProductTypeReference" = None,
-        name: "LocalizedString" = None,
         description: typing.Optional["LocalizedString"] = None,
-        slug: "LocalizedString" = None,
-        categories: typing.List["CategoryReference"] = None,
         category_order_hints: typing.Optional["CategoryOrderHints"] = None,
         meta_title: typing.Optional["LocalizedString"] = None,
         meta_description: typing.Optional["LocalizedString"] = None,
@@ -641,8 +643,6 @@ class ProductProjection(BaseResource):
         search_keywords: typing.Optional["SearchKeywords"] = None,
         has_staged_changes: typing.Optional[bool] = None,
         published: typing.Optional[bool] = None,
-        master_variant: "ProductVariant" = None,
-        variants: typing.List["ProductVariant"] = None,
         tax_category: typing.Optional["TaxCategoryReference"] = None,
         state: typing.Optional["StateReference"] = None,
         review_rating_statistics: typing.Optional["ReviewRatingStatistics"] = None,
@@ -719,11 +719,11 @@ class ProductProjectionPagedQueryResponse(_BaseType):
     def __init__(
         self,
         *,
-        limit: int = None,
-        count: int = None,
+        limit: int,
+        count: int,
+        offset: int,
+        results: typing.Sequence["ProductProjection"],
         total: typing.Optional[int] = None,
-        offset: int = None,
-        results: typing.Sequence["ProductProjection"] = None,
     ) -> None:
         self.limit = limit
         self.count = count
@@ -754,11 +754,11 @@ class ProductProjectionPagedSearchResponse(_BaseType):
     def __init__(
         self,
         *,
-        count: int = None,
+        count: int,
+        offset: int,
+        results: typing.List["ProductProjection"],
+        facets: "FacetResults",
         total: typing.Optional[int] = None,
-        offset: int = None,
-        results: typing.List["ProductProjection"] = None,
-        facets: "FacetResults" = None,
     ) -> None:
         self.count = count
         self.total = total
@@ -778,13 +778,7 @@ class ProductReference(Reference):
     #: Optional :class:`commercetools.types.Product`
     obj: typing.Optional["Product"]
 
-    def __init__(
-        self,
-        *,
-        type_id: "ReferenceTypeId" = None,
-        id: str = None,
-        obj: typing.Optional["Product"] = None,
-    ) -> None:
+    def __init__(self, *, id: str, obj: typing.Optional["Product"] = None) -> None:
         self.obj = obj
         super().__init__(type_id=ReferenceTypeId.PRODUCT, id=id)
 
@@ -798,11 +792,7 @@ class ProductReference(Reference):
 
 class ProductResourceIdentifier(ResourceIdentifier):
     def __init__(
-        self,
-        *,
-        type_id: typing.Optional["ReferenceTypeId"] = None,
-        id: typing.Optional[str] = None,
-        key: typing.Optional[str] = None,
+        self, *, id: typing.Optional[str] = None, key: typing.Optional[str] = None
     ) -> None:
         super().__init__(type_id=ReferenceTypeId.PRODUCT, id=id, key=key)
 
@@ -820,7 +810,7 @@ class ProductUpdate(_BaseType):
     #: :class:`list`
     actions: list
 
-    def __init__(self, *, version: int = None, actions: list = None) -> None:
+    def __init__(self, *, version: int, actions: list) -> None:
         self.version = version
         self.actions = actions
         super().__init__()
@@ -833,7 +823,7 @@ class ProductUpdateAction(_BaseType):
     #: :class:`str`
     action: str
 
-    def __init__(self, *, action: str = None) -> None:
+    def __init__(self, *, action: str) -> None:
         self.action = action
         super().__init__()
 
@@ -870,7 +860,7 @@ class ProductVariant(_BaseType):
     def __init__(
         self,
         *,
-        id: int = None,
+        id: int,
         sku: typing.Optional[str] = None,
         key: typing.Optional[str] = None,
         prices: typing.Optional[typing.List["Price"]] = None,
@@ -1044,7 +1034,7 @@ class SearchKeyword(_BaseType):
     def __init__(
         self,
         *,
-        text: str = None,
+        text: str,
         suggest_tokenizer: typing.Optional["SuggestTokenizer"] = None,
     ) -> None:
         self.text = text
@@ -1067,7 +1057,7 @@ class SuggestTokenizer(_BaseType):
     #: :class:`str`
     type: str
 
-    def __init__(self, *, type: str = None) -> None:
+    def __init__(self, *, type: str) -> None:
         self.type = type
         super().__init__()
 
@@ -1079,7 +1069,7 @@ class Suggestion(_BaseType):
     #: :class:`str`
     text: str
 
-    def __init__(self, *, text: str = None) -> None:
+    def __init__(self, *, text: str) -> None:
         self.text = text
         super().__init__()
 
@@ -1107,7 +1097,7 @@ class CustomTokenizer(SuggestTokenizer):
     #: List of :class:`str`
     inputs: typing.List[str]
 
-    def __init__(self, *, type: str = None, inputs: typing.List[str] = None) -> None:
+    def __init__(self, *, inputs: typing.List[str]) -> None:
         self.inputs = inputs
         super().__init__(type="custom")
 
@@ -1122,11 +1112,7 @@ class FilteredFacetResult(FacetResult):
     product_count: typing.Optional[int]
 
     def __init__(
-        self,
-        *,
-        type: "FacetTypes" = None,
-        count: int = None,
-        product_count: typing.Optional[int] = None,
+        self, *, count: int, product_count: typing.Optional[int] = None
     ) -> None:
         self.count = count
         self.product_count = product_count
@@ -1155,11 +1141,10 @@ class ProductAddAssetAction(ProductUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
+        asset: "AssetDraft",
         variant_id: typing.Optional[int] = None,
         sku: typing.Optional[str] = None,
         staged: typing.Optional[bool] = None,
-        asset: "AssetDraft" = None,
         position: typing.Optional[int] = None,
     ) -> None:
         self.variant_id = variant_id
@@ -1196,10 +1181,9 @@ class ProductAddExternalImageAction(ProductUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
+        image: "Image",
         variant_id: typing.Optional[int] = None,
         sku: typing.Optional[str] = None,
-        image: "Image" = None,
         staged: typing.Optional[bool] = None,
     ) -> None:
         self.variant_id = variant_id
@@ -1228,10 +1212,9 @@ class ProductAddPriceAction(ProductUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
+        price: "PriceDraft",
         variant_id: typing.Optional[int] = None,
         sku: typing.Optional[str] = None,
-        price: "PriceDraft" = None,
         staged: typing.Optional[bool] = None,
     ) -> None:
         self.variant_id = variant_id
@@ -1258,8 +1241,7 @@ class ProductAddToCategoryAction(ProductUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
-        category: "CategoryResourceIdentifier" = None,
+        category: "CategoryResourceIdentifier",
         order_hint: typing.Optional[str] = None,
         staged: typing.Optional[bool] = None,
     ) -> None:
@@ -1294,7 +1276,6 @@ class ProductAddVariantAction(ProductUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
         sku: typing.Optional[str] = None,
         key: typing.Optional[str] = None,
         prices: typing.Optional[typing.List["PriceDraft"]] = None,
@@ -1345,13 +1326,12 @@ class ProductChangeAssetNameAction(ProductUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
+        name: "LocalizedString",
         variant_id: typing.Optional[int] = None,
         sku: typing.Optional[str] = None,
         staged: typing.Optional[bool] = None,
         asset_id: typing.Optional[str] = None,
         asset_key: typing.Optional[str] = None,
-        name: "LocalizedString" = None,
     ) -> None:
         self.variant_id = variant_id
         self.sku = sku
@@ -1389,11 +1369,10 @@ class ProductChangeAssetOrderAction(ProductUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
+        asset_order: typing.List[str],
         variant_id: typing.Optional[int] = None,
         sku: typing.Optional[str] = None,
         staged: typing.Optional[bool] = None,
-        asset_order: typing.List[str] = None,
     ) -> None:
         self.variant_id = variant_id
         self.sku = sku
@@ -1419,7 +1398,6 @@ class ProductChangeMasterVariantAction(ProductUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
         variant_id: typing.Optional[int] = None,
         sku: typing.Optional[str] = None,
         staged: typing.Optional[bool] = None,
@@ -1443,11 +1421,7 @@ class ProductChangeNameAction(ProductUpdateAction):
     staged: typing.Optional[bool]
 
     def __init__(
-        self,
-        *,
-        action: str = None,
-        name: "LocalizedString" = None,
-        staged: typing.Optional[bool] = None,
+        self, *, name: "LocalizedString", staged: typing.Optional[bool] = None
     ) -> None:
         self.name = name
         self.staged = staged
@@ -1472,9 +1446,8 @@ class ProductChangePriceAction(ProductUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
-        price_id: str = None,
-        price: "PriceDraft" = None,
+        price_id: str,
+        price: "PriceDraft",
         staged: typing.Optional[bool] = None,
     ) -> None:
         self.price_id = price_id
@@ -1496,11 +1469,7 @@ class ProductChangeSlugAction(ProductUpdateAction):
     staged: typing.Optional[bool]
 
     def __init__(
-        self,
-        *,
-        action: str = None,
-        slug: "LocalizedString" = None,
-        staged: typing.Optional[bool] = None,
+        self, *, slug: "LocalizedString", staged: typing.Optional[bool] = None
     ) -> None:
         self.slug = slug
         self.staged = staged
@@ -1520,13 +1489,7 @@ class ProductLegacySetSkuAction(ProductUpdateAction):
     #: :class:`int` `(Named` ``variantId`` `in Commercetools)`
     variant_id: int
 
-    def __init__(
-        self,
-        *,
-        action: str = None,
-        sku: typing.Optional[str] = None,
-        variant_id: int = None,
-    ) -> None:
+    def __init__(self, *, variant_id: int, sku: typing.Optional[str] = None) -> None:
         self.sku = sku
         self.variant_id = variant_id
         super().__init__(action="legacySetSku")
@@ -1554,11 +1517,10 @@ class ProductMoveImageToPositionAction(ProductUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
+        image_url: str,
+        position: int,
         variant_id: typing.Optional[int] = None,
         sku: typing.Optional[str] = None,
-        image_url: str = None,
-        position: int = None,
         staged: typing.Optional[bool] = None,
     ) -> None:
         self.variant_id = variant_id
@@ -1586,12 +1548,7 @@ class ProductPublishAction(ProductUpdateAction):
     #: Optional :class:`commercetools.types.ProductPublishScope`
     scope: typing.Optional["ProductPublishScope"]
 
-    def __init__(
-        self,
-        *,
-        action: str = None,
-        scope: typing.Optional["ProductPublishScope"] = None,
-    ) -> None:
+    def __init__(self, *, scope: typing.Optional["ProductPublishScope"] = None) -> None:
         self.scope = scope
         super().__init__(action="publish")
 
@@ -1614,7 +1571,6 @@ class ProductRemoveAssetAction(ProductUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
         variant_id: typing.Optional[int] = None,
         sku: typing.Optional[str] = None,
         staged: typing.Optional[bool] = None,
@@ -1651,8 +1607,7 @@ class ProductRemoveFromCategoryAction(ProductUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
-        category: "CategoryResourceIdentifier" = None,
+        category: "CategoryResourceIdentifier",
         staged: typing.Optional[bool] = None,
     ) -> None:
         self.category = category
@@ -1680,10 +1635,9 @@ class ProductRemoveImageAction(ProductUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
+        image_url: str,
         variant_id: typing.Optional[int] = None,
         sku: typing.Optional[str] = None,
-        image_url: str = None,
         staged: typing.Optional[bool] = None,
     ) -> None:
         self.variant_id = variant_id
@@ -1705,13 +1659,7 @@ class ProductRemovePriceAction(ProductUpdateAction):
     #: Optional :class:`bool`
     staged: typing.Optional[bool]
 
-    def __init__(
-        self,
-        *,
-        action: str = None,
-        price_id: str = None,
-        staged: typing.Optional[bool] = None,
-    ) -> None:
+    def __init__(self, *, price_id: str, staged: typing.Optional[bool] = None) -> None:
         self.price_id = price_id
         self.staged = staged
         super().__init__(action="removePrice")
@@ -1735,7 +1683,6 @@ class ProductRemoveVariantAction(ProductUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
         id: typing.Optional[int] = None,
         sku: typing.Optional[str] = None,
         staged: typing.Optional[bool] = None,
@@ -1755,7 +1702,7 @@ class ProductRemoveVariantAction(ProductUpdateAction):
 
 
 class ProductRevertStagedChangesAction(ProductUpdateAction):
-    def __init__(self, *, action: str = None) -> None:
+    def __init__(self) -> None:
         super().__init__(action="revertStagedChanges")
 
     def __repr__(self) -> str:
@@ -1766,7 +1713,7 @@ class ProductRevertStagedVariantChangesAction(ProductUpdateAction):
     #: :class:`int` `(Named` ``variantId`` `in Commercetools)`
     variant_id: int
 
-    def __init__(self, *, action: str = None, variant_id: int = None) -> None:
+    def __init__(self, *, variant_id: int) -> None:
         self.variant_id = variant_id
         super().__init__(action="revertStagedVariantChanges")
 
@@ -1796,13 +1743,12 @@ class ProductSetAssetCustomFieldAction(ProductUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
+        name: str,
         variant_id: typing.Optional[int] = None,
         sku: typing.Optional[str] = None,
         staged: typing.Optional[bool] = None,
         asset_id: typing.Optional[str] = None,
         asset_key: typing.Optional[str] = None,
-        name: str = None,
         value: typing.Optional[typing.Any] = None,
     ) -> None:
         self.variant_id = variant_id
@@ -1849,7 +1795,6 @@ class ProductSetAssetCustomTypeAction(ProductUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
         variant_id: typing.Optional[int] = None,
         sku: typing.Optional[str] = None,
         staged: typing.Optional[bool] = None,
@@ -1900,7 +1845,6 @@ class ProductSetAssetDescriptionAction(ProductUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
         variant_id: typing.Optional[int] = None,
         sku: typing.Optional[str] = None,
         staged: typing.Optional[bool] = None,
@@ -1946,11 +1890,10 @@ class ProductSetAssetKeyAction(ProductUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
+        asset_id: str,
         variant_id: typing.Optional[int] = None,
         sku: typing.Optional[str] = None,
         staged: typing.Optional[bool] = None,
-        asset_id: str = None,
         asset_key: typing.Optional[str] = None,
     ) -> None:
         self.variant_id = variant_id
@@ -1991,13 +1934,12 @@ class ProductSetAssetSourcesAction(ProductUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
+        sources: typing.List["AssetSource"],
         variant_id: typing.Optional[int] = None,
         sku: typing.Optional[str] = None,
         staged: typing.Optional[bool] = None,
         asset_id: typing.Optional[str] = None,
         asset_key: typing.Optional[str] = None,
-        sources: typing.List["AssetSource"] = None,
     ) -> None:
         self.variant_id = variant_id
         self.sku = sku
@@ -2039,7 +1981,6 @@ class ProductSetAssetTagsAction(ProductUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
         variant_id: typing.Optional[int] = None,
         sku: typing.Optional[str] = None,
         staged: typing.Optional[bool] = None,
@@ -2085,10 +2026,9 @@ class ProductSetAttributeAction(ProductUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
+        name: str,
         variant_id: typing.Optional[int] = None,
         sku: typing.Optional[str] = None,
-        name: str = None,
         value: typing.Optional[typing.Any] = None,
         staged: typing.Optional[bool] = None,
     ) -> None:
@@ -2124,8 +2064,7 @@ class ProductSetAttributeInAllVariantsAction(ProductUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
-        name: str = None,
+        name: str,
         value: typing.Optional[typing.Any] = None,
         staged: typing.Optional[bool] = None,
     ) -> None:
@@ -2152,8 +2091,7 @@ class ProductSetCategoryOrderHintAction(ProductUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
-        category_id: str = None,
+        category_id: str,
         order_hint: typing.Optional[str] = None,
         staged: typing.Optional[bool] = None,
     ) -> None:
@@ -2178,7 +2116,6 @@ class ProductSetDescriptionAction(ProductUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
         description: typing.Optional["LocalizedString"] = None,
         staged: typing.Optional[bool] = None,
     ) -> None:
@@ -2205,8 +2142,7 @@ class ProductSetDiscountedPriceAction(ProductUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
-        price_id: str = None,
+        price_id: str,
         staged: typing.Optional[bool] = None,
         discounted: typing.Optional["DiscountedPrice"] = None,
     ) -> None:
@@ -2237,10 +2173,9 @@ class ProductSetImageLabelAction(ProductUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
+        image_url: str,
         sku: typing.Optional[str] = None,
         variant_id: typing.Optional[int] = None,
-        image_url: str = None,
         label: typing.Optional[str] = None,
         staged: typing.Optional[bool] = None,
     ) -> None:
@@ -2269,7 +2204,7 @@ class ProductSetKeyAction(ProductUpdateAction):
     #: Optional :class:`str`
     key: typing.Optional[str]
 
-    def __init__(self, *, action: str = None, key: typing.Optional[str] = None) -> None:
+    def __init__(self, *, key: typing.Optional[str] = None) -> None:
         self.key = key
         super().__init__(action="setKey")
 
@@ -2286,7 +2221,6 @@ class ProductSetMetaDescriptionAction(ProductUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
         meta_description: typing.Optional["LocalizedString"] = None,
         staged: typing.Optional[bool] = None,
     ) -> None:
@@ -2310,7 +2244,6 @@ class ProductSetMetaKeywordsAction(ProductUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
         meta_keywords: typing.Optional["LocalizedString"] = None,
         staged: typing.Optional[bool] = None,
     ) -> None:
@@ -2334,7 +2267,6 @@ class ProductSetMetaTitleAction(ProductUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
         meta_title: typing.Optional["LocalizedString"] = None,
         staged: typing.Optional[bool] = None,
     ) -> None:
@@ -2363,10 +2295,9 @@ class ProductSetPricesAction(ProductUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
+        prices: typing.List["PriceDraft"],
         variant_id: typing.Optional[int] = None,
         sku: typing.Optional[str] = None,
-        prices: typing.List["PriceDraft"] = None,
         staged: typing.Optional[bool] = None,
     ) -> None:
         self.variant_id = variant_id
@@ -2395,10 +2326,9 @@ class ProductSetProductPriceCustomFieldAction(ProductUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
-        price_id: str = None,
+        price_id: str,
+        name: str,
         staged: typing.Optional[bool] = None,
-        name: str = None,
         value: typing.Optional[typing.Any] = None,
     ) -> None:
         self.price_id = price_id
@@ -2427,8 +2357,7 @@ class ProductSetProductPriceCustomTypeAction(ProductUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
-        price_id: str = None,
+        price_id: str,
         staged: typing.Optional[bool] = None,
         type: typing.Optional["TypeResourceIdentifier"] = None,
         fields: typing.Optional["FieldContainer"] = None,
@@ -2459,7 +2388,6 @@ class ProductSetProductVariantKeyAction(ProductUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
         variant_id: typing.Optional[int] = None,
         sku: typing.Optional[str] = None,
         key: typing.Optional[str] = None,
@@ -2485,11 +2413,7 @@ class ProductSetSearchKeywordsAction(ProductUpdateAction):
     staged: typing.Optional[bool]
 
     def __init__(
-        self,
-        *,
-        action: str = None,
-        search_keywords: "SearchKeywords" = None,
-        staged: typing.Optional[bool] = None,
+        self, *, search_keywords: "SearchKeywords", staged: typing.Optional[bool] = None
     ) -> None:
         self.search_keywords = search_keywords
         self.staged = staged
@@ -2513,8 +2437,7 @@ class ProductSetSkuAction(ProductUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
-        variant_id: int = None,
+        variant_id: int,
         sku: typing.Optional[str] = None,
         staged: typing.Optional[bool] = None,
     ) -> None:
@@ -2537,10 +2460,7 @@ class ProductSetTaxCategoryAction(ProductUpdateAction):
     tax_category: typing.Optional["TaxCategoryResourceIdentifier"]
 
     def __init__(
-        self,
-        *,
-        action: str = None,
-        tax_category: typing.Optional["TaxCategoryResourceIdentifier"] = None,
+        self, *, tax_category: typing.Optional["TaxCategoryResourceIdentifier"] = None
     ) -> None:
         self.tax_category = tax_category
         super().__init__(action="setTaxCategory")
@@ -2561,7 +2481,6 @@ class ProductTransitionStateAction(ProductUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
         state: typing.Optional["StateResourceIdentifier"] = None,
         force: typing.Optional[bool] = None,
     ) -> None:
@@ -2578,7 +2497,7 @@ class ProductTransitionStateAction(ProductUpdateAction):
 
 
 class ProductUnpublishAction(ProductUpdateAction):
-    def __init__(self, *, action: str = None) -> None:
+    def __init__(self) -> None:
         super().__init__(action="unpublish")
 
     def __repr__(self) -> str:
@@ -2589,12 +2508,7 @@ class RangeFacetResult(FacetResult):
     #: List of :class:`commercetools.types.FacetResultRange`
     ranges: typing.List["FacetResultRange"]
 
-    def __init__(
-        self,
-        *,
-        type: "FacetTypes" = None,
-        ranges: typing.List["FacetResultRange"] = None,
-    ) -> None:
+    def __init__(self, *, ranges: typing.List["FacetResultRange"]) -> None:
         self.ranges = ranges
         super().__init__(type=FacetTypes.RANGE)
 
@@ -2617,12 +2531,11 @@ class TermFacetResult(FacetResult):
     def __init__(
         self,
         *,
-        type: "FacetTypes" = None,
-        data_type: "TermFacetResultType" = None,
-        missing: int = None,
-        total: int = None,
-        other: int = None,
-        terms: typing.List["FacetResultTerm"] = None,
+        data_type: "TermFacetResultType",
+        missing: int,
+        total: int,
+        other: int,
+        terms: typing.List["FacetResultTerm"],
     ) -> None:
         self.data_type = data_type
         self.missing = missing
@@ -2646,7 +2559,7 @@ class TermFacetResult(FacetResult):
 
 
 class WhitespaceTokenizer(SuggestTokenizer):
-    def __init__(self, *, type: str = None) -> None:
+    def __init__(self) -> None:
         super().__init__(type="whitespace")
 
     def __repr__(self) -> str:

--- a/src/commercetools/types/_product_discount.py
+++ b/src/commercetools/types/_product_discount.py
@@ -86,20 +86,20 @@ class ProductDiscount(BaseResource):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        name: "LocalizedString",
+        value: "ProductDiscountValue",
+        predicate: str,
+        sort_order: str,
+        is_active: bool,
+        references: typing.List["Reference"],
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
-        name: "LocalizedString" = None,
         key: typing.Optional[str] = None,
         description: typing.Optional["LocalizedString"] = None,
-        value: "ProductDiscountValue" = None,
-        predicate: str = None,
-        sort_order: str = None,
-        is_active: bool = None,
-        references: typing.List["Reference"] = None,
         valid_from: typing.Optional[datetime.datetime] = None,
         valid_until: typing.Optional[datetime.datetime] = None
     ) -> None:
@@ -173,13 +173,13 @@ class ProductDiscountDraft(_BaseType):
     def __init__(
         self,
         *,
-        name: "LocalizedString" = None,
+        name: "LocalizedString",
+        value: "ProductDiscountValueDraft",
+        predicate: str,
+        sort_order: str,
+        is_active: bool,
         key: typing.Optional[str] = None,
         description: typing.Optional["LocalizedString"] = None,
-        value: "ProductDiscountValueDraft" = None,
-        predicate: str = None,
-        sort_order: str = None,
-        is_active: bool = None,
         valid_from: typing.Optional[datetime.datetime] = None,
         valid_until: typing.Optional[datetime.datetime] = None
     ) -> None:
@@ -222,12 +222,7 @@ class ProductDiscountMatchQuery(_BaseType):
     price: "QueryPrice"
 
     def __init__(
-        self,
-        *,
-        product_id: str = None,
-        variant_id: int = None,
-        staged: bool = None,
-        price: "QueryPrice" = None
+        self, *, product_id: str, variant_id: int, staged: bool, price: "QueryPrice"
     ) -> None:
         self.product_id = product_id
         self.variant_id = variant_id
@@ -257,11 +252,11 @@ class ProductDiscountPagedQueryResponse(_BaseType):
     def __init__(
         self,
         *,
-        limit: int = None,
-        count: int = None,
-        total: typing.Optional[int] = None,
-        offset: int = None,
-        results: typing.Sequence["ProductDiscount"] = None
+        limit: int,
+        count: int,
+        offset: int,
+        results: typing.Sequence["ProductDiscount"],
+        total: typing.Optional[int] = None
     ) -> None:
         self.limit = limit
         self.count = count
@@ -282,11 +277,7 @@ class ProductDiscountReference(Reference):
     obj: typing.Optional["ProductDiscount"]
 
     def __init__(
-        self,
-        *,
-        type_id: "ReferenceTypeId" = None,
-        id: str = None,
-        obj: typing.Optional["ProductDiscount"] = None
+        self, *, id: str, obj: typing.Optional["ProductDiscount"] = None
     ) -> None:
         self.obj = obj
         super().__init__(type_id=ReferenceTypeId.PRODUCT_DISCOUNT, id=id)
@@ -301,11 +292,7 @@ class ProductDiscountReference(Reference):
 
 class ProductDiscountResourceIdentifier(ResourceIdentifier):
     def __init__(
-        self,
-        *,
-        type_id: typing.Optional["ReferenceTypeId"] = None,
-        id: typing.Optional[str] = None,
-        key: typing.Optional[str] = None
+        self, *, id: typing.Optional[str] = None, key: typing.Optional[str] = None
     ) -> None:
         super().__init__(type_id=ReferenceTypeId.PRODUCT_DISCOUNT, id=id, key=key)
 
@@ -323,7 +310,7 @@ class ProductDiscountUpdate(_BaseType):
     #: :class:`list`
     actions: list
 
-    def __init__(self, *, version: int = None, actions: list = None) -> None:
+    def __init__(self, *, version: int, actions: list) -> None:
         self.version = version
         self.actions = actions
         super().__init__()
@@ -339,7 +326,7 @@ class ProductDiscountUpdateAction(_BaseType):
     #: :class:`str`
     action: str
 
-    def __init__(self, *, action: str = None) -> None:
+    def __init__(self, *, action: str) -> None:
         self.action = action
         super().__init__()
 
@@ -351,7 +338,7 @@ class ProductDiscountValue(_BaseType):
     #: :class:`str`
     type: str
 
-    def __init__(self, *, type: str = None) -> None:
+    def __init__(self, *, type: str) -> None:
         self.type = type
         super().__init__()
 
@@ -363,7 +350,7 @@ class ProductDiscountValueDraft(_BaseType):
     #: :class:`str`
     type: str
 
-    def __init__(self, *, type: str = None) -> None:
+    def __init__(self, *, type: str) -> None:
         self.type = type
         super().__init__()
 
@@ -375,7 +362,7 @@ class ProductDiscountChangeIsActiveAction(ProductDiscountUpdateAction):
     #: :class:`bool` `(Named` ``isActive`` `in Commercetools)`
     is_active: bool
 
-    def __init__(self, *, action: str = None, is_active: bool = None) -> None:
+    def __init__(self, *, is_active: bool) -> None:
         self.is_active = is_active
         super().__init__(action="changeIsActive")
 
@@ -390,7 +377,7 @@ class ProductDiscountChangeNameAction(ProductDiscountUpdateAction):
     #: :class:`commercetools.types.LocalizedString`
     name: "LocalizedString"
 
-    def __init__(self, *, action: str = None, name: "LocalizedString" = None) -> None:
+    def __init__(self, *, name: "LocalizedString") -> None:
         self.name = name
         super().__init__(action="changeName")
 
@@ -405,7 +392,7 @@ class ProductDiscountChangePredicateAction(ProductDiscountUpdateAction):
     #: :class:`str`
     predicate: str
 
-    def __init__(self, *, action: str = None, predicate: str = None) -> None:
+    def __init__(self, *, predicate: str) -> None:
         self.predicate = predicate
         super().__init__(action="changePredicate")
 
@@ -420,7 +407,7 @@ class ProductDiscountChangeSortOrderAction(ProductDiscountUpdateAction):
     #: :class:`str` `(Named` ``sortOrder`` `in Commercetools)`
     sort_order: str
 
-    def __init__(self, *, action: str = None, sort_order: str = None) -> None:
+    def __init__(self, *, sort_order: str) -> None:
         self.sort_order = sort_order
         super().__init__(action="changeSortOrder")
 
@@ -435,9 +422,7 @@ class ProductDiscountChangeValueAction(ProductDiscountUpdateAction):
     #: :class:`commercetools.types.ProductDiscountValueDraft`
     value: "ProductDiscountValueDraft"
 
-    def __init__(
-        self, *, action: str = None, value: "ProductDiscountValueDraft" = None
-    ) -> None:
+    def __init__(self, *, value: "ProductDiscountValueDraft") -> None:
         self.value = value
         super().__init__(action="changeValue")
 
@@ -453,10 +438,7 @@ class ProductDiscountSetDescriptionAction(ProductDiscountUpdateAction):
     description: typing.Optional["LocalizedString"]
 
     def __init__(
-        self,
-        *,
-        action: str = None,
-        description: typing.Optional["LocalizedString"] = None
+        self, *, description: typing.Optional["LocalizedString"] = None
     ) -> None:
         self.description = description
         super().__init__(action="setDescription")
@@ -472,7 +454,7 @@ class ProductDiscountSetKeyAction(ProductDiscountUpdateAction):
     #: Optional :class:`str`
     key: typing.Optional[str]
 
-    def __init__(self, *, action: str = None, key: typing.Optional[str] = None) -> None:
+    def __init__(self, *, key: typing.Optional[str] = None) -> None:
         self.key = key
         super().__init__(action="setKey")
 
@@ -488,10 +470,7 @@ class ProductDiscountSetValidFromAction(ProductDiscountUpdateAction):
     valid_from: typing.Optional[datetime.datetime]
 
     def __init__(
-        self,
-        *,
-        action: str = None,
-        valid_from: typing.Optional[datetime.datetime] = None
+        self, *, valid_from: typing.Optional[datetime.datetime] = None
     ) -> None:
         self.valid_from = valid_from
         super().__init__(action="setValidFrom")
@@ -512,7 +491,6 @@ class ProductDiscountSetValidFromAndUntilAction(ProductDiscountUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
         valid_from: typing.Optional[datetime.datetime] = None,
         valid_until: typing.Optional[datetime.datetime] = None
     ) -> None:
@@ -532,10 +510,7 @@ class ProductDiscountSetValidUntilAction(ProductDiscountUpdateAction):
     valid_until: typing.Optional[datetime.datetime]
 
     def __init__(
-        self,
-        *,
-        action: str = None,
-        valid_until: typing.Optional[datetime.datetime] = None
+        self, *, valid_until: typing.Optional[datetime.datetime] = None
     ) -> None:
         self.valid_until = valid_until
         super().__init__(action="setValidUntil")
@@ -551,9 +526,7 @@ class ProductDiscountValueAbsolute(ProductDiscountValue):
     #: List of :class:`commercetools.types.TypedMoney`
     money: typing.List["TypedMoney"]
 
-    def __init__(
-        self, *, type: str = None, money: typing.List["TypedMoney"] = None
-    ) -> None:
+    def __init__(self, *, money: typing.List["TypedMoney"]) -> None:
         self.money = money
         super().__init__(type="absolute")
 
@@ -568,7 +541,7 @@ class ProductDiscountValueAbsoluteDraft(ProductDiscountValueDraft):
     #: List of :class:`commercetools.types.Money`
     money: typing.List["Money"]
 
-    def __init__(self, *, type: str = None, money: typing.List["Money"] = None) -> None:
+    def __init__(self, *, money: typing.List["Money"]) -> None:
         self.money = money
         super().__init__(type="absolute")
 
@@ -580,7 +553,7 @@ class ProductDiscountValueAbsoluteDraft(ProductDiscountValueDraft):
 
 
 class ProductDiscountValueExternal(ProductDiscountValue):
-    def __init__(self, *, type: str = None) -> None:
+    def __init__(self) -> None:
         super().__init__(type="external")
 
     def __repr__(self) -> str:
@@ -588,7 +561,7 @@ class ProductDiscountValueExternal(ProductDiscountValue):
 
 
 class ProductDiscountValueExternalDraft(ProductDiscountValueDraft):
-    def __init__(self, *, type: str = None) -> None:
+    def __init__(self) -> None:
         super().__init__(type="external")
 
     def __repr__(self) -> str:
@@ -599,7 +572,7 @@ class ProductDiscountValueRelative(ProductDiscountValue):
     #: :class:`int`
     permyriad: int
 
-    def __init__(self, *, type: str = None, permyriad: int = None) -> None:
+    def __init__(self, *, permyriad: int) -> None:
         self.permyriad = permyriad
         super().__init__(type="relative")
 
@@ -614,7 +587,7 @@ class ProductDiscountValueRelativeDraft(ProductDiscountValueDraft):
     #: :class:`int`
     permyriad: int
 
-    def __init__(self, *, type: str = None, permyriad: int = None) -> None:
+    def __init__(self, *, permyriad: int) -> None:
         self.permyriad = permyriad
         super().__init__(type="relative")
 

--- a/src/commercetools/types/_product_type.py
+++ b/src/commercetools/types/_product_type.py
@@ -98,14 +98,14 @@ class AttributeDefinition(_BaseType):
     def __init__(
         self,
         *,
-        type: "AttributeType" = None,
-        name: str = None,
-        label: "LocalizedString" = None,
-        is_required: bool = None,
-        attribute_constraint: "AttributeConstraintEnum" = None,
-        input_tip: typing.Optional["LocalizedString"] = None,
-        input_hint: "TextInputHint" = None,
-        is_searchable: bool = None
+        type: "AttributeType",
+        name: str,
+        label: "LocalizedString",
+        is_required: bool,
+        attribute_constraint: "AttributeConstraintEnum",
+        input_hint: "TextInputHint",
+        is_searchable: bool,
+        input_tip: typing.Optional["LocalizedString"] = None
     ) -> None:
         self.type = type
         self.name = name
@@ -154,10 +154,10 @@ class AttributeDefinitionDraft(_BaseType):
     def __init__(
         self,
         *,
-        type: "AttributeType" = None,
-        name: str = None,
-        label: "LocalizedString" = None,
-        is_required: bool = None,
+        type: "AttributeType",
+        name: str,
+        label: "LocalizedString",
+        is_required: bool,
         attribute_constraint: typing.Optional["AttributeConstraintEnum"] = None,
         input_tip: typing.Optional["LocalizedString"] = None,
         input_hint: typing.Optional["TextInputHint"] = None,
@@ -195,7 +195,7 @@ class AttributeLocalizedEnumValue(_BaseType):
     #: :class:`commercetools.types.LocalizedString`
     label: "LocalizedString"
 
-    def __init__(self, *, key: str = None, label: "LocalizedString" = None) -> None:
+    def __init__(self, *, key: str, label: "LocalizedString") -> None:
         self.key = key
         self.label = label
         super().__init__()
@@ -210,7 +210,7 @@ class AttributePlainEnumValue(_BaseType):
     #: :class:`str`
     label: str
 
-    def __init__(self, *, key: str = None, label: str = None) -> None:
+    def __init__(self, *, key: str, label: str) -> None:
         self.key = key
         self.label = label
         super().__init__()
@@ -223,7 +223,7 @@ class AttributeType(_BaseType):
     #: :class:`str`
     name: str
 
-    def __init__(self, *, name: str = None) -> None:
+    def __init__(self, *, name: str) -> None:
         self.name = name
         super().__init__()
 
@@ -256,15 +256,15 @@ class ProductType(BaseResource):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        name: str,
+        description: str,
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
         key: typing.Optional[str] = None,
-        name: str = None,
-        description: str = None,
         attributes: typing.Optional[typing.List["AttributeDefinition"]] = None
     ) -> None:
         self.id = id
@@ -315,9 +315,9 @@ class ProductTypeDraft(_BaseType):
     def __init__(
         self,
         *,
+        name: str,
+        description: str,
         key: typing.Optional[str] = None,
-        name: str = None,
-        description: str = None,
         attributes: typing.Optional[typing.List["AttributeDefinitionDraft"]] = None
     ) -> None:
         self.key = key
@@ -350,11 +350,11 @@ class ProductTypePagedQueryResponse(_BaseType):
     def __init__(
         self,
         *,
-        limit: int = None,
-        count: int = None,
-        total: typing.Optional[int] = None,
-        offset: int = None,
-        results: typing.Sequence["ProductType"] = None
+        limit: int,
+        count: int,
+        offset: int,
+        results: typing.Sequence["ProductType"],
+        total: typing.Optional[int] = None
     ) -> None:
         self.limit = limit
         self.count = count
@@ -374,13 +374,7 @@ class ProductTypeReference(Reference):
     #: Optional :class:`commercetools.types.ProductType`
     obj: typing.Optional["ProductType"]
 
-    def __init__(
-        self,
-        *,
-        type_id: "ReferenceTypeId" = None,
-        id: str = None,
-        obj: typing.Optional["ProductType"] = None
-    ) -> None:
+    def __init__(self, *, id: str, obj: typing.Optional["ProductType"] = None) -> None:
         self.obj = obj
         super().__init__(type_id=ReferenceTypeId.PRODUCT_TYPE, id=id)
 
@@ -394,11 +388,7 @@ class ProductTypeReference(Reference):
 
 class ProductTypeResourceIdentifier(ResourceIdentifier):
     def __init__(
-        self,
-        *,
-        type_id: typing.Optional["ReferenceTypeId"] = None,
-        id: typing.Optional[str] = None,
-        key: typing.Optional[str] = None
+        self, *, id: typing.Optional[str] = None, key: typing.Optional[str] = None
     ) -> None:
         super().__init__(type_id=ReferenceTypeId.PRODUCT_TYPE, id=id, key=key)
 
@@ -416,7 +406,7 @@ class ProductTypeUpdate(_BaseType):
     #: :class:`list`
     actions: list
 
-    def __init__(self, *, version: int = None, actions: list = None) -> None:
+    def __init__(self, *, version: int, actions: list) -> None:
         self.version = version
         self.actions = actions
         super().__init__()
@@ -432,7 +422,7 @@ class ProductTypeUpdateAction(_BaseType):
     #: :class:`str`
     action: str
 
-    def __init__(self, *, action: str = None) -> None:
+    def __init__(self, *, action: str) -> None:
         self.action = action
         super().__init__()
 
@@ -446,7 +436,7 @@ class TextInputHint(enum.Enum):
 
 
 class AttributeBooleanType(AttributeType):
-    def __init__(self, *, name: str = None) -> None:
+    def __init__(self) -> None:
         super().__init__(name="boolean")
 
     def __repr__(self) -> str:
@@ -454,7 +444,7 @@ class AttributeBooleanType(AttributeType):
 
 
 class AttributeDateTimeType(AttributeType):
-    def __init__(self, *, name: str = None) -> None:
+    def __init__(self) -> None:
         super().__init__(name="datetime")
 
     def __repr__(self) -> str:
@@ -462,7 +452,7 @@ class AttributeDateTimeType(AttributeType):
 
 
 class AttributeDateType(AttributeType):
-    def __init__(self, *, name: str = None) -> None:
+    def __init__(self) -> None:
         super().__init__(name="date")
 
     def __repr__(self) -> str:
@@ -473,9 +463,7 @@ class AttributeEnumType(AttributeType):
     #: List of :class:`commercetools.types.AttributePlainEnumValue`
     values: typing.List["AttributePlainEnumValue"]
 
-    def __init__(
-        self, *, name: str = None, values: typing.List["AttributePlainEnumValue"] = None
-    ) -> None:
+    def __init__(self, *, values: typing.List["AttributePlainEnumValue"]) -> None:
         self.values = values
         super().__init__(name="enum")
 
@@ -484,7 +472,7 @@ class AttributeEnumType(AttributeType):
 
 
 class AttributeLocalizableTextType(AttributeType):
-    def __init__(self, *, name: str = None) -> None:
+    def __init__(self) -> None:
         super().__init__(name="ltext")
 
     def __repr__(self) -> str:
@@ -495,12 +483,7 @@ class AttributeLocalizedEnumType(AttributeType):
     #: List of :class:`commercetools.types.AttributeLocalizedEnumValue`
     values: typing.List["AttributeLocalizedEnumValue"]
 
-    def __init__(
-        self,
-        *,
-        name: str = None,
-        values: typing.List["AttributeLocalizedEnumValue"] = None
-    ) -> None:
+    def __init__(self, *, values: typing.List["AttributeLocalizedEnumValue"]) -> None:
         self.values = values
         super().__init__(name="lenum")
 
@@ -512,7 +495,7 @@ class AttributeLocalizedEnumType(AttributeType):
 
 
 class AttributeMoneyType(AttributeType):
-    def __init__(self, *, name: str = None) -> None:
+    def __init__(self) -> None:
         super().__init__(name="money")
 
     def __repr__(self) -> str:
@@ -523,9 +506,7 @@ class AttributeNestedType(AttributeType):
     #: :class:`commercetools.types.ProductTypeReference` `(Named` ``typeReference`` `in Commercetools)`
     type_reference: "ProductTypeReference"
 
-    def __init__(
-        self, *, name: str = None, type_reference: "ProductTypeReference" = None
-    ) -> None:
+    def __init__(self, *, type_reference: "ProductTypeReference") -> None:
         self.type_reference = type_reference
         super().__init__(name="nested")
 
@@ -537,7 +518,7 @@ class AttributeNestedType(AttributeType):
 
 
 class AttributeNumberType(AttributeType):
-    def __init__(self, *, name: str = None) -> None:
+    def __init__(self) -> None:
         super().__init__(name="number")
 
     def __repr__(self) -> str:
@@ -548,9 +529,7 @@ class AttributeReferenceType(AttributeType):
     #: :class:`commercetools.types.ReferenceTypeId` `(Named` ``referenceTypeId`` `in Commercetools)`
     reference_type_id: "ReferenceTypeId"
 
-    def __init__(
-        self, *, name: str = None, reference_type_id: "ReferenceTypeId" = None
-    ) -> None:
+    def __init__(self, *, reference_type_id: "ReferenceTypeId") -> None:
         self.reference_type_id = reference_type_id
         super().__init__(name="reference")
 
@@ -565,9 +544,7 @@ class AttributeSetType(AttributeType):
     #: :class:`commercetools.types.AttributeType` `(Named` ``elementType`` `in Commercetools)`
     element_type: "AttributeType"
 
-    def __init__(
-        self, *, name: str = None, element_type: "AttributeType" = None
-    ) -> None:
+    def __init__(self, *, element_type: "AttributeType") -> None:
         self.element_type = element_type
         super().__init__(name="set")
 
@@ -579,7 +556,7 @@ class AttributeSetType(AttributeType):
 
 
 class AttributeTextType(AttributeType):
-    def __init__(self, *, name: str = None) -> None:
+    def __init__(self) -> None:
         super().__init__(name="text")
 
     def __repr__(self) -> str:
@@ -587,7 +564,7 @@ class AttributeTextType(AttributeType):
 
 
 class AttributeTimeType(AttributeType):
-    def __init__(self, *, name: str = None) -> None:
+    def __init__(self) -> None:
         super().__init__(name="time")
 
     def __repr__(self) -> str:
@@ -598,9 +575,7 @@ class ProductTypeAddAttributeDefinitionAction(ProductTypeUpdateAction):
     #: :class:`commercetools.types.AttributeDefinitionDraft`
     attribute: "AttributeDefinitionDraft"
 
-    def __init__(
-        self, *, action: str = None, attribute: "AttributeDefinitionDraft" = None
-    ) -> None:
+    def __init__(self, *, attribute: "AttributeDefinitionDraft") -> None:
         self.attribute = attribute
         super().__init__(action="addAttributeDefinition")
 
@@ -618,11 +593,7 @@ class ProductTypeAddLocalizedEnumValueAction(ProductTypeUpdateAction):
     value: "AttributeLocalizedEnumValue"
 
     def __init__(
-        self,
-        *,
-        action: str = None,
-        attribute_name: str = None,
-        value: "AttributeLocalizedEnumValue" = None
+        self, *, attribute_name: str, value: "AttributeLocalizedEnumValue"
     ) -> None:
         self.attribute_name = attribute_name
         self.value = value
@@ -642,11 +613,7 @@ class ProductTypeAddPlainEnumValueAction(ProductTypeUpdateAction):
     value: "AttributePlainEnumValue"
 
     def __init__(
-        self,
-        *,
-        action: str = None,
-        attribute_name: str = None,
-        value: "AttributePlainEnumValue" = None
+        self, *, attribute_name: str, value: "AttributePlainEnumValue"
     ) -> None:
         self.attribute_name = attribute_name
         self.value = value
@@ -666,11 +633,7 @@ class ProductTypeChangeAttributeConstraintAction(ProductTypeUpdateAction):
     new_value: "AttributeConstraintEnumDraft"
 
     def __init__(
-        self,
-        *,
-        action: str = None,
-        attribute_name: str = None,
-        new_value: "AttributeConstraintEnumDraft" = None
+        self, *, attribute_name: str, new_value: "AttributeConstraintEnumDraft"
     ) -> None:
         self.attribute_name = attribute_name
         self.new_value = new_value
@@ -689,13 +652,7 @@ class ProductTypeChangeAttributeNameAction(ProductTypeUpdateAction):
     #: :class:`str` `(Named` ``newAttributeName`` `in Commercetools)`
     new_attribute_name: str
 
-    def __init__(
-        self,
-        *,
-        action: str = None,
-        attribute_name: str = None,
-        new_attribute_name: str = None
-    ) -> None:
+    def __init__(self, *, attribute_name: str, new_attribute_name: str) -> None:
         self.attribute_name = attribute_name
         self.new_attribute_name = new_attribute_name
         super().__init__(action="changeAttributeName")
@@ -711,12 +668,7 @@ class ProductTypeChangeAttributeOrderAction(ProductTypeUpdateAction):
     #: List of :class:`commercetools.types.AttributeDefinition`
     attributes: typing.List["AttributeDefinition"]
 
-    def __init__(
-        self,
-        *,
-        action: str = None,
-        attributes: typing.List["AttributeDefinition"] = None
-    ) -> None:
+    def __init__(self, *, attributes: typing.List["AttributeDefinition"]) -> None:
         self.attributes = attributes
         super().__init__(action="changeAttributeOrder")
 
@@ -731,9 +683,7 @@ class ProductTypeChangeAttributeOrderByNameAction(ProductTypeUpdateAction):
     #: List of :class:`str` `(Named` ``attributeNames`` `in Commercetools)`
     attribute_names: typing.List[str]
 
-    def __init__(
-        self, *, action: str = None, attribute_names: typing.List[str] = None
-    ) -> None:
+    def __init__(self, *, attribute_names: typing.List[str]) -> None:
         self.attribute_names = attribute_names
         super().__init__(action="changeAttributeOrderByName")
 
@@ -748,7 +698,7 @@ class ProductTypeChangeDescriptionAction(ProductTypeUpdateAction):
     #: :class:`str`
     description: str
 
-    def __init__(self, *, action: str = None, description: str = None) -> None:
+    def __init__(self, *, description: str) -> None:
         self.description = description
         super().__init__(action="changeDescription")
 
@@ -767,14 +717,7 @@ class ProductTypeChangeEnumKeyAction(ProductTypeUpdateAction):
     #: :class:`str` `(Named` ``newKey`` `in Commercetools)`
     new_key: str
 
-    def __init__(
-        self,
-        *,
-        action: str = None,
-        attribute_name: str = None,
-        key: str = None,
-        new_key: str = None
-    ) -> None:
+    def __init__(self, *, attribute_name: str, key: str, new_key: str) -> None:
         self.attribute_name = attribute_name
         self.key = key
         self.new_key = new_key
@@ -793,13 +736,7 @@ class ProductTypeChangeInputHintAction(ProductTypeUpdateAction):
     #: :class:`commercetools.types.TextInputHint` `(Named` ``newValue`` `in Commercetools)`
     new_value: "TextInputHint"
 
-    def __init__(
-        self,
-        *,
-        action: str = None,
-        attribute_name: str = None,
-        new_value: "TextInputHint" = None
-    ) -> None:
+    def __init__(self, *, attribute_name: str, new_value: "TextInputHint") -> None:
         self.attribute_name = attribute_name
         self.new_value = new_value
         super().__init__(action="changeInputHint")
@@ -817,13 +754,7 @@ class ProductTypeChangeIsSearchableAction(ProductTypeUpdateAction):
     #: :class:`bool` `(Named` ``isSearchable`` `in Commercetools)`
     is_searchable: bool
 
-    def __init__(
-        self,
-        *,
-        action: str = None,
-        attribute_name: str = None,
-        is_searchable: bool = None
-    ) -> None:
+    def __init__(self, *, attribute_name: str, is_searchable: bool) -> None:
         self.attribute_name = attribute_name
         self.is_searchable = is_searchable
         super().__init__(action="changeIsSearchable")
@@ -841,13 +772,7 @@ class ProductTypeChangeLabelAction(ProductTypeUpdateAction):
     #: :class:`commercetools.types.LocalizedString`
     label: "LocalizedString"
 
-    def __init__(
-        self,
-        *,
-        action: str = None,
-        attribute_name: str = None,
-        label: "LocalizedString" = None
-    ) -> None:
+    def __init__(self, *, attribute_name: str, label: "LocalizedString") -> None:
         self.attribute_name = attribute_name
         self.label = label
         super().__init__(action="changeLabel")
@@ -866,11 +791,7 @@ class ProductTypeChangeLocalizedEnumValueLabelAction(ProductTypeUpdateAction):
     new_value: "AttributeLocalizedEnumValue"
 
     def __init__(
-        self,
-        *,
-        action: str = None,
-        attribute_name: str = None,
-        new_value: "AttributeLocalizedEnumValue" = None
+        self, *, attribute_name: str, new_value: "AttributeLocalizedEnumValue"
     ) -> None:
         self.attribute_name = attribute_name
         self.new_value = new_value
@@ -890,11 +811,7 @@ class ProductTypeChangeLocalizedEnumValueOrderAction(ProductTypeUpdateAction):
     values: typing.List["AttributeLocalizedEnumValue"]
 
     def __init__(
-        self,
-        *,
-        action: str = None,
-        attribute_name: str = None,
-        values: typing.List["AttributeLocalizedEnumValue"] = None
+        self, *, attribute_name: str, values: typing.List["AttributeLocalizedEnumValue"]
     ) -> None:
         self.attribute_name = attribute_name
         self.values = values
@@ -911,7 +828,7 @@ class ProductTypeChangeNameAction(ProductTypeUpdateAction):
     #: :class:`str`
     name: str
 
-    def __init__(self, *, action: str = None, name: str = None) -> None:
+    def __init__(self, *, name: str) -> None:
         self.name = name
         super().__init__(action="changeName")
 
@@ -929,11 +846,7 @@ class ProductTypeChangePlainEnumValueLabelAction(ProductTypeUpdateAction):
     new_value: "AttributePlainEnumValue"
 
     def __init__(
-        self,
-        *,
-        action: str = None,
-        attribute_name: str = None,
-        new_value: "AttributePlainEnumValue" = None
+        self, *, attribute_name: str, new_value: "AttributePlainEnumValue"
     ) -> None:
         self.attribute_name = attribute_name
         self.new_value = new_value
@@ -953,11 +866,7 @@ class ProductTypeChangePlainEnumValueOrderAction(ProductTypeUpdateAction):
     values: typing.List["AttributePlainEnumValue"]
 
     def __init__(
-        self,
-        *,
-        action: str = None,
-        attribute_name: str = None,
-        values: typing.List["AttributePlainEnumValue"] = None
+        self, *, attribute_name: str, values: typing.List["AttributePlainEnumValue"]
     ) -> None:
         self.attribute_name = attribute_name
         self.values = values
@@ -974,7 +883,7 @@ class ProductTypeRemoveAttributeDefinitionAction(ProductTypeUpdateAction):
     #: :class:`str`
     name: str
 
-    def __init__(self, *, action: str = None, name: str = None) -> None:
+    def __init__(self, *, name: str) -> None:
         self.name = name
         super().__init__(action="removeAttributeDefinition")
 
@@ -991,13 +900,7 @@ class ProductTypeRemoveEnumValuesAction(ProductTypeUpdateAction):
     #: List of :class:`str`
     keys: typing.List[str]
 
-    def __init__(
-        self,
-        *,
-        action: str = None,
-        attribute_name: str = None,
-        keys: typing.List[str] = None
-    ) -> None:
+    def __init__(self, *, attribute_name: str, keys: typing.List[str]) -> None:
         self.attribute_name = attribute_name
         self.keys = keys
         super().__init__(action="removeEnumValues")
@@ -1018,8 +921,7 @@ class ProductTypeSetInputTipAction(ProductTypeUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
-        attribute_name: str = None,
+        attribute_name: str,
         input_tip: typing.Optional["LocalizedString"] = None
     ) -> None:
         self.attribute_name = attribute_name
@@ -1037,7 +939,7 @@ class ProductTypeSetKeyAction(ProductTypeUpdateAction):
     #: Optional :class:`str`
     key: typing.Optional[str]
 
-    def __init__(self, *, action: str = None, key: typing.Optional[str] = None) -> None:
+    def __init__(self, *, key: typing.Optional[str] = None) -> None:
         self.key = key
         super().__init__(action="setKey")
 

--- a/src/commercetools/types/_project.py
+++ b/src/commercetools/types/_project.py
@@ -51,7 +51,7 @@ class ExternalOAuth(_BaseType):
     #: :class:`str` `(Named` ``authorizationHeader`` `in Commercetools)`
     authorization_header: str
 
-    def __init__(self, *, url: str = None, authorization_header: str = None) -> None:
+    def __init__(self, *, url: str, authorization_header: str) -> None:
         self.url = url
         self.authorization_header = authorization_header
         super().__init__()
@@ -92,18 +92,18 @@ class Project(_BaseType):
     def __init__(
         self,
         *,
-        version: int = None,
-        key: str = None,
-        name: str = None,
-        countries: typing.List["str"] = None,
-        currencies: typing.List["str"] = None,
-        languages: typing.List["str"] = None,
-        created_at: datetime.datetime = None,
+        version: int,
+        key: str,
+        name: str,
+        countries: typing.List["str"],
+        currencies: typing.List["str"],
+        languages: typing.List["str"],
+        created_at: datetime.datetime,
+        messages: "MessageConfiguration",
+        carts: "CartsConfiguration",
         trial_until: typing.Optional[str] = None,
-        messages: "MessageConfiguration" = None,
         shipping_rate_input_type: typing.Optional["ShippingRateInputType"] = None,
-        external_oauth: typing.Optional["ExternalOAuth"] = None,
-        carts: "CartsConfiguration" = None
+        external_oauth: typing.Optional["ExternalOAuth"] = None
     ) -> None:
         self.version = version
         self.key = key
@@ -145,7 +145,7 @@ class ProjectUpdate(_BaseType):
     #: :class:`list`
     actions: list
 
-    def __init__(self, *, version: int = None, actions: list = None) -> None:
+    def __init__(self, *, version: int, actions: list) -> None:
         self.version = version
         self.actions = actions
         super().__init__()
@@ -158,7 +158,7 @@ class ProjectUpdateAction(_BaseType):
     #: :class:`str`
     action: str
 
-    def __init__(self, *, action: str = None) -> None:
+    def __init__(self, *, action: str) -> None:
         self.action = action
         super().__init__()
 
@@ -170,7 +170,7 @@ class ShippingRateInputType(_BaseType):
     #: :class:`commercetools.types.ShippingRateTierType`
     type: "ShippingRateTierType"
 
-    def __init__(self, *, type: "ShippingRateTierType" = None) -> None:
+    def __init__(self, *, type: "ShippingRateTierType") -> None:
         self.type = type
         super().__init__()
 
@@ -182,9 +182,7 @@ class CartClassificationType(ShippingRateInputType):
     #: :class:`list`
     values: list
 
-    def __init__(
-        self, *, type: "ShippingRateTierType" = None, values: list = None
-    ) -> None:
+    def __init__(self, *, values: list) -> None:
         self.values = values
         super().__init__(type=ShippingRateTierType.CART_CLASSIFICATION)
 
@@ -193,7 +191,7 @@ class CartClassificationType(ShippingRateInputType):
 
 
 class CartScoreType(ShippingRateInputType):
-    def __init__(self, *, type: "ShippingRateTierType" = None) -> None:
+    def __init__(self) -> None:
         super().__init__(type=ShippingRateTierType.CART_SCORE)
 
     def __repr__(self) -> str:
@@ -201,7 +199,7 @@ class CartScoreType(ShippingRateInputType):
 
 
 class CartValueType(ShippingRateInputType):
-    def __init__(self, *, type: "ShippingRateTierType" = None) -> None:
+    def __init__(self) -> None:
         super().__init__(type=ShippingRateTierType.CART_VALUE)
 
     def __repr__(self) -> str:
@@ -212,9 +210,7 @@ class ProjectChangeCountriesAction(ProjectUpdateAction):
     #: List of :class:`str`
     countries: typing.List["str"]
 
-    def __init__(
-        self, *, action: str = None, countries: typing.List["str"] = None
-    ) -> None:
+    def __init__(self, *, countries: typing.List["str"]) -> None:
         self.countries = countries
         super().__init__(action="changeCountries")
 
@@ -229,9 +225,7 @@ class ProjectChangeCountryTaxRateFallbackEnabledAction(ProjectUpdateAction):
     #: :class:`bool` `(Named` ``countryTaxRateFallbackEnabled`` `in Commercetools)`
     country_tax_rate_fallback_enabled: bool
 
-    def __init__(
-        self, *, action: str = None, country_tax_rate_fallback_enabled: bool = None
-    ) -> None:
+    def __init__(self, *, country_tax_rate_fallback_enabled: bool) -> None:
         self.country_tax_rate_fallback_enabled = country_tax_rate_fallback_enabled
         super().__init__(action="changeCountryTaxRateFallbackEnabled")
 
@@ -246,9 +240,7 @@ class ProjectChangeCurrenciesAction(ProjectUpdateAction):
     #: List of :class:`str`
     currencies: typing.List["str"]
 
-    def __init__(
-        self, *, action: str = None, currencies: typing.List["str"] = None
-    ) -> None:
+    def __init__(self, *, currencies: typing.List["str"]) -> None:
         self.currencies = currencies
         super().__init__(action="changeCurrencies")
 
@@ -263,9 +255,7 @@ class ProjectChangeLanguagesAction(ProjectUpdateAction):
     #: List of :class:`str`
     languages: typing.List["str"]
 
-    def __init__(
-        self, *, action: str = None, languages: typing.List["str"] = None
-    ) -> None:
+    def __init__(self, *, languages: typing.List["str"]) -> None:
         self.languages = languages
         super().__init__(action="changeLanguages")
 
@@ -280,12 +270,7 @@ class ProjectChangeMessagesConfigurationAction(ProjectUpdateAction):
     #: :class:`commercetools.types.MessageConfigurationDraft` `(Named` ``messagesConfiguration`` `in Commercetools)`
     messages_configuration: "MessageConfigurationDraft"
 
-    def __init__(
-        self,
-        *,
-        action: str = None,
-        messages_configuration: "MessageConfigurationDraft" = None
-    ) -> None:
+    def __init__(self, *, messages_configuration: "MessageConfigurationDraft") -> None:
         self.messages_configuration = messages_configuration
         super().__init__(action="changeMessagesConfiguration")
 
@@ -300,7 +285,7 @@ class ProjectChangeMessagesEnabledAction(ProjectUpdateAction):
     #: :class:`bool` `(Named` ``messagesEnabled`` `in Commercetools)`
     messages_enabled: bool
 
-    def __init__(self, *, action: str = None, messages_enabled: bool = None) -> None:
+    def __init__(self, *, messages_enabled: bool) -> None:
         self.messages_enabled = messages_enabled
         super().__init__(action="changeMessagesEnabled")
 
@@ -315,7 +300,7 @@ class ProjectChangeNameAction(ProjectUpdateAction):
     #: :class:`str`
     name: str
 
-    def __init__(self, *, action: str = None, name: str = None) -> None:
+    def __init__(self, *, name: str) -> None:
         self.name = name
         super().__init__(action="changeName")
 
@@ -328,10 +313,7 @@ class ProjectSetExternalOAuthAction(ProjectUpdateAction):
     external_oauth: typing.Optional["ExternalOAuth"]
 
     def __init__(
-        self,
-        *,
-        action: str = None,
-        external_oauth: typing.Optional["ExternalOAuth"] = None
+        self, *, external_oauth: typing.Optional["ExternalOAuth"] = None
     ) -> None:
         self.external_oauth = external_oauth
         super().__init__(action="setExternalOAuth")
@@ -350,7 +332,6 @@ class ProjectSetShippingRateInputTypeAction(ProjectUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
         shipping_rate_input_type: typing.Optional["ShippingRateInputType"] = None
     ) -> None:
         self.shipping_rate_input_type = shipping_rate_input_type

--- a/src/commercetools/types/_review.py
+++ b/src/commercetools/types/_review.py
@@ -85,10 +85,11 @@ class Review(BaseResource):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        included_in_statistics: bool,
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
         key: typing.Optional[str] = None,
@@ -98,7 +99,6 @@ class Review(BaseResource):
         title: typing.Optional[str] = None,
         text: typing.Optional[str] = None,
         target: typing.Optional["ProductReference"] = None,
-        included_in_statistics: bool = None,
         rating: typing.Optional[int] = None,
         state: typing.Optional["StateReference"] = None,
         customer: typing.Optional["CustomerReference"] = None,
@@ -241,11 +241,11 @@ class ReviewPagedQueryResponse(_BaseType):
     def __init__(
         self,
         *,
-        limit: int = None,
-        count: int = None,
-        total: typing.Optional[int] = None,
-        offset: int = None,
-        results: typing.Sequence["Review"] = None
+        limit: int,
+        count: int,
+        offset: int,
+        results: typing.Sequence["Review"],
+        total: typing.Optional[int] = None
     ) -> None:
         self.limit = limit
         self.count = count
@@ -276,11 +276,11 @@ class ReviewRatingStatistics(_BaseType):
     def __init__(
         self,
         *,
-        average_rating: int = None,
-        highest_rating: int = None,
-        lowest_rating: int = None,
-        count: int = None,
-        ratings_distribution: object = None
+        average_rating: int,
+        highest_rating: int,
+        lowest_rating: int,
+        count: int,
+        ratings_distribution: object
     ) -> None:
         self.average_rating = average_rating
         self.highest_rating = highest_rating
@@ -306,13 +306,7 @@ class ReviewReference(Reference):
     #: Optional :class:`commercetools.types.Review`
     obj: typing.Optional["Review"]
 
-    def __init__(
-        self,
-        *,
-        type_id: "ReferenceTypeId" = None,
-        id: str = None,
-        obj: typing.Optional["Review"] = None
-    ) -> None:
+    def __init__(self, *, id: str, obj: typing.Optional["Review"] = None) -> None:
         self.obj = obj
         super().__init__(type_id=ReferenceTypeId.REVIEW, id=id)
 
@@ -326,11 +320,7 @@ class ReviewReference(Reference):
 
 class ReviewResourceIdentifier(ResourceIdentifier):
     def __init__(
-        self,
-        *,
-        type_id: typing.Optional["ReferenceTypeId"] = None,
-        id: typing.Optional[str] = None,
-        key: typing.Optional[str] = None
+        self, *, id: typing.Optional[str] = None, key: typing.Optional[str] = None
     ) -> None:
         super().__init__(type_id=ReferenceTypeId.REVIEW, id=id, key=key)
 
@@ -348,7 +338,7 @@ class ReviewUpdate(_BaseType):
     #: :class:`list`
     actions: list
 
-    def __init__(self, *, version: int = None, actions: list = None) -> None:
+    def __init__(self, *, version: int, actions: list) -> None:
         self.version = version
         self.actions = actions
         super().__init__()
@@ -361,7 +351,7 @@ class ReviewUpdateAction(_BaseType):
     #: :class:`str`
     action: str
 
-    def __init__(self, *, action: str = None) -> None:
+    def __init__(self, *, action: str) -> None:
         self.action = action
         super().__init__()
 
@@ -373,9 +363,7 @@ class ReviewSetAuthorNameAction(ReviewUpdateAction):
     #: Optional :class:`str` `(Named` ``authorName`` `in Commercetools)`
     author_name: typing.Optional[str]
 
-    def __init__(
-        self, *, action: str = None, author_name: typing.Optional[str] = None
-    ) -> None:
+    def __init__(self, *, author_name: typing.Optional[str] = None) -> None:
         self.author_name = author_name
         super().__init__(action="setAuthorName")
 
@@ -392,13 +380,7 @@ class ReviewSetCustomFieldAction(ReviewUpdateAction):
     #: Optional :class:`typing.Any`
     value: typing.Optional[typing.Any]
 
-    def __init__(
-        self,
-        *,
-        action: str = None,
-        name: str = None,
-        value: typing.Optional[typing.Any] = None
-    ) -> None:
+    def __init__(self, *, name: str, value: typing.Optional[typing.Any] = None) -> None:
         self.name = name
         self.value = value
         super().__init__(action="setCustomField")
@@ -420,7 +402,6 @@ class ReviewSetCustomTypeAction(ReviewUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
         type: typing.Optional["TypeResourceIdentifier"] = None,
         fields: typing.Optional["FieldContainer"] = None
     ) -> None:
@@ -441,10 +422,7 @@ class ReviewSetCustomerAction(ReviewUpdateAction):
     customer: typing.Optional["CustomerResourceIdentifier"]
 
     def __init__(
-        self,
-        *,
-        action: str = None,
-        customer: typing.Optional["CustomerResourceIdentifier"] = None
+        self, *, customer: typing.Optional["CustomerResourceIdentifier"] = None
     ) -> None:
         self.customer = customer
         super().__init__(action="setCustomer")
@@ -460,7 +438,7 @@ class ReviewSetKeyAction(ReviewUpdateAction):
     #: Optional :class:`str`
     key: typing.Optional[str]
 
-    def __init__(self, *, action: str = None, key: typing.Optional[str] = None) -> None:
+    def __init__(self, *, key: typing.Optional[str] = None) -> None:
         self.key = key
         super().__init__(action="setKey")
 
@@ -472,9 +450,7 @@ class ReviewSetLocaleAction(ReviewUpdateAction):
     #: Optional :class:`str`
     locale: typing.Optional[str]
 
-    def __init__(
-        self, *, action: str = None, locale: typing.Optional[str] = None
-    ) -> None:
+    def __init__(self, *, locale: typing.Optional[str] = None) -> None:
         self.locale = locale
         super().__init__(action="setLocale")
 
@@ -489,9 +465,7 @@ class ReviewSetRatingAction(ReviewUpdateAction):
     #: Optional :class:`int`
     rating: typing.Optional[int]
 
-    def __init__(
-        self, *, action: str = None, rating: typing.Optional[int] = None
-    ) -> None:
+    def __init__(self, *, rating: typing.Optional[int] = None) -> None:
         self.rating = rating
         super().__init__(action="setRating")
 
@@ -506,9 +480,7 @@ class ReviewSetTargetAction(ReviewUpdateAction):
     #: :class:`commercetools.types.ProductResourceIdentifier`
     target: "ProductResourceIdentifier"
 
-    def __init__(
-        self, *, action: str = None, target: "ProductResourceIdentifier" = None
-    ) -> None:
+    def __init__(self, *, target: "ProductResourceIdentifier") -> None:
         self.target = target
         super().__init__(action="setTarget")
 
@@ -523,9 +495,7 @@ class ReviewSetTextAction(ReviewUpdateAction):
     #: Optional :class:`str`
     text: typing.Optional[str]
 
-    def __init__(
-        self, *, action: str = None, text: typing.Optional[str] = None
-    ) -> None:
+    def __init__(self, *, text: typing.Optional[str] = None) -> None:
         self.text = text
         super().__init__(action="setText")
 
@@ -537,9 +507,7 @@ class ReviewSetTitleAction(ReviewUpdateAction):
     #: Optional :class:`str`
     title: typing.Optional[str]
 
-    def __init__(
-        self, *, action: str = None, title: typing.Optional[str] = None
-    ) -> None:
+    def __init__(self, *, title: typing.Optional[str] = None) -> None:
         self.title = title
         super().__init__(action="setTitle")
 
@@ -554,11 +522,7 @@ class ReviewTransitionStateAction(ReviewUpdateAction):
     force: typing.Optional[bool]
 
     def __init__(
-        self,
-        *,
-        action: str = None,
-        state: "StateResourceIdentifier" = None,
-        force: typing.Optional[bool] = None
+        self, *, state: "StateResourceIdentifier", force: typing.Optional[bool] = None
     ) -> None:
         self.state = state
         self.force = force

--- a/src/commercetools/types/_shipping_method.py
+++ b/src/commercetools/types/_shipping_method.py
@@ -53,7 +53,7 @@ class PriceFunction(_BaseType):
     #: :class:`str`
     function: str
 
-    def __init__(self, *, currency_code: "str" = None, function: str = None) -> None:
+    def __init__(self, *, currency_code: "str", function: str) -> None:
         self.currency_code = currency_code
         self.function = function
         super().__init__()
@@ -98,19 +98,19 @@ class ShippingMethod(BaseResource):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        name: str,
+        tax_category: "TaxCategoryReference",
+        zone_rates: typing.List["ZoneRate"],
+        is_default: bool,
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
         key: typing.Optional[str] = None,
-        name: str = None,
         description: typing.Optional[str] = None,
         localized_description: typing.Optional["LocalizedString"] = None,
-        tax_category: "TaxCategoryReference" = None,
-        zone_rates: typing.List["ZoneRate"] = None,
-        is_default: bool = None,
         predicate: typing.Optional[str] = None
     ) -> None:
         self.id = id
@@ -177,13 +177,13 @@ class ShippingMethodDraft(_BaseType):
     def __init__(
         self,
         *,
+        name: str,
+        tax_category: "TaxCategoryResourceIdentifier",
+        zone_rates: typing.List["ZoneRateDraft"],
+        is_default: bool,
         key: typing.Optional[str] = None,
-        name: str = None,
         description: typing.Optional[str] = None,
         localized_description: typing.Optional["LocalizedString"] = None,
-        tax_category: "TaxCategoryResourceIdentifier" = None,
-        zone_rates: typing.List["ZoneRateDraft"] = None,
-        is_default: bool = None,
         predicate: typing.Optional[str] = None
     ) -> None:
         self.key = key
@@ -227,11 +227,11 @@ class ShippingMethodPagedQueryResponse(_BaseType):
     def __init__(
         self,
         *,
+        count: int,
+        results: typing.Sequence["ShippingMethod"],
         limit: typing.Optional[int] = None,
-        count: int = None,
         total: typing.Optional[int] = None,
-        offset: typing.Optional[int] = None,
-        results: typing.Sequence["ShippingMethod"] = None
+        offset: typing.Optional[int] = None
     ) -> None:
         self.limit = limit
         self.count = count
@@ -252,11 +252,7 @@ class ShippingMethodReference(Reference):
     obj: typing.Optional["ShippingMethod"]
 
     def __init__(
-        self,
-        *,
-        type_id: "ReferenceTypeId" = None,
-        id: str = None,
-        obj: typing.Optional["ShippingMethod"] = None
+        self, *, id: str, obj: typing.Optional["ShippingMethod"] = None
     ) -> None:
         self.obj = obj
         super().__init__(type_id=ReferenceTypeId.SHIPPING_METHOD, id=id)
@@ -271,11 +267,7 @@ class ShippingMethodReference(Reference):
 
 class ShippingMethodResourceIdentifier(ResourceIdentifier):
     def __init__(
-        self,
-        *,
-        type_id: typing.Optional["ReferenceTypeId"] = None,
-        id: typing.Optional[str] = None,
-        key: typing.Optional[str] = None
+        self, *, id: typing.Optional[str] = None, key: typing.Optional[str] = None
     ) -> None:
         super().__init__(type_id=ReferenceTypeId.SHIPPING_METHOD, id=id, key=key)
 
@@ -293,7 +285,7 @@ class ShippingMethodUpdate(_BaseType):
     #: :class:`list`
     actions: list
 
-    def __init__(self, *, version: int = None, actions: list = None) -> None:
+    def __init__(self, *, version: int, actions: list) -> None:
         self.version = version
         self.actions = actions
         super().__init__()
@@ -309,7 +301,7 @@ class ShippingMethodUpdateAction(_BaseType):
     #: :class:`str`
     action: str
 
-    def __init__(self, *, action: str = None) -> None:
+    def __init__(self, *, action: str) -> None:
         self.action = action
         super().__init__()
 
@@ -330,10 +322,10 @@ class ShippingRate(_BaseType):
     def __init__(
         self,
         *,
-        price: "TypedMoney" = None,
+        price: "TypedMoney",
+        tiers: typing.List["ShippingRatePriceTier"],
         free_above: typing.Optional["TypedMoney"] = None,
-        is_matching: typing.Optional[bool] = None,
-        tiers: typing.List["ShippingRatePriceTier"] = None
+        is_matching: typing.Optional[bool] = None
     ) -> None:
         self.price = price
         self.free_above = free_above
@@ -361,7 +353,7 @@ class ShippingRateDraft(_BaseType):
     def __init__(
         self,
         *,
-        price: "Money" = None,
+        price: "Money",
         free_above: typing.Optional["Money"] = None,
         tiers: typing.Optional[typing.List["ShippingRatePriceTier"]] = None
     ) -> None:
@@ -382,7 +374,7 @@ class ShippingRatePriceTier(_BaseType):
     #: :class:`commercetools.types.ShippingRateTierType`
     type: "ShippingRateTierType"
 
-    def __init__(self, *, type: "ShippingRateTierType" = None) -> None:
+    def __init__(self, *, type: "ShippingRateTierType") -> None:
         self.type = type
         super().__init__()
 
@@ -403,10 +395,7 @@ class ZoneRate(_BaseType):
     shipping_rates: typing.List["ShippingRate"]
 
     def __init__(
-        self,
-        *,
-        zone: "ZoneReference" = None,
-        shipping_rates: typing.List["ShippingRate"] = None
+        self, *, zone: "ZoneReference", shipping_rates: typing.List["ShippingRate"]
     ) -> None:
         self.zone = zone
         self.shipping_rates = shipping_rates
@@ -425,8 +414,8 @@ class ZoneRateDraft(_BaseType):
     def __init__(
         self,
         *,
-        zone: "ZoneResourceIdentifier" = None,
-        shipping_rates: typing.List["ShippingRateDraft"] = None
+        zone: "ZoneResourceIdentifier",
+        shipping_rates: typing.List["ShippingRateDraft"]
     ) -> None:
         self.zone = zone
         self.shipping_rates = shipping_rates
@@ -448,12 +437,7 @@ class CartClassificationTier(ShippingRatePriceTier):
     is_matching: typing.Optional[bool]
 
     def __init__(
-        self,
-        *,
-        type: "ShippingRateTierType" = None,
-        value: str = None,
-        price: "Money" = None,
-        is_matching: typing.Optional[bool] = None
+        self, *, value: str, price: "Money", is_matching: typing.Optional[bool] = None
     ) -> None:
         self.value = value
         self.price = price
@@ -482,8 +466,7 @@ class CartScoreTier(ShippingRatePriceTier):
     def __init__(
         self,
         *,
-        type: "ShippingRateTierType" = None,
-        score: int = None,
+        score: int,
         price: typing.Optional["Money"] = None,
         price_function: typing.Optional["PriceFunction"] = None,
         is_matching: typing.Optional[bool] = None
@@ -512,9 +495,8 @@ class CartValueTier(ShippingRatePriceTier):
     def __init__(
         self,
         *,
-        type: "ShippingRateTierType" = None,
-        minimum_cent_amount: int = None,
-        price: "Money" = None,
+        minimum_cent_amount: int,
+        price: "Money",
         is_matching: typing.Optional[bool] = None
     ) -> None:
         self.minimum_cent_amount = minimum_cent_amount
@@ -536,11 +518,7 @@ class ShippingMethodAddShippingRateAction(ShippingMethodUpdateAction):
     shipping_rate: "ShippingRateDraft"
 
     def __init__(
-        self,
-        *,
-        action: str = None,
-        zone: "ZoneResourceIdentifier" = None,
-        shipping_rate: "ShippingRateDraft" = None
+        self, *, zone: "ZoneResourceIdentifier", shipping_rate: "ShippingRateDraft"
     ) -> None:
         self.zone = zone
         self.shipping_rate = shipping_rate
@@ -557,9 +535,7 @@ class ShippingMethodAddZoneAction(ShippingMethodUpdateAction):
     #: :class:`commercetools.types.ZoneResourceIdentifier`
     zone: "ZoneResourceIdentifier"
 
-    def __init__(
-        self, *, action: str = None, zone: "ZoneResourceIdentifier" = None
-    ) -> None:
+    def __init__(self, *, zone: "ZoneResourceIdentifier") -> None:
         self.zone = zone
         super().__init__(action="addZone")
 
@@ -574,7 +550,7 @@ class ShippingMethodChangeIsDefaultAction(ShippingMethodUpdateAction):
     #: :class:`bool` `(Named` ``isDefault`` `in Commercetools)`
     is_default: bool
 
-    def __init__(self, *, action: str = None, is_default: bool = None) -> None:
+    def __init__(self, *, is_default: bool) -> None:
         self.is_default = is_default
         super().__init__(action="changeIsDefault")
 
@@ -589,7 +565,7 @@ class ShippingMethodChangeNameAction(ShippingMethodUpdateAction):
     #: :class:`str`
     name: str
 
-    def __init__(self, *, action: str = None, name: str = None) -> None:
+    def __init__(self, *, name: str) -> None:
         self.name = name
         super().__init__(action="changeName")
 
@@ -604,12 +580,7 @@ class ShippingMethodChangeTaxCategoryAction(ShippingMethodUpdateAction):
     #: :class:`commercetools.types.TaxCategoryResourceIdentifier` `(Named` ``taxCategory`` `in Commercetools)`
     tax_category: "TaxCategoryResourceIdentifier"
 
-    def __init__(
-        self,
-        *,
-        action: str = None,
-        tax_category: "TaxCategoryResourceIdentifier" = None
-    ) -> None:
+    def __init__(self, *, tax_category: "TaxCategoryResourceIdentifier") -> None:
         self.tax_category = tax_category
         super().__init__(action="changeTaxCategory")
 
@@ -627,11 +598,7 @@ class ShippingMethodRemoveShippingRateAction(ShippingMethodUpdateAction):
     shipping_rate: "ShippingRateDraft"
 
     def __init__(
-        self,
-        *,
-        action: str = None,
-        zone: "ZoneResourceIdentifier" = None,
-        shipping_rate: "ShippingRateDraft" = None
+        self, *, zone: "ZoneResourceIdentifier", shipping_rate: "ShippingRateDraft"
     ) -> None:
         self.zone = zone
         self.shipping_rate = shipping_rate
@@ -648,9 +615,7 @@ class ShippingMethodRemoveZoneAction(ShippingMethodUpdateAction):
     #: :class:`commercetools.types.ZoneResourceIdentifier`
     zone: "ZoneResourceIdentifier"
 
-    def __init__(
-        self, *, action: str = None, zone: "ZoneResourceIdentifier" = None
-    ) -> None:
+    def __init__(self, *, zone: "ZoneResourceIdentifier") -> None:
         self.zone = zone
         super().__init__(action="removeZone")
 
@@ -665,9 +630,7 @@ class ShippingMethodSetDescriptionAction(ShippingMethodUpdateAction):
     #: Optional :class:`str`
     description: typing.Optional[str]
 
-    def __init__(
-        self, *, action: str = None, description: typing.Optional[str] = None
-    ) -> None:
+    def __init__(self, *, description: typing.Optional[str] = None) -> None:
         self.description = description
         super().__init__(action="setDescription")
 
@@ -682,7 +645,7 @@ class ShippingMethodSetKeyAction(ShippingMethodUpdateAction):
     #: Optional :class:`str`
     key: typing.Optional[str]
 
-    def __init__(self, *, action: str = None, key: typing.Optional[str] = None) -> None:
+    def __init__(self, *, key: typing.Optional[str] = None) -> None:
         self.key = key
         super().__init__(action="setKey")
 
@@ -694,9 +657,7 @@ class ShippingMethodSetLocalizedDescriptionAction(ShippingMethodUpdateAction):
     #: Optional :class:`str` `(Named` ``localizedDescription`` `in Commercetools)`
     localized_description: typing.Optional[str]
 
-    def __init__(
-        self, *, action: str = None, localized_description: typing.Optional[str] = None
-    ) -> None:
+    def __init__(self, *, localized_description: typing.Optional[str] = None) -> None:
         self.localized_description = localized_description
         super().__init__(action="setLocalizedDescription")
 
@@ -711,9 +672,7 @@ class ShippingMethodSetPredicateAction(ShippingMethodUpdateAction):
     #: Optional :class:`str`
     predicate: typing.Optional[str]
 
-    def __init__(
-        self, *, action: str = None, predicate: typing.Optional[str] = None
-    ) -> None:
+    def __init__(self, *, predicate: typing.Optional[str] = None) -> None:
         self.predicate = predicate
         super().__init__(action="setPredicate")
 

--- a/src/commercetools/types/_shopping_list.py
+++ b/src/commercetools/types/_shopping_list.py
@@ -97,10 +97,11 @@ class MyShoppingList(BaseResource):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        name: "LocalizedString",
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
         custom: typing.Optional["CustomFields"] = None,
@@ -109,7 +110,6 @@ class MyShoppingList(BaseResource):
         description: typing.Optional["LocalizedString"] = None,
         key: typing.Optional[str] = None,
         line_items: typing.Optional[typing.List["ShoppingListLineItem"]] = None,
-        name: "LocalizedString" = None,
         slug: typing.Optional["LocalizedString"] = None,
         text_line_items: typing.Optional[typing.List["TextLineItem"]] = None,
         anonymous_id: typing.Optional[str] = None
@@ -198,10 +198,11 @@ class ShoppingList(BaseResource):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        name: "LocalizedString",
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
         custom: typing.Optional["CustomFields"] = None,
@@ -210,7 +211,6 @@ class ShoppingList(BaseResource):
         description: typing.Optional["LocalizedString"] = None,
         key: typing.Optional[str] = None,
         line_items: typing.Optional[typing.List["ShoppingListLineItem"]] = None,
-        name: "LocalizedString" = None,
         slug: typing.Optional["LocalizedString"] = None,
         text_line_items: typing.Optional[typing.List["TextLineItem"]] = None,
         anonymous_id: typing.Optional[str] = None
@@ -287,13 +287,13 @@ class ShoppingListDraft(_BaseType):
     def __init__(
         self,
         *,
+        name: "LocalizedString",
         custom: typing.Optional["CustomFieldsDraft"] = None,
         customer: typing.Optional["CustomerResourceIdentifier"] = None,
         delete_days_after_last_modification: typing.Optional[int] = None,
         description: typing.Optional["LocalizedString"] = None,
         key: typing.Optional[str] = None,
         line_items: typing.Optional[typing.List["ShoppingListLineItemDraft"]] = None,
-        name: "LocalizedString" = None,
         slug: typing.Optional["LocalizedString"] = None,
         text_line_items: typing.Optional[typing.List["TextLineItemDraft"]] = None,
         anonymous_id: typing.Optional[str] = None
@@ -355,15 +355,15 @@ class ShoppingListLineItem(_BaseType):
     def __init__(
         self,
         *,
-        added_at: datetime.datetime = None,
+        added_at: datetime.datetime,
+        id: str,
+        name: "LocalizedString",
+        product_id: str,
+        product_type: "ProductTypeReference",
+        quantity: int,
         custom: typing.Optional["CustomFields"] = None,
         deactivated_at: typing.Optional[datetime.datetime] = None,
-        id: str = None,
-        name: "LocalizedString" = None,
-        product_id: str = None,
         product_slug: typing.Optional["LocalizedString"] = None,
-        product_type: "ProductTypeReference" = None,
-        quantity: int = None,
         variant: typing.Optional["ProductVariant"] = None,
         variant_id: typing.Optional[int] = None
     ) -> None:
@@ -460,11 +460,11 @@ class ShoppingListPagedQueryResponse(_BaseType):
     def __init__(
         self,
         *,
-        limit: int = None,
-        count: int = None,
-        total: typing.Optional[int] = None,
-        offset: int = None,
-        results: typing.Sequence["ShoppingList"] = None
+        limit: int,
+        count: int,
+        offset: int,
+        results: typing.Sequence["ShoppingList"],
+        total: typing.Optional[int] = None
     ) -> None:
         self.limit = limit
         self.count = count
@@ -484,13 +484,7 @@ class ShoppingListReference(Reference):
     #: Optional :class:`commercetools.types.ShoppingList`
     obj: typing.Optional["ShoppingList"]
 
-    def __init__(
-        self,
-        *,
-        type_id: "ReferenceTypeId" = None,
-        id: str = None,
-        obj: typing.Optional["ShoppingList"] = None
-    ) -> None:
+    def __init__(self, *, id: str, obj: typing.Optional["ShoppingList"] = None) -> None:
         self.obj = obj
         super().__init__(type_id=ReferenceTypeId.SHOPPING_LIST, id=id)
 
@@ -504,11 +498,7 @@ class ShoppingListReference(Reference):
 
 class ShoppingListResourceIdentifier(ResourceIdentifier):
     def __init__(
-        self,
-        *,
-        type_id: typing.Optional["ReferenceTypeId"] = None,
-        id: typing.Optional[str] = None,
-        key: typing.Optional[str] = None
+        self, *, id: typing.Optional[str] = None, key: typing.Optional[str] = None
     ) -> None:
         super().__init__(type_id=ReferenceTypeId.SHOPPING_LIST, id=id, key=key)
 
@@ -526,7 +516,7 @@ class ShoppingListUpdate(_BaseType):
     #: :class:`list`
     actions: list
 
-    def __init__(self, *, version: int = None, actions: list = None) -> None:
+    def __init__(self, *, version: int, actions: list) -> None:
         self.version = version
         self.actions = actions
         super().__init__()
@@ -542,7 +532,7 @@ class ShoppingListUpdateAction(_BaseType):
     #: :class:`str`
     action: str
 
-    def __init__(self, *, action: str = None) -> None:
+    def __init__(self, *, action: str) -> None:
         self.action = action
         super().__init__()
 
@@ -567,12 +557,12 @@ class TextLineItem(_BaseType):
     def __init__(
         self,
         *,
-        added_at: datetime.datetime = None,
+        added_at: datetime.datetime,
+        id: str,
+        name: "LocalizedString",
+        quantity: int,
         custom: typing.Optional["CustomFields"] = None,
-        description: typing.Optional["LocalizedString"] = None,
-        id: str = None,
-        name: "LocalizedString" = None,
-        quantity: int = None
+        description: typing.Optional["LocalizedString"] = None
     ) -> None:
         self.added_at = added_at
         self.custom = custom
@@ -611,10 +601,10 @@ class TextLineItemDraft(_BaseType):
     def __init__(
         self,
         *,
+        name: "LocalizedString",
         added_at: typing.Optional[datetime.datetime] = None,
         custom: typing.Optional["CustomFieldsDraft"] = None,
         description: typing.Optional["LocalizedString"] = None,
-        name: "LocalizedString" = None,
         quantity: typing.Optional[int] = None
     ) -> None:
         self.added_at = added_at
@@ -648,7 +638,6 @@ class ShoppingListAddLineItemAction(ShoppingListUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
         sku: typing.Optional[str] = None,
         product_id: typing.Optional[str] = None,
         variant_id: typing.Optional[int] = None,
@@ -694,8 +683,7 @@ class ShoppingListAddTextLineItemAction(ShoppingListUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
-        name: "LocalizedString" = None,
+        name: "LocalizedString",
         description: typing.Optional["LocalizedString"] = None,
         quantity: typing.Optional[int] = None,
         added_at: typing.Optional[datetime.datetime] = None,
@@ -728,9 +716,7 @@ class ShoppingListChangeLineItemQuantityAction(ShoppingListUpdateAction):
     #: :class:`int`
     quantity: int
 
-    def __init__(
-        self, *, action: str = None, line_item_id: str = None, quantity: int = None
-    ) -> None:
+    def __init__(self, *, line_item_id: str, quantity: int) -> None:
         self.line_item_id = line_item_id
         self.quantity = quantity
         super().__init__(action="changeLineItemQuantity")
@@ -746,9 +732,7 @@ class ShoppingListChangeLineItemsOrderAction(ShoppingListUpdateAction):
     #: List of :class:`str` `(Named` ``lineItemOrder`` `in Commercetools)`
     line_item_order: typing.List[str]
 
-    def __init__(
-        self, *, action: str = None, line_item_order: typing.List[str] = None
-    ) -> None:
+    def __init__(self, *, line_item_order: typing.List[str]) -> None:
         self.line_item_order = line_item_order
         super().__init__(action="changeLineItemsOrder")
 
@@ -763,7 +747,7 @@ class ShoppingListChangeNameAction(ShoppingListUpdateAction):
     #: :class:`commercetools.types.LocalizedString`
     name: "LocalizedString"
 
-    def __init__(self, *, action: str = None, name: "LocalizedString" = None) -> None:
+    def __init__(self, *, name: "LocalizedString") -> None:
         self.name = name
         super().__init__(action="changeName")
 
@@ -780,13 +764,7 @@ class ShoppingListChangeTextLineItemNameAction(ShoppingListUpdateAction):
     #: :class:`commercetools.types.LocalizedString`
     name: "LocalizedString"
 
-    def __init__(
-        self,
-        *,
-        action: str = None,
-        text_line_item_id: str = None,
-        name: "LocalizedString" = None
-    ) -> None:
+    def __init__(self, *, text_line_item_id: str, name: "LocalizedString") -> None:
         self.text_line_item_id = text_line_item_id
         self.name = name
         super().__init__(action="changeTextLineItemName")
@@ -804,9 +782,7 @@ class ShoppingListChangeTextLineItemQuantityAction(ShoppingListUpdateAction):
     #: :class:`int`
     quantity: int
 
-    def __init__(
-        self, *, action: str = None, text_line_item_id: str = None, quantity: int = None
-    ) -> None:
+    def __init__(self, *, text_line_item_id: str, quantity: int) -> None:
         self.text_line_item_id = text_line_item_id
         self.quantity = quantity
         super().__init__(action="changeTextLineItemQuantity")
@@ -822,9 +798,7 @@ class ShoppingListChangeTextLineItemsOrderAction(ShoppingListUpdateAction):
     #: List of :class:`str` `(Named` ``textLineItemOrder`` `in Commercetools)`
     text_line_item_order: typing.List[str]
 
-    def __init__(
-        self, *, action: str = None, text_line_item_order: typing.List[str] = None
-    ) -> None:
+    def __init__(self, *, text_line_item_order: typing.List[str]) -> None:
         self.text_line_item_order = text_line_item_order
         super().__init__(action="changeTextLineItemsOrder")
 
@@ -842,11 +816,7 @@ class ShoppingListRemoveLineItemAction(ShoppingListUpdateAction):
     quantity: typing.Optional[int]
 
     def __init__(
-        self,
-        *,
-        action: str = None,
-        line_item_id: str = None,
-        quantity: typing.Optional[int] = None
+        self, *, line_item_id: str, quantity: typing.Optional[int] = None
     ) -> None:
         self.line_item_id = line_item_id
         self.quantity = quantity
@@ -866,11 +836,7 @@ class ShoppingListRemoveTextLineItemAction(ShoppingListUpdateAction):
     quantity: typing.Optional[int]
 
     def __init__(
-        self,
-        *,
-        action: str = None,
-        text_line_item_id: str = None,
-        quantity: typing.Optional[int] = None
+        self, *, text_line_item_id: str, quantity: typing.Optional[int] = None
     ) -> None:
         self.text_line_item_id = text_line_item_id
         self.quantity = quantity
@@ -887,9 +853,7 @@ class ShoppingListSetAnonymousIdAction(ShoppingListUpdateAction):
     #: Optional :class:`str` `(Named` ``anonymousId`` `in Commercetools)`
     anonymous_id: typing.Optional[str]
 
-    def __init__(
-        self, *, action: str = None, anonymous_id: typing.Optional[str] = None
-    ) -> None:
+    def __init__(self, *, anonymous_id: typing.Optional[str] = None) -> None:
         self.anonymous_id = anonymous_id
         super().__init__(action="setAnonymousId")
 
@@ -906,13 +870,7 @@ class ShoppingListSetCustomFieldAction(ShoppingListUpdateAction):
     #: Optional :class:`typing.Any`
     value: typing.Optional[typing.Any]
 
-    def __init__(
-        self,
-        *,
-        action: str = None,
-        name: str = None,
-        value: typing.Optional[typing.Any] = None
-    ) -> None:
+    def __init__(self, *, name: str, value: typing.Optional[typing.Any] = None) -> None:
         self.name = name
         self.value = value
         super().__init__(action="setCustomField")
@@ -934,7 +892,6 @@ class ShoppingListSetCustomTypeAction(ShoppingListUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
         type: typing.Optional["TypeResourceIdentifier"] = None,
         fields: typing.Optional["FieldContainer"] = None
     ) -> None:
@@ -955,10 +912,7 @@ class ShoppingListSetCustomerAction(ShoppingListUpdateAction):
     customer: typing.Optional["CustomerResourceIdentifier"]
 
     def __init__(
-        self,
-        *,
-        action: str = None,
-        customer: typing.Optional["CustomerResourceIdentifier"] = None
+        self, *, customer: typing.Optional["CustomerResourceIdentifier"] = None
     ) -> None:
         self.customer = customer
         super().__init__(action="setCustomer")
@@ -975,10 +929,7 @@ class ShoppingListSetDeleteDaysAfterLastModificationAction(ShoppingListUpdateAct
     delete_days_after_last_modification: typing.Optional[int]
 
     def __init__(
-        self,
-        *,
-        action: str = None,
-        delete_days_after_last_modification: typing.Optional[int] = None
+        self, *, delete_days_after_last_modification: typing.Optional[int] = None
     ) -> None:
         self.delete_days_after_last_modification = delete_days_after_last_modification
         super().__init__(action="setDeleteDaysAfterLastModification")
@@ -995,10 +946,7 @@ class ShoppingListSetDescriptionAction(ShoppingListUpdateAction):
     description: typing.Optional["LocalizedString"]
 
     def __init__(
-        self,
-        *,
-        action: str = None,
-        description: typing.Optional["LocalizedString"] = None
+        self, *, description: typing.Optional["LocalizedString"] = None
     ) -> None:
         self.description = description
         super().__init__(action="setDescription")
@@ -1014,7 +962,7 @@ class ShoppingListSetKeyAction(ShoppingListUpdateAction):
     #: Optional :class:`str`
     key: typing.Optional[str]
 
-    def __init__(self, *, action: str = None, key: typing.Optional[str] = None) -> None:
+    def __init__(self, *, key: typing.Optional[str] = None) -> None:
         self.key = key
         super().__init__(action="setKey")
 
@@ -1031,12 +979,7 @@ class ShoppingListSetLineItemCustomFieldAction(ShoppingListUpdateAction):
     value: typing.Optional[typing.Any]
 
     def __init__(
-        self,
-        *,
-        action: str = None,
-        line_item_id: str = None,
-        name: str = None,
-        value: typing.Optional[typing.Any] = None
+        self, *, line_item_id: str, name: str, value: typing.Optional[typing.Any] = None
     ) -> None:
         self.line_item_id = line_item_id
         self.name = name
@@ -1061,8 +1004,7 @@ class ShoppingListSetLineItemCustomTypeAction(ShoppingListUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
-        line_item_id: str = None,
+        line_item_id: str,
         type: typing.Optional["TypeResourceIdentifier"] = None,
         fields: typing.Optional["FieldContainer"] = None
     ) -> None:
@@ -1082,9 +1024,7 @@ class ShoppingListSetSlugAction(ShoppingListUpdateAction):
     #: Optional :class:`commercetools.types.LocalizedString`
     slug: typing.Optional["LocalizedString"]
 
-    def __init__(
-        self, *, action: str = None, slug: typing.Optional["LocalizedString"] = None
-    ) -> None:
+    def __init__(self, *, slug: typing.Optional["LocalizedString"] = None) -> None:
         self.slug = slug
         super().__init__(action="setSlug")
 
@@ -1106,9 +1046,8 @@ class ShoppingListSetTextLineItemCustomFieldAction(ShoppingListUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
-        text_line_item_id: str = None,
-        name: str = None,
+        text_line_item_id: str,
+        name: str,
         value: typing.Optional[typing.Any] = None
     ) -> None:
         self.text_line_item_id = text_line_item_id
@@ -1134,8 +1073,7 @@ class ShoppingListSetTextLineItemCustomTypeAction(ShoppingListUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
-        text_line_item_id: str = None,
+        text_line_item_id: str,
         type: typing.Optional["TypeResourceIdentifier"] = None,
         fields: typing.Optional["FieldContainer"] = None
     ) -> None:
@@ -1160,8 +1098,7 @@ class ShoppingListSetTextLineItemDescriptionAction(ShoppingListUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
-        text_line_item_id: str = None,
+        text_line_item_id: str,
         description: typing.Optional["LocalizedString"] = None
     ) -> None:
         self.text_line_item_id = text_line_item_id

--- a/src/commercetools/types/_state.py
+++ b/src/commercetools/types/_state.py
@@ -68,18 +68,18 @@ class State(BaseResource):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        key: str,
+        type: "StateTypeEnum",
+        initial: bool,
+        built_in: bool,
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
-        key: str = None,
-        type: "StateTypeEnum" = None,
         name: typing.Optional["LocalizedString"] = None,
         description: typing.Optional["LocalizedString"] = None,
-        initial: bool = None,
-        built_in: bool = None,
         roles: typing.Optional[typing.List["StateRoleEnum"]] = None,
         transitions: typing.Optional[typing.List["StateReference"]] = None
     ) -> None:
@@ -145,8 +145,8 @@ class StateDraft(_BaseType):
     def __init__(
         self,
         *,
-        key: str = None,
-        type: "StateTypeEnum" = None,
+        key: str,
+        type: "StateTypeEnum",
         name: typing.Optional["LocalizedString"] = None,
         description: typing.Optional["LocalizedString"] = None,
         initial: typing.Optional[bool] = None,
@@ -192,11 +192,11 @@ class StatePagedQueryResponse(_BaseType):
     def __init__(
         self,
         *,
-        limit: int = None,
-        count: int = None,
-        total: typing.Optional[int] = None,
-        offset: int = None,
-        results: typing.Sequence["State"] = None
+        limit: int,
+        count: int,
+        offset: int,
+        results: typing.Sequence["State"],
+        total: typing.Optional[int] = None
     ) -> None:
         self.limit = limit
         self.count = count
@@ -216,13 +216,7 @@ class StateReference(Reference):
     #: Optional :class:`commercetools.types.State`
     obj: typing.Optional["State"]
 
-    def __init__(
-        self,
-        *,
-        type_id: "ReferenceTypeId" = None,
-        id: str = None,
-        obj: typing.Optional["State"] = None
-    ) -> None:
+    def __init__(self, *, id: str, obj: typing.Optional["State"] = None) -> None:
         self.obj = obj
         super().__init__(type_id=ReferenceTypeId.STATE, id=id)
 
@@ -236,11 +230,7 @@ class StateReference(Reference):
 
 class StateResourceIdentifier(ResourceIdentifier):
     def __init__(
-        self,
-        *,
-        type_id: typing.Optional["ReferenceTypeId"] = None,
-        id: typing.Optional[str] = None,
-        key: typing.Optional[str] = None
+        self, *, id: typing.Optional[str] = None, key: typing.Optional[str] = None
     ) -> None:
         super().__init__(type_id=ReferenceTypeId.STATE, id=id, key=key)
 
@@ -271,7 +261,7 @@ class StateUpdate(_BaseType):
     #: :class:`list`
     actions: list
 
-    def __init__(self, *, version: int = None, actions: list = None) -> None:
+    def __init__(self, *, version: int, actions: list) -> None:
         self.version = version
         self.actions = actions
         super().__init__()
@@ -284,7 +274,7 @@ class StateUpdateAction(_BaseType):
     #: :class:`str`
     action: str
 
-    def __init__(self, *, action: str = None) -> None:
+    def __init__(self, *, action: str) -> None:
         self.action = action
         super().__init__()
 
@@ -296,9 +286,7 @@ class StateAddRolesAction(StateUpdateAction):
     #: List of :class:`commercetools.types.StateRoleEnum`
     roles: typing.List["StateRoleEnum"]
 
-    def __init__(
-        self, *, action: str = None, roles: typing.List["StateRoleEnum"] = None
-    ) -> None:
+    def __init__(self, *, roles: typing.List["StateRoleEnum"]) -> None:
         self.roles = roles
         super().__init__(action="addRoles")
 
@@ -310,7 +298,7 @@ class StateChangeInitialAction(StateUpdateAction):
     #: :class:`bool`
     initial: bool
 
-    def __init__(self, *, action: str = None, initial: bool = None) -> None:
+    def __init__(self, *, initial: bool) -> None:
         self.initial = initial
         super().__init__(action="changeInitial")
 
@@ -325,7 +313,7 @@ class StateChangeKeyAction(StateUpdateAction):
     #: :class:`str`
     key: str
 
-    def __init__(self, *, action: str = None, key: str = None) -> None:
+    def __init__(self, *, key: str) -> None:
         self.key = key
         super().__init__(action="changeKey")
 
@@ -337,7 +325,7 @@ class StateChangeTypeAction(StateUpdateAction):
     #: :class:`commercetools.types.StateTypeEnum`
     type: "StateTypeEnum"
 
-    def __init__(self, *, action: str = None, type: "StateTypeEnum" = None) -> None:
+    def __init__(self, *, type: "StateTypeEnum") -> None:
         self.type = type
         super().__init__(action="changeType")
 
@@ -349,9 +337,7 @@ class StateRemoveRolesAction(StateUpdateAction):
     #: List of :class:`commercetools.types.StateRoleEnum`
     roles: typing.List["StateRoleEnum"]
 
-    def __init__(
-        self, *, action: str = None, roles: typing.List["StateRoleEnum"] = None
-    ) -> None:
+    def __init__(self, *, roles: typing.List["StateRoleEnum"]) -> None:
         self.roles = roles
         super().__init__(action="removeRoles")
 
@@ -363,9 +349,7 @@ class StateSetDescriptionAction(StateUpdateAction):
     #: :class:`commercetools.types.LocalizedString`
     description: "LocalizedString"
 
-    def __init__(
-        self, *, action: str = None, description: "LocalizedString" = None
-    ) -> None:
+    def __init__(self, *, description: "LocalizedString") -> None:
         self.description = description
         super().__init__(action="setDescription")
 
@@ -380,7 +364,7 @@ class StateSetNameAction(StateUpdateAction):
     #: :class:`commercetools.types.LocalizedString`
     name: "LocalizedString"
 
-    def __init__(self, *, action: str = None, name: "LocalizedString" = None) -> None:
+    def __init__(self, *, name: "LocalizedString") -> None:
         self.name = name
         super().__init__(action="setName")
 
@@ -392,9 +376,7 @@ class StateSetRolesAction(StateUpdateAction):
     #: List of :class:`commercetools.types.StateRoleEnum`
     roles: typing.List["StateRoleEnum"]
 
-    def __init__(
-        self, *, action: str = None, roles: typing.List["StateRoleEnum"] = None
-    ) -> None:
+    def __init__(self, *, roles: typing.List["StateRoleEnum"]) -> None:
         self.roles = roles
         super().__init__(action="setRoles")
 
@@ -409,7 +391,6 @@ class StateSetTransitionsAction(StateUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
         transitions: typing.Optional[typing.List["StateResourceIdentifier"]] = None
     ) -> None:
         self.transitions = transitions

--- a/src/commercetools/types/_store.py
+++ b/src/commercetools/types/_store.py
@@ -26,8 +26,11 @@ __all__ = [
     "StoreUpdate",
     "StoreUpdateAction",
     "StoresAddDistributionChannelsAction",
+    "StoresAddSupplyChannelsAction",
     "StoresRemoveDistributionChannelsAction",
+    "StoresRemoveSupplyChannelsAction",
     "StoresSetDistributionChannelsAction",
+    "StoresSetSupplyChannelsAction",
 ]
 
 
@@ -52,20 +55,25 @@ class Store(BaseResource):
     languages: typing.Optional[typing.List[str]]
     #: List of :class:`commercetools.types.ChannelReference` `(Named` ``distributionChannels`` `in Commercetools)`
     distribution_channels: typing.List["ChannelReference"]
+    #: Optional list of :class:`commercetools.types.ChannelResourceIdentifier` `(Named` ``supplyChannels`` `in Commercetools)`
+    supply_channels: typing.Optional[typing.List["ChannelResourceIdentifier"]]
 
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        key: str,
+        distribution_channels: typing.List["ChannelReference"],
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
-        key: str = None,
         name: typing.Optional["LocalizedString"] = None,
         languages: typing.Optional[typing.List[str]] = None,
-        distribution_channels: typing.List["ChannelReference"] = None
+        supply_channels: typing.Optional[
+            typing.List["ChannelResourceIdentifier"]
+        ] = None
     ) -> None:
         self.id = id
         self.version = version
@@ -77,6 +85,7 @@ class Store(BaseResource):
         self.name = name
         self.languages = languages
         self.distribution_channels = distribution_channels
+        self.supply_channels = supply_channels
         super().__init__(
             id=id,
             version=version,
@@ -86,7 +95,7 @@ class Store(BaseResource):
 
     def __repr__(self) -> str:
         return (
-            "Store(id=%r, version=%r, created_at=%r, last_modified_at=%r, last_modified_by=%r, created_by=%r, key=%r, name=%r, languages=%r, distribution_channels=%r)"
+            "Store(id=%r, version=%r, created_at=%r, last_modified_at=%r, last_modified_by=%r, created_by=%r, key=%r, name=%r, languages=%r, distribution_channels=%r, supply_channels=%r)"
             % (
                 self.id,
                 self.version,
@@ -98,6 +107,7 @@ class Store(BaseResource):
                 self.name,
                 self.languages,
                 self.distribution_channels,
+                self.supply_channels,
             )
         )
 
@@ -111,14 +121,19 @@ class StoreDraft(_BaseType):
     languages: typing.Optional[typing.List[str]]
     #: Optional list of :class:`commercetools.types.ChannelResourceIdentifier` `(Named` ``distributionChannels`` `in Commercetools)`
     distribution_channels: typing.Optional[typing.List["ChannelResourceIdentifier"]]
+    #: Optional list of :class:`commercetools.types.ChannelResourceIdentifier` `(Named` ``supplyChannels`` `in Commercetools)`
+    supply_channels: typing.Optional[typing.List["ChannelResourceIdentifier"]]
 
     def __init__(
         self,
         *,
-        key: str = None,
-        name: "LocalizedString" = None,
+        key: str,
+        name: "LocalizedString",
         languages: typing.Optional[typing.List[str]] = None,
         distribution_channels: typing.Optional[
+            typing.List["ChannelResourceIdentifier"]
+        ] = None,
+        supply_channels: typing.Optional[
             typing.List["ChannelResourceIdentifier"]
         ] = None
     ) -> None:
@@ -126,19 +141,24 @@ class StoreDraft(_BaseType):
         self.name = name
         self.languages = languages
         self.distribution_channels = distribution_channels
+        self.supply_channels = supply_channels
         super().__init__()
 
     def __repr__(self) -> str:
-        return "StoreDraft(key=%r, name=%r, languages=%r, distribution_channels=%r)" % (
-            self.key,
-            self.name,
-            self.languages,
-            self.distribution_channels,
+        return (
+            "StoreDraft(key=%r, name=%r, languages=%r, distribution_channels=%r, supply_channels=%r)"
+            % (
+                self.key,
+                self.name,
+                self.languages,
+                self.distribution_channels,
+                self.supply_channels,
+            )
         )
 
 
 class StoreKeyReference(KeyReference):
-    def __init__(self, *, type_id: "ReferenceTypeId" = None, key: str = None) -> None:
+    def __init__(self, *, key: str) -> None:
         super().__init__(type_id=ReferenceTypeId.STORE, key=key)
 
     def __repr__(self) -> str:
@@ -160,11 +180,11 @@ class StorePagedQueryResponse(_BaseType):
     def __init__(
         self,
         *,
-        limit: int = None,
-        count: int = None,
-        total: typing.Optional[int] = None,
-        offset: int = None,
-        results: typing.Sequence["Store"] = None
+        limit: int,
+        count: int,
+        offset: int,
+        results: typing.Sequence["Store"],
+        total: typing.Optional[int] = None
     ) -> None:
         self.limit = limit
         self.count = count
@@ -184,13 +204,7 @@ class StoreReference(Reference):
     #: Optional :class:`commercetools.types.Store`
     obj: typing.Optional["Store"]
 
-    def __init__(
-        self,
-        *,
-        type_id: "ReferenceTypeId" = None,
-        id: str = None,
-        obj: typing.Optional["Store"] = None
-    ) -> None:
+    def __init__(self, *, id: str, obj: typing.Optional["Store"] = None) -> None:
         self.obj = obj
         super().__init__(type_id=ReferenceTypeId.STORE, id=id)
 
@@ -204,11 +218,7 @@ class StoreReference(Reference):
 
 class StoreResourceIdentifier(ResourceIdentifier):
     def __init__(
-        self,
-        *,
-        type_id: typing.Optional["ReferenceTypeId"] = None,
-        id: typing.Optional[str] = None,
-        key: typing.Optional[str] = None
+        self, *, id: typing.Optional[str] = None, key: typing.Optional[str] = None
     ) -> None:
         super().__init__(type_id=ReferenceTypeId.STORE, id=id, key=key)
 
@@ -226,7 +236,7 @@ class StoreUpdate(_BaseType):
     #: :class:`list`
     actions: list
 
-    def __init__(self, *, version: int = None, actions: list = None) -> None:
+    def __init__(self, *, version: int, actions: list) -> None:
         self.version = version
         self.actions = actions
         super().__init__()
@@ -239,7 +249,7 @@ class StoreUpdateAction(_BaseType):
     #: :class:`str`
     action: str
 
-    def __init__(self, *, action: str = None) -> None:
+    def __init__(self, *, action: str) -> None:
         self.action = action
         super().__init__()
 
@@ -251,9 +261,7 @@ class StoreSetLanguagesAction(StoreUpdateAction):
     #: Optional list of :class:`str`
     languages: typing.Optional[typing.List[str]]
 
-    def __init__(
-        self, *, action: str = None, languages: typing.Optional[typing.List[str]] = None
-    ) -> None:
+    def __init__(self, *, languages: typing.Optional[typing.List[str]] = None) -> None:
         self.languages = languages
         super().__init__(action="setLanguages")
 
@@ -268,9 +276,7 @@ class StoreSetNameAction(StoreUpdateAction):
     #: Optional :class:`commercetools.types.LocalizedString`
     name: typing.Optional["LocalizedString"]
 
-    def __init__(
-        self, *, action: str = None, name: typing.Optional["LocalizedString"] = None
-    ) -> None:
+    def __init__(self, *, name: typing.Optional["LocalizedString"] = None) -> None:
         self.name = name
         super().__init__(action="setName")
 
@@ -282,12 +288,7 @@ class StoresAddDistributionChannelsAction(StoreUpdateAction):
     #: :class:`commercetools.types.ChannelResourceIdentifier` `(Named` ``distributionChannel`` `in Commercetools)`
     distribution_channel: "ChannelResourceIdentifier"
 
-    def __init__(
-        self,
-        *,
-        action: str = None,
-        distribution_channel: "ChannelResourceIdentifier" = None
-    ) -> None:
+    def __init__(self, *, distribution_channel: "ChannelResourceIdentifier") -> None:
         self.distribution_channel = distribution_channel
         super().__init__(action="addDistributionChannel")
 
@@ -298,16 +299,26 @@ class StoresAddDistributionChannelsAction(StoreUpdateAction):
         )
 
 
+class StoresAddSupplyChannelsAction(StoreUpdateAction):
+    #: :class:`commercetools.types.ChannelResourceIdentifier` `(Named` ``supplyChannel`` `in Commercetools)`
+    supply_channel: "ChannelResourceIdentifier"
+
+    def __init__(self, *, supply_channel: "ChannelResourceIdentifier") -> None:
+        self.supply_channel = supply_channel
+        super().__init__(action="addSupplyChannel")
+
+    def __repr__(self) -> str:
+        return "StoresAddSupplyChannelsAction(action=%r, supply_channel=%r)" % (
+            self.action,
+            self.supply_channel,
+        )
+
+
 class StoresRemoveDistributionChannelsAction(StoreUpdateAction):
     #: :class:`commercetools.types.ChannelResourceIdentifier` `(Named` ``distributionChannel`` `in Commercetools)`
     distribution_channel: "ChannelResourceIdentifier"
 
-    def __init__(
-        self,
-        *,
-        action: str = None,
-        distribution_channel: "ChannelResourceIdentifier" = None
-    ) -> None:
+    def __init__(self, *, distribution_channel: "ChannelResourceIdentifier") -> None:
         self.distribution_channel = distribution_channel
         super().__init__(action="removeDistributionChannel")
 
@@ -318,6 +329,21 @@ class StoresRemoveDistributionChannelsAction(StoreUpdateAction):
         )
 
 
+class StoresRemoveSupplyChannelsAction(StoreUpdateAction):
+    #: :class:`commercetools.types.ChannelResourceIdentifier` `(Named` ``supplyChannel`` `in Commercetools)`
+    supply_channel: "ChannelResourceIdentifier"
+
+    def __init__(self, *, supply_channel: "ChannelResourceIdentifier") -> None:
+        self.supply_channel = supply_channel
+        super().__init__(action="removeSupplyChannel")
+
+    def __repr__(self) -> str:
+        return "StoresRemoveSupplyChannelsAction(action=%r, supply_channel=%r)" % (
+            self.action,
+            self.supply_channel,
+        )
+
+
 class StoresSetDistributionChannelsAction(StoreUpdateAction):
     #: Optional list of :class:`commercetools.types.ChannelResourceIdentifier` `(Named` ``distributionChannels`` `in Commercetools)`
     distribution_channels: typing.Optional[typing.List["ChannelResourceIdentifier"]]
@@ -325,7 +351,6 @@ class StoresSetDistributionChannelsAction(StoreUpdateAction):
     def __init__(
         self,
         *,
-        action: str = None,
         distribution_channels: typing.Optional[
             typing.List["ChannelResourceIdentifier"]
         ] = None
@@ -337,4 +362,25 @@ class StoresSetDistributionChannelsAction(StoreUpdateAction):
         return (
             "StoresSetDistributionChannelsAction(action=%r, distribution_channels=%r)"
             % (self.action, self.distribution_channels)
+        )
+
+
+class StoresSetSupplyChannelsAction(StoreUpdateAction):
+    #: Optional list of :class:`commercetools.types.ChannelResourceIdentifier` `(Named` ``supplyChannels`` `in Commercetools)`
+    supply_channels: typing.Optional[typing.List["ChannelResourceIdentifier"]]
+
+    def __init__(
+        self,
+        *,
+        supply_channels: typing.Optional[
+            typing.List["ChannelResourceIdentifier"]
+        ] = None
+    ) -> None:
+        self.supply_channels = supply_channels
+        super().__init__(action="setSupplyChannels")
+
+    def __repr__(self) -> str:
+        return "StoresSetSupplyChannelsAction(action=%r, supply_channels=%r)" % (
+            self.action,
+            self.supply_channels,
         )

--- a/src/commercetools/types/_subscription.py
+++ b/src/commercetools/types/_subscription.py
@@ -45,7 +45,7 @@ class ChangeSubscription(_BaseType):
     #: :class:`str` `(Named` ``resourceTypeId`` `in Commercetools)`
     resource_type_id: str
 
-    def __init__(self, *, resource_type_id: str = None) -> None:
+    def __init__(self, *, resource_type_id: str) -> None:
         self.resource_type_id = resource_type_id
         super().__init__()
 
@@ -57,7 +57,7 @@ class DeliveryFormat(_BaseType):
     #: :class:`str`
     type: str
 
-    def __init__(self, *, type: str = None) -> None:
+    def __init__(self, *, type: str) -> None:
         self.type = type
         super().__init__()
 
@@ -69,7 +69,7 @@ class Destination(_BaseType):
     #: :class:`str`
     type: str
 
-    def __init__(self, *, type: str = None) -> None:
+    def __init__(self, *, type: str) -> None:
         self.type = type
         super().__init__()
 
@@ -84,10 +84,7 @@ class MessageSubscription(_BaseType):
     types: typing.Optional[typing.List[str]]
 
     def __init__(
-        self,
-        *,
-        resource_type_id: str = None,
-        types: typing.Optional[typing.List[str]] = None
+        self, *, resource_type_id: str, types: typing.Optional[typing.List[str]] = None
     ) -> None:
         self.resource_type_id = resource_type_id
         self.types = types
@@ -106,7 +103,7 @@ class PayloadNotIncluded(_BaseType):
     #: :class:`str` `(Named` ``payloadType`` `in Commercetools)`
     payload_type: str
 
-    def __init__(self, *, reason: str = None, payload_type: str = None) -> None:
+    def __init__(self, *, reason: str, payload_type: str) -> None:
         self.reason = reason
         self.payload_type = payload_type
         super().__init__()
@@ -147,18 +144,18 @@ class Subscription(BaseResource):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        changes: typing.List["ChangeSubscription"],
+        destination: "Destination",
+        messages: typing.List["MessageSubscription"],
+        format: "DeliveryFormat",
+        status: "SubscriptionHealthStatus",
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
-        changes: typing.List["ChangeSubscription"] = None,
-        destination: "Destination" = None,
-        key: typing.Optional[str] = None,
-        messages: typing.List["MessageSubscription"] = None,
-        format: "DeliveryFormat" = None,
-        status: "SubscriptionHealthStatus" = None
+        key: typing.Optional[str] = None
     ) -> None:
         self.id = id
         self.version = version
@@ -212,9 +209,9 @@ class SubscriptionDelivery(_BaseType):
     def __init__(
         self,
         *,
-        project_key: str = None,
-        notification_type: str = None,
-        resource: "Reference" = None,
+        project_key: str,
+        notification_type: str,
+        resource: "Reference",
         resource_user_provided_identifiers: typing.Optional[
             "UserProvidedIdentifiers"
         ] = None
@@ -252,8 +249,8 @@ class SubscriptionDraft(_BaseType):
     def __init__(
         self,
         *,
+        destination: "Destination",
         changes: typing.Optional[typing.List["ChangeSubscription"]] = None,
-        destination: "Destination" = None,
         key: typing.Optional[str] = None,
         messages: typing.Optional[typing.List["MessageSubscription"]] = None,
         format: typing.Optional["DeliveryFormat"] = None
@@ -294,11 +291,11 @@ class SubscriptionPagedQueryResponse(_BaseType):
     def __init__(
         self,
         *,
-        limit: int = None,
-        count: int = None,
-        total: typing.Optional[int] = None,
-        offset: int = None,
-        results: typing.Sequence["Subscription"] = None
+        limit: int,
+        count: int,
+        offset: int,
+        results: typing.Sequence["Subscription"],
+        total: typing.Optional[int] = None
     ) -> None:
         self.limit = limit
         self.count = count
@@ -320,7 +317,7 @@ class SubscriptionUpdate(_BaseType):
     #: :class:`list`
     actions: list
 
-    def __init__(self, *, version: int = None, actions: list = None) -> None:
+    def __init__(self, *, version: int, actions: list) -> None:
         self.version = version
         self.actions = actions
         super().__init__()
@@ -336,7 +333,7 @@ class SubscriptionUpdateAction(_BaseType):
     #: :class:`str`
     action: str
 
-    def __init__(self, *, action: str = None) -> None:
+    def __init__(self, *, action: str) -> None:
         self.action = action
         super().__init__()
 
@@ -350,9 +347,7 @@ class AzureEventGridDestination(Destination):
     #: :class:`str` `(Named` ``accessKey`` `in Commercetools)`
     access_key: str
 
-    def __init__(
-        self, *, type: str = None, uri: str = None, access_key: str = None
-    ) -> None:
+    def __init__(self, *, uri: str, access_key: str) -> None:
         self.uri = uri
         self.access_key = access_key
         super().__init__(type="EventGrid")
@@ -369,7 +364,7 @@ class AzureServiceBusDestination(Destination):
     #: :class:`str` `(Named` ``connectionString`` `in Commercetools)`
     connection_string: str
 
-    def __init__(self, *, type: str = None, connection_string: str = None) -> None:
+    def __init__(self, *, connection_string: str) -> None:
         self.connection_string = connection_string
         super().__init__(type="AzureServiceBus")
 
@@ -384,7 +379,7 @@ class DeliveryCloudEventsFormat(DeliveryFormat):
     #: :class:`str` `(Named` ``cloudEventsVersion`` `in Commercetools)`
     cloud_events_version: str
 
-    def __init__(self, *, type: str = None, cloud_events_version: str = None) -> None:
+    def __init__(self, *, cloud_events_version: str) -> None:
         self.cloud_events_version = cloud_events_version
         super().__init__(type="CloudEvents")
 
@@ -396,7 +391,7 @@ class DeliveryCloudEventsFormat(DeliveryFormat):
 
 
 class DeliveryPlatformFormat(DeliveryFormat):
-    def __init__(self, *, type: str = None) -> None:
+    def __init__(self) -> None:
         super().__init__(type="Platform")
 
     def __repr__(self) -> str:
@@ -409,9 +404,7 @@ class GoogleCloudPubSubDestination(Destination):
     #: :class:`str`
     topic: str
 
-    def __init__(
-        self, *, type: str = None, project_id: str = None, topic: str = None
-    ) -> None:
+    def __init__(self, *, project_id: str, topic: str) -> None:
         self.project_id = project_id
         self.topic = topic
         super().__init__(type="GoogleCloudPubSub")
@@ -428,7 +421,7 @@ class IronMqDestination(Destination):
     #: :class:`str`
     uri: str
 
-    def __init__(self, *, type: str = None, uri: str = None) -> None:
+    def __init__(self, *, uri: str) -> None:
         self.uri = uri
         super().__init__(type="IronMQ")
 
@@ -455,19 +448,18 @@ class MessageDelivery(SubscriptionDelivery):
     def __init__(
         self,
         *,
-        project_key: str = None,
-        notification_type: str = None,
-        resource: "Reference" = None,
+        project_key: str,
+        resource: "Reference",
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        sequence_number: int,
+        resource_version: int,
+        payload_not_included: "PayloadNotIncluded",
         resource_user_provided_identifiers: typing.Optional[
             "UserProvidedIdentifiers"
-        ] = None,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
-        sequence_number: int = None,
-        resource_version: int = None,
-        payload_not_included: "PayloadNotIncluded" = None
+        ] = None
     ) -> None:
         self.id = id
         self.version = version
@@ -511,14 +503,13 @@ class ResourceCreatedDelivery(SubscriptionDelivery):
     def __init__(
         self,
         *,
-        project_key: str = None,
-        notification_type: str = None,
-        resource: "Reference" = None,
+        project_key: str,
+        resource: "Reference",
+        version: int,
+        modified_at: datetime.datetime,
         resource_user_provided_identifiers: typing.Optional[
             "UserProvidedIdentifiers"
-        ] = None,
-        version: int = None,
-        modified_at: datetime.datetime = None
+        ] = None
     ) -> None:
         self.version = version
         self.modified_at = modified_at
@@ -552,14 +543,13 @@ class ResourceDeletedDelivery(SubscriptionDelivery):
     def __init__(
         self,
         *,
-        project_key: str = None,
-        notification_type: str = None,
-        resource: "Reference" = None,
+        project_key: str,
+        resource: "Reference",
+        version: int,
+        modified_at: datetime.datetime,
         resource_user_provided_identifiers: typing.Optional[
             "UserProvidedIdentifiers"
-        ] = None,
-        version: int = None,
-        modified_at: datetime.datetime = None
+        ] = None
     ) -> None:
         self.version = version
         self.modified_at = modified_at
@@ -595,15 +585,14 @@ class ResourceUpdatedDelivery(SubscriptionDelivery):
     def __init__(
         self,
         *,
-        project_key: str = None,
-        notification_type: str = None,
-        resource: "Reference" = None,
+        project_key: str,
+        resource: "Reference",
+        version: int,
+        old_version: int,
+        modified_at: datetime.datetime,
         resource_user_provided_identifiers: typing.Optional[
             "UserProvidedIdentifiers"
-        ] = None,
-        version: int = None,
-        old_version: int = None,
-        modified_at: datetime.datetime = None
+        ] = None
     ) -> None:
         self.version = version
         self.old_version = old_version
@@ -638,14 +627,7 @@ class SnsDestination(Destination):
     #: :class:`str` `(Named` ``topicArn`` `in Commercetools)`
     topic_arn: str
 
-    def __init__(
-        self,
-        *,
-        type: str = None,
-        access_key: str = None,
-        access_secret: str = None,
-        topic_arn: str = None
-    ) -> None:
+    def __init__(self, *, access_key: str, access_secret: str, topic_arn: str) -> None:
         self.access_key = access_key
         self.access_secret = access_secret
         self.topic_arn = topic_arn
@@ -669,13 +651,7 @@ class SqsDestination(Destination):
     region: str
 
     def __init__(
-        self,
-        *,
-        type: str = None,
-        access_key: str = None,
-        access_secret: str = None,
-        queue_url: str = None,
-        region: str = None
+        self, *, access_key: str, access_secret: str, queue_url: str, region: str
     ) -> None:
         self.access_key = access_key
         self.access_secret = access_secret
@@ -700,9 +676,7 @@ class SubscriptionChangeDestinationAction(SubscriptionUpdateAction):
     #: :class:`commercetools.types.Destination`
     destination: "Destination"
 
-    def __init__(
-        self, *, action: str = None, destination: "Destination" = None
-    ) -> None:
+    def __init__(self, *, destination: "Destination") -> None:
         self.destination = destination
         super().__init__(action="changeDestination")
 
@@ -718,10 +692,7 @@ class SubscriptionSetChangesAction(SubscriptionUpdateAction):
     changes: typing.Optional[typing.List["ChangeSubscription"]]
 
     def __init__(
-        self,
-        *,
-        action: str = None,
-        changes: typing.Optional[typing.List["ChangeSubscription"]] = None
+        self, *, changes: typing.Optional[typing.List["ChangeSubscription"]] = None
     ) -> None:
         self.changes = changes
         super().__init__(action="setChanges")
@@ -737,7 +708,7 @@ class SubscriptionSetKeyAction(SubscriptionUpdateAction):
     #: Optional :class:`str`
     key: typing.Optional[str]
 
-    def __init__(self, *, action: str = None, key: typing.Optional[str] = None) -> None:
+    def __init__(self, *, key: typing.Optional[str] = None) -> None:
         self.key = key
         super().__init__(action="setKey")
 
@@ -750,10 +721,7 @@ class SubscriptionSetMessagesAction(SubscriptionUpdateAction):
     messages: typing.Optional[typing.List["MessageSubscription"]]
 
     def __init__(
-        self,
-        *,
-        action: str = None,
-        messages: typing.Optional[typing.List["MessageSubscription"]] = None
+        self, *, messages: typing.Optional[typing.List["MessageSubscription"]] = None
     ) -> None:
         self.messages = messages
         super().__init__(action="setMessages")

--- a/src/commercetools/types/_tax_category.py
+++ b/src/commercetools/types/_tax_category.py
@@ -38,7 +38,7 @@ class SubRate(_BaseType):
     #: :class:`float`
     amount: float
 
-    def __init__(self, *, name: str = None, amount: float = None) -> None:
+    def __init__(self, *, name: str, amount: float) -> None:
         self.name = name
         self.amount = amount
         super().__init__()
@@ -72,15 +72,15 @@ class TaxCategory(BaseResource):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        name: str,
+        rates: typing.List["TaxRate"],
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
-        name: str = None,
         description: typing.Optional[str] = None,
-        rates: typing.List["TaxRate"] = None,
         key: typing.Optional[str] = None
     ) -> None:
         self.id = id
@@ -131,9 +131,9 @@ class TaxCategoryDraft(_BaseType):
     def __init__(
         self,
         *,
-        name: str = None,
+        name: str,
+        rates: typing.List["TaxRateDraft"],
         description: typing.Optional[str] = None,
-        rates: typing.List["TaxRateDraft"] = None,
         key: typing.Optional[str] = None
     ) -> None:
         self.name = name
@@ -166,11 +166,11 @@ class TaxCategoryPagedQueryResponse(_BaseType):
     def __init__(
         self,
         *,
-        limit: int = None,
-        count: int = None,
-        total: typing.Optional[int] = None,
-        offset: int = None,
-        results: typing.Sequence["TaxCategory"] = None
+        limit: int,
+        count: int,
+        offset: int,
+        results: typing.Sequence["TaxCategory"],
+        total: typing.Optional[int] = None
     ) -> None:
         self.limit = limit
         self.count = count
@@ -190,13 +190,7 @@ class TaxCategoryReference(Reference):
     #: Optional :class:`commercetools.types.TaxCategory`
     obj: typing.Optional["TaxCategory"]
 
-    def __init__(
-        self,
-        *,
-        type_id: "ReferenceTypeId" = None,
-        id: str = None,
-        obj: typing.Optional["TaxCategory"] = None
-    ) -> None:
+    def __init__(self, *, id: str, obj: typing.Optional["TaxCategory"] = None) -> None:
         self.obj = obj
         super().__init__(type_id=ReferenceTypeId.TAX_CATEGORY, id=id)
 
@@ -210,11 +204,7 @@ class TaxCategoryReference(Reference):
 
 class TaxCategoryResourceIdentifier(ResourceIdentifier):
     def __init__(
-        self,
-        *,
-        type_id: typing.Optional["ReferenceTypeId"] = None,
-        id: typing.Optional[str] = None,
-        key: typing.Optional[str] = None
+        self, *, id: typing.Optional[str] = None, key: typing.Optional[str] = None
     ) -> None:
         super().__init__(type_id=ReferenceTypeId.TAX_CATEGORY, id=id, key=key)
 
@@ -232,7 +222,7 @@ class TaxCategoryUpdate(_BaseType):
     #: :class:`list`
     actions: list
 
-    def __init__(self, *, version: int = None, actions: list = None) -> None:
+    def __init__(self, *, version: int, actions: list) -> None:
         self.version = version
         self.actions = actions
         super().__init__()
@@ -248,7 +238,7 @@ class TaxCategoryUpdateAction(_BaseType):
     #: :class:`str`
     action: str
 
-    def __init__(self, *, action: str = None) -> None:
+    def __init__(self, *, action: str) -> None:
         self.action = action
         super().__init__()
 
@@ -275,11 +265,11 @@ class TaxRate(_BaseType):
     def __init__(
         self,
         *,
+        name: str,
+        amount: float,
+        included_in_price: bool,
+        country: "str",
         id: typing.Optional[str] = None,
-        name: str = None,
-        amount: float = None,
-        included_in_price: bool = None,
-        country: "str" = None,
         state: typing.Optional[str] = None,
         sub_rates: typing.Optional[typing.List["SubRate"]] = None
     ) -> None:
@@ -324,10 +314,10 @@ class TaxRateDraft(_BaseType):
     def __init__(
         self,
         *,
-        name: str = None,
+        name: str,
+        included_in_price: bool,
+        country: "str",
         amount: typing.Optional[float] = None,
-        included_in_price: bool = None,
-        country: "str" = None,
         state: typing.Optional[str] = None,
         sub_rates: typing.Optional[typing.List["SubRate"]] = None
     ) -> None:
@@ -357,7 +347,7 @@ class TaxCategoryAddTaxRateAction(TaxCategoryUpdateAction):
     #: :class:`commercetools.types.TaxRateDraft` `(Named` ``taxRate`` `in Commercetools)`
     tax_rate: "TaxRateDraft"
 
-    def __init__(self, *, action: str = None, tax_rate: "TaxRateDraft" = None) -> None:
+    def __init__(self, *, tax_rate: "TaxRateDraft") -> None:
         self.tax_rate = tax_rate
         super().__init__(action="addTaxRate")
 
@@ -372,7 +362,7 @@ class TaxCategoryChangeNameAction(TaxCategoryUpdateAction):
     #: :class:`str`
     name: str
 
-    def __init__(self, *, action: str = None, name: str = None) -> None:
+    def __init__(self, *, name: str) -> None:
         self.name = name
         super().__init__(action="changeName")
 
@@ -387,7 +377,7 @@ class TaxCategoryRemoveTaxRateAction(TaxCategoryUpdateAction):
     #: :class:`str` `(Named` ``taxRateId`` `in Commercetools)`
     tax_rate_id: str
 
-    def __init__(self, *, action: str = None, tax_rate_id: str = None) -> None:
+    def __init__(self, *, tax_rate_id: str) -> None:
         self.tax_rate_id = tax_rate_id
         super().__init__(action="removeTaxRate")
 
@@ -404,13 +394,7 @@ class TaxCategoryReplaceTaxRateAction(TaxCategoryUpdateAction):
     #: :class:`commercetools.types.TaxRateDraft` `(Named` ``taxRate`` `in Commercetools)`
     tax_rate: "TaxRateDraft"
 
-    def __init__(
-        self,
-        *,
-        action: str = None,
-        tax_rate_id: str = None,
-        tax_rate: "TaxRateDraft" = None
-    ) -> None:
+    def __init__(self, *, tax_rate_id: str, tax_rate: "TaxRateDraft") -> None:
         self.tax_rate_id = tax_rate_id
         self.tax_rate = tax_rate
         super().__init__(action="replaceTaxRate")
@@ -426,9 +410,7 @@ class TaxCategorySetDescriptionAction(TaxCategoryUpdateAction):
     #: Optional :class:`str`
     description: typing.Optional[str]
 
-    def __init__(
-        self, *, action: str = None, description: typing.Optional[str] = None
-    ) -> None:
+    def __init__(self, *, description: typing.Optional[str] = None) -> None:
         self.description = description
         super().__init__(action="setDescription")
 
@@ -443,7 +425,7 @@ class TaxCategorySetKeyAction(TaxCategoryUpdateAction):
     #: Optional :class:`str`
     key: typing.Optional[str]
 
-    def __init__(self, *, action: str = None, key: typing.Optional[str] = None) -> None:
+    def __init__(self, *, key: typing.Optional[str] = None) -> None:
         self.key = key
         super().__init__(action="setKey")
 

--- a/src/commercetools/types/_type.py
+++ b/src/commercetools/types/_type.py
@@ -66,7 +66,7 @@ class CustomFieldEnumValue(_BaseType):
     #: :class:`str`
     label: str
 
-    def __init__(self, *, key: str = None, label: str = None) -> None:
+    def __init__(self, *, key: str, label: str) -> None:
         self.key = key
         self.label = label
         super().__init__()
@@ -81,7 +81,7 @@ class CustomFieldLocalizedEnumValue(_BaseType):
     #: :class:`commercetools.types.LocalizedString`
     label: "LocalizedString"
 
-    def __init__(self, *, key: str = None, label: "LocalizedString" = None) -> None:
+    def __init__(self, *, key: str, label: "LocalizedString") -> None:
         self.key = key
         self.label = label
         super().__init__()
@@ -99,9 +99,7 @@ class CustomFields(_BaseType):
     #: :class:`commercetools.types.FieldContainer`
     fields: "FieldContainer"
 
-    def __init__(
-        self, *, type: "TypeReference" = None, fields: "FieldContainer" = None
-    ) -> None:
+    def __init__(self, *, type: "TypeReference", fields: "FieldContainer") -> None:
         self.type = type
         self.fields = fields
         super().__init__()
@@ -119,7 +117,7 @@ class CustomFieldsDraft(_BaseType):
     def __init__(
         self,
         *,
-        type: "TypeResourceIdentifier" = None,
+        type: "TypeResourceIdentifier",
         fields: typing.Optional["FieldContainer"] = None,
     ) -> None:
         self.type = type
@@ -150,10 +148,10 @@ class FieldDefinition(_BaseType):
     def __init__(
         self,
         *,
-        type: "FieldType" = None,
-        name: str = None,
-        label: "LocalizedString" = None,
-        required: bool = None,
+        type: "FieldType",
+        name: str,
+        label: "LocalizedString",
+        required: bool,
         input_hint: typing.Optional["TypeTextInputHint"] = None,
     ) -> None:
         self.type = type
@@ -174,7 +172,7 @@ class FieldType(_BaseType):
     #: :class:`str`
     name: str
 
-    def __init__(self, *, name: str = None) -> None:
+    def __init__(self, *, name: str) -> None:
         self.name = name
         super().__init__()
 
@@ -230,17 +228,17 @@ class Type(BaseResource):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        key: str,
+        name: "LocalizedString",
+        resource_type_ids: typing.List["ResourceTypeId"],
+        field_definitions: typing.List["FieldDefinition"],
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
-        key: str = None,
-        name: "LocalizedString" = None,
         description: typing.Optional["LocalizedString"] = None,
-        resource_type_ids: typing.List["ResourceTypeId"] = None,
-        field_definitions: typing.List["FieldDefinition"] = None,
     ) -> None:
         self.id = id
         self.version = version
@@ -294,10 +292,10 @@ class TypeDraft(_BaseType):
     def __init__(
         self,
         *,
-        key: str = None,
-        name: "LocalizedString" = None,
+        key: str,
+        name: "LocalizedString",
+        resource_type_ids: typing.List["ResourceTypeId"],
         description: typing.Optional["LocalizedString"] = None,
-        resource_type_ids: typing.List["ResourceTypeId"] = None,
         field_definitions: typing.Optional[typing.List["FieldDefinition"]] = None,
     ) -> None:
         self.key = key
@@ -335,11 +333,11 @@ class TypePagedQueryResponse(_BaseType):
     def __init__(
         self,
         *,
-        limit: int = None,
-        count: int = None,
+        limit: int,
+        count: int,
+        offset: int,
+        results: typing.Sequence["Type"],
         total: typing.Optional[int] = None,
-        offset: int = None,
-        results: typing.Sequence["Type"] = None,
     ) -> None:
         self.limit = limit
         self.count = count
@@ -359,13 +357,7 @@ class TypeReference(Reference):
     #: Optional :class:`commercetools.types.Type`
     obj: typing.Optional["Type"]
 
-    def __init__(
-        self,
-        *,
-        type_id: "ReferenceTypeId" = None,
-        id: str = None,
-        obj: typing.Optional["Type"] = None,
-    ) -> None:
+    def __init__(self, *, id: str, obj: typing.Optional["Type"] = None) -> None:
         self.obj = obj
         super().__init__(type_id=ReferenceTypeId.TYPE, id=id)
 
@@ -379,11 +371,7 @@ class TypeReference(Reference):
 
 class TypeResourceIdentifier(ResourceIdentifier):
     def __init__(
-        self,
-        *,
-        type_id: typing.Optional["ReferenceTypeId"] = None,
-        id: typing.Optional[str] = None,
-        key: typing.Optional[str] = None,
+        self, *, id: typing.Optional[str] = None, key: typing.Optional[str] = None
     ) -> None:
         super().__init__(type_id=ReferenceTypeId.TYPE, id=id, key=key)
 
@@ -406,7 +394,7 @@ class TypeUpdate(_BaseType):
     #: :class:`list`
     actions: list
 
-    def __init__(self, *, version: int = None, actions: list = None) -> None:
+    def __init__(self, *, version: int, actions: list) -> None:
         self.version = version
         self.actions = actions
         super().__init__()
@@ -419,7 +407,7 @@ class TypeUpdateAction(_BaseType):
     #: :class:`str`
     action: str
 
-    def __init__(self, *, action: str = None) -> None:
+    def __init__(self, *, action: str) -> None:
         self.action = action
         super().__init__()
 
@@ -428,7 +416,7 @@ class TypeUpdateAction(_BaseType):
 
 
 class CustomFieldBooleanType(FieldType):
-    def __init__(self, *, name: str = None) -> None:
+    def __init__(self) -> None:
         super().__init__(name="Boolean")
 
     def __repr__(self) -> str:
@@ -436,7 +424,7 @@ class CustomFieldBooleanType(FieldType):
 
 
 class CustomFieldDateTimeType(FieldType):
-    def __init__(self, *, name: str = None) -> None:
+    def __init__(self) -> None:
         super().__init__(name="DateTime")
 
     def __repr__(self) -> str:
@@ -444,7 +432,7 @@ class CustomFieldDateTimeType(FieldType):
 
 
 class CustomFieldDateType(FieldType):
-    def __init__(self, *, name: str = None) -> None:
+    def __init__(self) -> None:
         super().__init__(name="Date")
 
     def __repr__(self) -> str:
@@ -455,9 +443,7 @@ class CustomFieldEnumType(FieldType):
     #: List of :class:`commercetools.types.CustomFieldEnumValue`
     values: typing.List["CustomFieldEnumValue"]
 
-    def __init__(
-        self, *, name: str = None, values: typing.List["CustomFieldEnumValue"] = None
-    ) -> None:
+    def __init__(self, *, values: typing.List["CustomFieldEnumValue"]) -> None:
         self.values = values
         super().__init__(name="Enum")
 
@@ -469,12 +455,7 @@ class CustomFieldLocalizedEnumType(FieldType):
     #: List of :class:`commercetools.types.CustomFieldLocalizedEnumValue`
     values: typing.List["CustomFieldLocalizedEnumValue"]
 
-    def __init__(
-        self,
-        *,
-        name: str = None,
-        values: typing.List["CustomFieldLocalizedEnumValue"] = None,
-    ) -> None:
+    def __init__(self, *, values: typing.List["CustomFieldLocalizedEnumValue"]) -> None:
         self.values = values
         super().__init__(name="LocalizedEnum")
 
@@ -486,7 +467,7 @@ class CustomFieldLocalizedEnumType(FieldType):
 
 
 class CustomFieldLocalizedStringType(FieldType):
-    def __init__(self, *, name: str = None) -> None:
+    def __init__(self) -> None:
         super().__init__(name="LocalizedString")
 
     def __repr__(self) -> str:
@@ -494,7 +475,7 @@ class CustomFieldLocalizedStringType(FieldType):
 
 
 class CustomFieldMoneyType(FieldType):
-    def __init__(self, *, name: str = None) -> None:
+    def __init__(self) -> None:
         super().__init__(name="Money")
 
     def __repr__(self) -> str:
@@ -502,7 +483,7 @@ class CustomFieldMoneyType(FieldType):
 
 
 class CustomFieldNumberType(FieldType):
-    def __init__(self, *, name: str = None) -> None:
+    def __init__(self) -> None:
         super().__init__(name="Number")
 
     def __repr__(self) -> str:
@@ -513,9 +494,7 @@ class CustomFieldReferenceType(FieldType):
     #: :class:`commercetools.types.ReferenceTypeId` `(Named` ``referenceTypeId`` `in Commercetools)`
     reference_type_id: "ReferenceTypeId"
 
-    def __init__(
-        self, *, name: str = None, reference_type_id: "ReferenceTypeId" = None
-    ) -> None:
+    def __init__(self, *, reference_type_id: "ReferenceTypeId") -> None:
         self.reference_type_id = reference_type_id
         super().__init__(name="Reference")
 
@@ -530,7 +509,7 @@ class CustomFieldSetType(FieldType):
     #: :class:`commercetools.types.FieldType` `(Named` ``elementType`` `in Commercetools)`
     element_type: "FieldType"
 
-    def __init__(self, *, name: str = None, element_type: "FieldType" = None) -> None:
+    def __init__(self, *, element_type: "FieldType") -> None:
         self.element_type = element_type
         super().__init__(name="Set")
 
@@ -542,7 +521,7 @@ class CustomFieldSetType(FieldType):
 
 
 class CustomFieldStringType(FieldType):
-    def __init__(self, *, name: str = None) -> None:
+    def __init__(self) -> None:
         super().__init__(name="String")
 
     def __repr__(self) -> str:
@@ -550,7 +529,7 @@ class CustomFieldStringType(FieldType):
 
 
 class CustomFieldTimeType(FieldType):
-    def __init__(self, *, name: str = None) -> None:
+    def __init__(self) -> None:
         super().__init__(name="Time")
 
     def __repr__(self) -> str:
@@ -563,13 +542,7 @@ class TypeAddEnumValueAction(TypeUpdateAction):
     #: :class:`commercetools.types.CustomFieldEnumValue`
     value: "CustomFieldEnumValue"
 
-    def __init__(
-        self,
-        *,
-        action: str = None,
-        field_name: str = None,
-        value: "CustomFieldEnumValue" = None,
-    ) -> None:
+    def __init__(self, *, field_name: str, value: "CustomFieldEnumValue") -> None:
         self.field_name = field_name
         self.value = value
         super().__init__(action="addEnumValue")
@@ -586,9 +559,7 @@ class TypeAddFieldDefinitionAction(TypeUpdateAction):
     #: :class:`commercetools.types.FieldDefinition` `(Named` ``fieldDefinition`` `in Commercetools)`
     field_definition: "FieldDefinition"
 
-    def __init__(
-        self, *, action: str = None, field_definition: "FieldDefinition" = None
-    ) -> None:
+    def __init__(self, *, field_definition: "FieldDefinition") -> None:
         self.field_definition = field_definition
         super().__init__(action="addFieldDefinition")
 
@@ -606,11 +577,7 @@ class TypeAddLocalizedEnumValueAction(TypeUpdateAction):
     value: "CustomFieldLocalizedEnumValue"
 
     def __init__(
-        self,
-        *,
-        action: str = None,
-        field_name: str = None,
-        value: "CustomFieldLocalizedEnumValue" = None,
+        self, *, field_name: str, value: "CustomFieldLocalizedEnumValue"
     ) -> None:
         self.field_name = field_name
         self.value = value
@@ -630,13 +597,7 @@ class TypeChangeEnumValueLabelAction(TypeUpdateAction):
     #: :class:`commercetools.types.CustomFieldEnumValue`
     value: "CustomFieldEnumValue"
 
-    def __init__(
-        self,
-        *,
-        action: str = None,
-        field_name: str = None,
-        value: "CustomFieldEnumValue" = None,
-    ) -> None:
+    def __init__(self, *, field_name: str, value: "CustomFieldEnumValue") -> None:
         self.field_name = field_name
         self.value = value
         super().__init__(action="changeEnumValueLabel")
@@ -655,13 +616,7 @@ class TypeChangeEnumValueOrderAction(TypeUpdateAction):
     #: List of :class:`str`
     keys: typing.List[str]
 
-    def __init__(
-        self,
-        *,
-        action: str = None,
-        field_name: str = None,
-        keys: typing.List[str] = None,
-    ) -> None:
+    def __init__(self, *, field_name: str, keys: typing.List[str]) -> None:
         self.field_name = field_name
         self.keys = keys
         super().__init__(action="changeEnumValueOrder")
@@ -680,13 +635,7 @@ class TypeChangeFieldDefinitionLabelAction(TypeUpdateAction):
     #: :class:`commercetools.types.LocalizedString`
     label: "LocalizedString"
 
-    def __init__(
-        self,
-        *,
-        action: str = None,
-        field_name: str = None,
-        label: "LocalizedString" = None,
-    ) -> None:
+    def __init__(self, *, field_name: str, label: "LocalizedString") -> None:
         self.field_name = field_name
         self.label = label
         super().__init__(action="changeFieldDefinitionLabel")
@@ -702,9 +651,7 @@ class TypeChangeFieldDefinitionOrderAction(TypeUpdateAction):
     #: List of :class:`str` `(Named` ``fieldNames`` `in Commercetools)`
     field_names: typing.List[str]
 
-    def __init__(
-        self, *, action: str = None, field_names: typing.List[str] = None
-    ) -> None:
+    def __init__(self, *, field_names: typing.List[str]) -> None:
         self.field_names = field_names
         super().__init__(action="changeFieldDefinitionOrder")
 
@@ -721,13 +668,7 @@ class TypeChangeInputHintAction(TypeUpdateAction):
     #: :class:`commercetools.types.TypeTextInputHint` `(Named` ``inputHint`` `in Commercetools)`
     input_hint: "TypeTextInputHint"
 
-    def __init__(
-        self,
-        *,
-        action: str = None,
-        field_name: str = None,
-        input_hint: "TypeTextInputHint" = None,
-    ) -> None:
+    def __init__(self, *, field_name: str, input_hint: "TypeTextInputHint") -> None:
         self.field_name = field_name
         self.input_hint = input_hint
         super().__init__(action="changeInputHint")
@@ -744,7 +685,7 @@ class TypeChangeKeyAction(TypeUpdateAction):
     #: :class:`str`
     key: str
 
-    def __init__(self, *, action: str = None, key: str = None) -> None:
+    def __init__(self, *, key: str) -> None:
         self.key = key
         super().__init__(action="changeKey")
 
@@ -758,13 +699,7 @@ class TypeChangeLabelAction(TypeUpdateAction):
     #: :class:`commercetools.types.LocalizedString`
     label: "LocalizedString"
 
-    def __init__(
-        self,
-        *,
-        action: str = None,
-        field_name: str = None,
-        label: "LocalizedString" = None,
-    ) -> None:
+    def __init__(self, *, field_name: str, label: "LocalizedString") -> None:
         self.field_name = field_name
         self.label = label
         super().__init__(action="changeLabel")
@@ -784,11 +719,7 @@ class TypeChangeLocalizedEnumValueLabelAction(TypeUpdateAction):
     value: "CustomFieldLocalizedEnumValue"
 
     def __init__(
-        self,
-        *,
-        action: str = None,
-        field_name: str = None,
-        value: "CustomFieldLocalizedEnumValue" = None,
+        self, *, field_name: str, value: "CustomFieldLocalizedEnumValue"
     ) -> None:
         self.field_name = field_name
         self.value = value
@@ -807,13 +738,7 @@ class TypeChangeLocalizedEnumValueOrderAction(TypeUpdateAction):
     #: List of :class:`str`
     keys: typing.List[str]
 
-    def __init__(
-        self,
-        *,
-        action: str = None,
-        field_name: str = None,
-        keys: typing.List[str] = None,
-    ) -> None:
+    def __init__(self, *, field_name: str, keys: typing.List[str]) -> None:
         self.field_name = field_name
         self.keys = keys
         super().__init__(action="changeLocalizedEnumValueOrder")
@@ -829,7 +754,7 @@ class TypeChangeNameAction(TypeUpdateAction):
     #: :class:`commercetools.types.LocalizedString`
     name: "LocalizedString"
 
-    def __init__(self, *, action: str = None, name: "LocalizedString" = None) -> None:
+    def __init__(self, *, name: "LocalizedString") -> None:
         self.name = name
         super().__init__(action="changeName")
 
@@ -841,7 +766,7 @@ class TypeRemoveFieldDefinitionAction(TypeUpdateAction):
     #: :class:`str` `(Named` ``fieldName`` `in Commercetools)`
     field_name: str
 
-    def __init__(self, *, action: str = None, field_name: str = None) -> None:
+    def __init__(self, *, field_name: str) -> None:
         self.field_name = field_name
         super().__init__(action="removeFieldDefinition")
 
@@ -857,10 +782,7 @@ class TypeSetDescriptionAction(TypeUpdateAction):
     description: typing.Optional["LocalizedString"]
 
     def __init__(
-        self,
-        *,
-        action: str = None,
-        description: typing.Optional["LocalizedString"] = None,
+        self, *, description: typing.Optional["LocalizedString"] = None
     ) -> None:
         self.description = description
         super().__init__(action="setDescription")

--- a/src/commercetools/types/_zone.py
+++ b/src/commercetools/types/_zone.py
@@ -35,9 +35,7 @@ class Location(_BaseType):
     #: Optional :class:`str`
     state: typing.Optional[str]
 
-    def __init__(
-        self, *, country: "str" = None, state: typing.Optional[str] = None
-    ) -> None:
+    def __init__(self, *, country: "str", state: typing.Optional[str] = None) -> None:
         self.country = country
         self.state = state
         super().__init__()
@@ -71,16 +69,16 @@ class Zone(BaseResource):
     def __init__(
         self,
         *,
-        id: str = None,
-        version: int = None,
-        created_at: datetime.datetime = None,
-        last_modified_at: datetime.datetime = None,
+        id: str,
+        version: int,
+        created_at: datetime.datetime,
+        last_modified_at: datetime.datetime,
+        name: str,
+        locations: typing.List["Location"],
         last_modified_by: typing.Optional["LastModifiedBy"] = None,
         created_by: typing.Optional["CreatedBy"] = None,
         key: typing.Optional[str] = None,
-        name: str = None,
-        description: typing.Optional[str] = None,
-        locations: typing.List["Location"] = None
+        description: typing.Optional[str] = None
     ) -> None:
         self.id = id
         self.version = version
@@ -130,10 +128,10 @@ class ZoneDraft(_BaseType):
     def __init__(
         self,
         *,
+        name: str,
+        locations: typing.List["Location"],
         key: typing.Optional[str] = None,
-        name: str = None,
-        description: typing.Optional[str] = None,
-        locations: typing.List["Location"] = None
+        description: typing.Optional[str] = None
     ) -> None:
         self.key = key
         self.name = name
@@ -165,11 +163,11 @@ class ZonePagedQueryResponse(_BaseType):
     def __init__(
         self,
         *,
-        limit: int = None,
-        count: int = None,
-        total: typing.Optional[int] = None,
-        offset: int = None,
-        results: typing.Sequence["Zone"] = None
+        limit: int,
+        count: int,
+        offset: int,
+        results: typing.Sequence["Zone"],
+        total: typing.Optional[int] = None
     ) -> None:
         self.limit = limit
         self.count = count
@@ -189,13 +187,7 @@ class ZoneReference(Reference):
     #: Optional :class:`commercetools.types.Zone`
     obj: typing.Optional["Zone"]
 
-    def __init__(
-        self,
-        *,
-        type_id: "ReferenceTypeId" = None,
-        id: str = None,
-        obj: typing.Optional["Zone"] = None
-    ) -> None:
+    def __init__(self, *, id: str, obj: typing.Optional["Zone"] = None) -> None:
         self.obj = obj
         super().__init__(type_id=ReferenceTypeId.ZONE, id=id)
 
@@ -209,11 +201,7 @@ class ZoneReference(Reference):
 
 class ZoneResourceIdentifier(ResourceIdentifier):
     def __init__(
-        self,
-        *,
-        type_id: typing.Optional["ReferenceTypeId"] = None,
-        id: typing.Optional[str] = None,
-        key: typing.Optional[str] = None
+        self, *, id: typing.Optional[str] = None, key: typing.Optional[str] = None
     ) -> None:
         super().__init__(type_id=ReferenceTypeId.ZONE, id=id, key=key)
 
@@ -231,7 +219,7 @@ class ZoneUpdate(_BaseType):
     #: :class:`list`
     actions: list
 
-    def __init__(self, *, version: int = None, actions: list = None) -> None:
+    def __init__(self, *, version: int, actions: list) -> None:
         self.version = version
         self.actions = actions
         super().__init__()
@@ -244,7 +232,7 @@ class ZoneUpdateAction(_BaseType):
     #: :class:`str`
     action: str
 
-    def __init__(self, *, action: str = None) -> None:
+    def __init__(self, *, action: str) -> None:
         self.action = action
         super().__init__()
 
@@ -256,7 +244,7 @@ class ZoneAddLocationAction(ZoneUpdateAction):
     #: :class:`commercetools.types.Location`
     location: "Location"
 
-    def __init__(self, *, action: str = None, location: "Location" = None) -> None:
+    def __init__(self, *, location: "Location") -> None:
         self.location = location
         super().__init__(action="addLocation")
 
@@ -271,7 +259,7 @@ class ZoneChangeNameAction(ZoneUpdateAction):
     #: :class:`str`
     name: str
 
-    def __init__(self, *, action: str = None, name: str = None) -> None:
+    def __init__(self, *, name: str) -> None:
         self.name = name
         super().__init__(action="changeName")
 
@@ -283,7 +271,7 @@ class ZoneRemoveLocationAction(ZoneUpdateAction):
     #: :class:`commercetools.types.Location`
     location: "Location"
 
-    def __init__(self, *, action: str = None, location: "Location" = None) -> None:
+    def __init__(self, *, location: "Location") -> None:
         self.location = location
         super().__init__(action="removeLocation")
 
@@ -298,9 +286,7 @@ class ZoneSetDescriptionAction(ZoneUpdateAction):
     #: Optional :class:`str`
     description: typing.Optional[str]
 
-    def __init__(
-        self, *, action: str = None, description: typing.Optional[str] = None
-    ) -> None:
+    def __init__(self, *, description: typing.Optional[str] = None) -> None:
         self.description = description
         super().__init__(action="setDescription")
 
@@ -315,7 +301,7 @@ class ZoneSetKeyAction(ZoneUpdateAction):
     #: Optional :class:`str`
     key: typing.Optional[str]
 
-    def __init__(self, *, action: str = None, key: typing.Optional[str] = None) -> None:
+    def __init__(self, *, key: typing.Optional[str] = None) -> None:
         self.key = key
         super().__init__(action="setKey")
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -78,13 +78,10 @@ def test_resource_update_conflict(client):
         types.ProductDraft(
             key="test-product",
             product_type=types.ProductTypeResourceIdentifier(key="dummy"),
-            name={
-                "en": "my-product",
-            },
-            slug={
-                "en": "foo-bar"
-            }
-        ))
+            name={"en": "my-product"},
+            slug={"en": "foo-bar"},
+        )
+    )
 
     assert product.version == 1
     assert uuid.UUID(product.id)
@@ -133,13 +130,10 @@ def test_resource_delete_conflict(client):
         types.ProductDraft(
             key="test-product",
             product_type=types.ProductTypeResourceIdentifier(key="dummy"),
-            name={
-                "en": "my-product",
-            },
-            slug={
-                "en": "foo-bar"
-            }
-        ))
+            name={"en": "my-product"},
+            slug={"en": "foo-bar"},
+        )
+    )
 
     product = client.products.update_by_id(
         id=product.id,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -74,7 +74,17 @@ def test_resource_update_conflict(client):
     It doesn't test the actual update itself.
     TODO: See if this is worth testing since we're using a mocking backend
     """
-    product = client.products.create(types.ProductDraft(key="test-product"))
+    product = client.products.create(
+        types.ProductDraft(
+            key="test-product",
+            product_type=types.ProductTypeResourceIdentifier(key="dummy"),
+            name={
+                "en": "my-product",
+            },
+            slug={
+                "en": "foo-bar"
+            }
+        ))
 
     assert product.version == 1
     assert uuid.UUID(product.id)
@@ -119,7 +129,17 @@ def test_resource_delete_conflict(client):
     It doesn't test the actual update itself.
     TODO: See if this is worth testing since we're using a mocking backend
     """
-    product = client.products.create(types.ProductDraft(key="test-product"))
+    product = client.products.create(
+        types.ProductDraft(
+            key="test-product",
+            product_type=types.ProductTypeResourceIdentifier(key="dummy"),
+            name={
+                "en": "my-product",
+            },
+            slug={
+                "en": "foo-bar"
+            }
+        ))
 
     product = client.products.update_by_id(
         id=product.id,

--- a/tests/test_expand.py
+++ b/tests/test_expand.py
@@ -1,5 +1,5 @@
-from commercetools import types
 import commercetools
+from commercetools import types
 from tests.test_service_order import get_test_order
 
 
@@ -7,9 +7,7 @@ def test_unknown_expand_terms(client: commercetools.Client):
     cart = client.carts.create(types.CartDraft(currency="EUR"))
 
     order = client.orders.create(
-        types.OrderFromCartDraft(
-            id=cart.id, version=1, order_number="test-order"
-        ),
+        types.OrderFromCartDraft(id=cart.id, version=1, order_number="test-order"),
         expand="nonExisting",
     )
 
@@ -43,12 +41,12 @@ def test_unknown_reference_expand_terms(client, commercetools_api):
 def test_multiple_expand(client, commercetools_api):
     shipping_method = client.shipping_methods.create(
         types.ShippingMethodDraft(
-            key="test-shipping-method", name="test shipping method",
+            key="test-shipping-method",
+            name="test shipping method",
             tax_category=types.TaxCategoryResourceIdentifier(id="dummy"),
             zone_rates=[],
             is_default=False,
         )
-
     )
 
     payment = client.payments.create(

--- a/tests/test_expand.py
+++ b/tests/test_expand.py
@@ -43,8 +43,12 @@ def test_unknown_reference_expand_terms(client, commercetools_api):
 def test_multiple_expand(client, commercetools_api):
     shipping_method = client.shipping_methods.create(
         types.ShippingMethodDraft(
-            key="test-shipping-method", name="test shipping method"
+            key="test-shipping-method", name="test shipping method",
+            tax_category=types.TaxCategoryResourceIdentifier(id="dummy"),
+            zone_rates=[],
+            is_default=False,
         )
+
     )
 
     payment = client.payments.create(

--- a/tests/test_expand.py
+++ b/tests/test_expand.py
@@ -1,10 +1,16 @@
 from commercetools import types
+import commercetools
 from tests.test_service_order import get_test_order
 
 
-def test_unknown_expand_terms(client):
+def test_unknown_expand_terms(client: commercetools.Client):
+    cart = client.carts.create(types.CartDraft(currency="EUR"))
+
     order = client.orders.create(
-        types.OrderFromCartDraft(order_number="test-order"), expand="nonExisting"
+        types.OrderFromCartDraft(
+            id=cart.id, version=1, order_number="test-order"
+        ),
+        expand="nonExisting",
     )
 
     assert order.id

--- a/tests/test_mock_server.py
+++ b/tests/test_mock_server.py
@@ -2,13 +2,14 @@ import os
 
 import requests
 
-from commercetools import Client
+from commercetools import Client, types
 from commercetools.types import (
     ChannelDraft,
     ChannelResourceIdentifier,
     ChannelRoleEnum,
     LocalizedString,
     ProductDraft,
+    ProductTypeResourceIdentifier,
     StoreDraft,
 )
 
@@ -27,7 +28,14 @@ def test_http_server(commercetools_client, commercetools_http_server):
 
     query_result = client.products.query()
     assert query_result.count == 0
-    product = client.products.create(ProductDraft(name=LocalizedString(nl="Testje")))
+    product = client.products.create(
+        ProductDraft(
+            key="test-product",
+            product_type=ProductTypeResourceIdentifier(key="dummy"),
+            name={"nl": "Testje"},
+            slug={"en": "foo-bar"},
+        )
+    )
 
     client.products.get_by_id(product.id)
     url = commercetools_http_server.api_url + f"/unittest/products/{product.id}"
@@ -56,7 +64,9 @@ def test_http_server_expanding(commercetools_client, commercetools_http_server):
 
     store = client.stores.create(
         StoreDraft(
-            key="FOO", distribution_channels=[ChannelResourceIdentifier(key="FOO")]
+            name=types.LocalizedString(nl="foo"),
+            key="FOO",
+            distribution_channels=[ChannelResourceIdentifier(key="FOO")],
         )
     )
 

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -11,7 +11,8 @@ def create_products(client):
                 product_type=types.ProductTypeResourceIdentifier(key="dummy"),
                 name=types.LocalizedString(en=f"my-product-{i}"),
                 slug=types.LocalizedString(en=f"my-product-{i}"),
-            ))
+            )
+        )
 
 
 def test_page_paginator(client):

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -3,12 +3,19 @@ import pytest
 from commercetools import paginators, types
 
 
-def test_page_paginator(client):
+def create_products(client):
     for i in range(100):
         client.products.create(
-            types.ProductDraft(name=types.LocalizedString(en=f"Product {i}"))
-        )
+            types.ProductDraft(
+                key=f"test-product-{i}",
+                product_type=types.ProductTypeResourceIdentifier(key="dummy"),
+                name=types.LocalizedString(en=f"my-product-{i}"),
+                slug=types.LocalizedString(en=f"my-product-{i}"),
+            ))
 
+
+def test_page_paginator(client):
+    create_products(client)
     paginator = paginators.Paginator(client.products.query, sort=["id asc", "name asc"])
 
     items = []
@@ -18,11 +25,7 @@ def test_page_paginator(client):
 
 
 def test_page_paginator_slice_start(client):
-    for i in range(100):
-        client.products.create(
-            types.ProductDraft(name=types.LocalizedString(en=f"Product {i}"))
-        )
-
+    create_products(client)
     paginator = paginators.Paginator(client.products.query, sort=["id asc", "name asc"])
 
     items = []
@@ -34,11 +37,7 @@ def test_page_paginator_slice_start(client):
 
 
 def test_page_paginator_slice_stop(client):
-    for i in range(100):
-        client.products.create(
-            types.ProductDraft(name=types.LocalizedString(en=f"Product {i}"))
-        )
-
+    create_products(client)
     paginator = paginators.Paginator(client.products.query, sort=["id asc", "name asc"])
 
     items = []
@@ -50,11 +49,7 @@ def test_page_paginator_slice_stop(client):
 
 
 def test_page_paginator_slice_start_stop(client):
-    for i in range(100):
-        client.products.create(
-            types.ProductDraft(name=types.LocalizedString(en=f"Product {i}"))
-        )
-
+    create_products(client)
     paginator = paginators.Paginator(client.products.query, sort=["id asc", "name asc"])
 
     items = []
@@ -66,11 +61,7 @@ def test_page_paginator_slice_start_stop(client):
 
 
 def test_cursor_paginator(client):
-    for i in range(100):
-        client.products.create(
-            types.ProductDraft(name=types.LocalizedString(en=f"Product {i}"))
-        )
-
+    create_products(client)
     paginator = paginators.CursorPaginator(
         client.products.query, sort=["id asc", "name asc"]
     )
@@ -82,11 +73,7 @@ def test_cursor_paginator(client):
 
 
 def test_cursor_paginator_slice_start(client):
-    for i in range(100):
-        client.products.create(
-            types.ProductDraft(name=types.LocalizedString(en=f"Product {i}"))
-        )
-
+    create_products(client)
     paginator = paginators.CursorPaginator(
         client.products.query, sort=["id asc", "name asc"]
     )
@@ -98,11 +85,7 @@ def test_cursor_paginator_slice_start(client):
 
 
 def test_cursor_paginator_slice_stop(client):
-    for i in range(100):
-        client.products.create(
-            types.ProductDraft(name=types.LocalizedString(en=f"Product {i}"))
-        )
-
+    create_products(client)
     paginator = paginators.CursorPaginator(
         client.products.query, sort=["id asc", "name asc"]
     )

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -217,9 +217,7 @@ def test_project_schema():
             "pt-PT",
         ],
         "createdAt": "2018-10-24T08:58:22.935Z",
-        "carts": {
-            "countryTaxRateFallbackEnabled": True,
-        },
+        "carts": {"countryTaxRateFallbackEnabled": True},
         "trialUntil": "2018-12",
         "messages": {"enabled": False, "deleteDaysAfterCreation": 15},
         "version": 9,

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -217,6 +217,9 @@ def test_project_schema():
             "pt-PT",
         ],
         "createdAt": "2018-10-24T08:58:22.935Z",
+        "carts": {
+            "countryTaxRateFallbackEnabled": True,
+        },
         "trialUntil": "2018-12",
         "messages": {"enabled": False, "deleteDaysAfterCreation": 15},
         "version": 9,

--- a/tests/test_service_cart.py
+++ b/tests/test_service_cart.py
@@ -20,7 +20,8 @@ def cart_draft(client):
             name=types.LocalizedString(en=f"my-product-1"),
             slug=types.LocalizedString(en=f"my-product-1"),
             publish=True,
-        ))
+        )
+    )
     product_2 = client.products.create(
         types.ProductDraft(
             key=f"product-2",
@@ -28,7 +29,8 @@ def cart_draft(client):
             name=types.LocalizedString(en=f"my-product-2"),
             slug=types.LocalizedString(en=f"my-product-2"),
             publish=True,
-        ))
+        )
+    )
 
     return types.CartDraft(
         customer_id=str(uuid.uuid4()),
@@ -61,35 +63,27 @@ def test_update_actions(commercetools_api, client, cart_draft):
     type_draft = types.TypeDraft(
         key="foobar",
         resource_type_ids=[types.ResourceTypeId.ORDER],
-        name={
-            "en-US": "test",
-        },
+        name={"en-US": "test"},
         field_definitions=[
             types.FieldDefinition(
                 type=types.CustomFieldStringType(),
                 name="foo1",
-                label={
-                    "en-US": "foo-1",
-                },
+                label={"en-US": "foo-1"},
                 required=False,
             ),
             types.FieldDefinition(
                 type=types.CustomFieldSetType(element_type=None),
                 name="foo2",
-                label={
-                    "en-US": "foo-2",
-                },
+                label={"en-US": "foo-2"},
                 required=False,
             ),
             types.FieldDefinition(
                 type=types.CustomFieldBooleanType(),
                 name="foo3",
-                label={
-                    "en-US": "foo-3",
-                },
+                label={"en-US": "foo-3"},
                 required=False,
-            )
-        ]
+            ),
+        ],
     )
     custom_type = client.types.create(type_draft)
     assert custom_type.id

--- a/tests/test_service_cart.py
+++ b/tests/test_service_cart.py
@@ -12,7 +12,24 @@ def test_cart_get_by_id(client, cart_draft):
 
 
 @pytest.fixture
-def cart_draft():
+def cart_draft(client):
+    product_1 = client.products.create(
+        types.ProductDraft(
+            key=f"product-1",
+            product_type=types.ProductTypeResourceIdentifier(key="dummy"),
+            name=types.LocalizedString(en=f"my-product-1"),
+            slug=types.LocalizedString(en=f"my-product-1"),
+            publish=True,
+        ))
+    product_2 = client.products.create(
+        types.ProductDraft(
+            key=f"product-2",
+            product_type=types.ProductTypeResourceIdentifier(key="dummy"),
+            name=types.LocalizedString(en=f"my-product-2"),
+            slug=types.LocalizedString(en=f"my-product-2"),
+            publish=True,
+        ))
+
     return types.CartDraft(
         customer_id=str(uuid.uuid4()),
         customer_email="foo@example.com",
@@ -24,8 +41,8 @@ def cart_draft():
         tax_rounding_mode=types.RoundingMode.HALF_EVEN,
         tax_calculation_mode=types.TaxCalculationMode.LINE_ITEM_LEVEL,
         line_items=[
-            types.LineItemDraft(sku="123", quantity=2),
-            types.LineItemDraft(sku="124", quantity=1),
+            types.LineItemDraft(product_id=product_1.id, quantity=1),
+            types.LineItemDraft(product_id=product_2.id, quantity=2),
         ],
         locale="en",
         origin=types.CartOrigin.CUSTOMER,

--- a/tests/test_service_cart_discounts.py
+++ b/tests/test_service_cart_discounts.py
@@ -9,6 +9,9 @@ def test_cart_discount_get_by_id(client):
         types.CartDiscountDraft(
             name=types.LocalizedString({"en": "test discount"}),
             value=types.CartDiscountValueRelative(permyriad=10),
+            cart_predicate="",
+            sort_order="",
+            requires_discount_code=False,
         )
     )
 
@@ -26,12 +29,18 @@ def test_cart_discount_query(client):
         types.CartDiscountDraft(
             name=types.LocalizedString({"en:": "test discount"}),
             value=types.CartDiscountValueRelative(permyriad=10),
+            cart_predicate="",
+            sort_order="",
+            requires_discount_code=False,
         )
     )
     client.cart_discounts.create(
         types.CartDiscountDraft(
             name=types.LocalizedString({"en:": "test discount"}),
             value=types.CartDiscountValueRelative(permyriad=10),
+            cart_predicate="",
+            sort_order="",
+            requires_discount_code=False,
         )
     )
 
@@ -52,6 +61,9 @@ def test_cart_discount_update(client):
             name=types.LocalizedString(en="en-cart_discount"),
             value=types.CartDiscountValueRelative(permyriad=10),
             is_active=True,
+            cart_predicate="",
+            sort_order="",
+            requires_discount_code=False,
         )
     )
     assert cart_discount.is_active is True

--- a/tests/test_service_categories.py
+++ b/tests/test_service_categories.py
@@ -79,7 +79,8 @@ def test_category_update(client):
     """
     category = client.categories.create(
         types.CategoryDraft(
-            key="test-category", slug=types.LocalizedString(nl="nl-slug"),
+            key="test-category",
+            slug=types.LocalizedString(nl="nl-slug"),
             name=types.LocalizedString(nl="category"),
         )
     )

--- a/tests/test_service_categories.py
+++ b/tests/test_service_categories.py
@@ -5,7 +5,13 @@ from commercetools import types
 
 
 def test_category_get_by_id(client):
-    category = client.categories.create(types.CategoryDraft(key="test-category"))
+    category = client.categories.create(
+        types.CategoryDraft(
+            key="test-category",
+            name=types.LocalizedString(en="category"),
+            slug=types.LocalizedString(en="something"),
+        )
+    )
 
     assert category.id
     assert category.key == "test-category"
@@ -19,7 +25,13 @@ def test_category_get_by_id(client):
 
 
 def test_category_get_by_key(client):
-    category = client.categories.create(types.CategoryDraft(key="test-category"))
+    category = client.categories.create(
+        types.CategoryDraft(
+            key="test-category",
+            name=types.LocalizedString(en="category"),
+            slug=types.LocalizedString(en="something"),
+        )
+    )
 
     assert category.id
     assert category.key == "test-category"
@@ -33,8 +45,20 @@ def test_category_get_by_key(client):
 
 
 def test_category_query(client):
-    client.categories.create(types.CategoryDraft(key="test-category1"))
-    client.categories.create(types.CategoryDraft(key="test-category2"))
+    category = client.categories.create(
+        types.CategoryDraft(
+            key="test-category1",
+            name=types.LocalizedString(en="category"),
+            slug=types.LocalizedString(en="something"),
+        )
+    )
+    category = client.categories.create(
+        types.CategoryDraft(
+            key="test-category2",
+            name=types.LocalizedString(en="category"),
+            slug=types.LocalizedString(en="something"),
+        )
+    )
 
     # single sort query
     result = client.categories.query(sort="id asc", limit=10)
@@ -55,7 +79,8 @@ def test_category_update(client):
     """
     category = client.categories.create(
         types.CategoryDraft(
-            key="test-category", slug=types.LocalizedString(nl="nl-slug")
+            key="test-category", slug=types.LocalizedString(nl="nl-slug"),
+            name=types.LocalizedString(nl="category"),
         )
     )
     assert category.key == "test-category"

--- a/tests/test_service_customer_groups.py
+++ b/tests/test_service_customer_groups.py
@@ -25,10 +25,14 @@ def test_get_by_key(client):
 
 def test_query(client):
     client.customer_groups.create(
-        draft=types.CustomerGroupDraft(key="test-customer-group-1")
+        draft=types.CustomerGroupDraft(
+            key="test-customer-group-1", group_name="group-1"
+        )
     )
     client.customer_groups.create(
-        draft=types.CustomerGroupDraft(key="test-customer-group-2")
+        draft=types.CustomerGroupDraft(
+            key="test-customer-group-2", group_name="group-2"
+        )
     )
 
     result = client.customer_groups.query(sort="id asc", limit=10)

--- a/tests/test_service_customers.py
+++ b/tests/test_service_customers.py
@@ -9,6 +9,8 @@ def _get_draft_object(**kwargs):
         "last_name": "Doe",
         "title": "mr",
         "date_of_birth": datetime.date(year=1985, month=8, day=4),
+        "email": "info@example.org",
+        "password": "notsosecret",
     }
     customer.update(kwargs)
     return types.CustomerDraft(**customer)

--- a/tests/test_service_discount_codes.py
+++ b/tests/test_service_discount_codes.py
@@ -7,7 +7,9 @@ from commercetools import types
 def test_discount_code_get_by_id(client):
     discount_code = client.discount_codes.create(
         types.DiscountCodeDraft(
-            name=types.LocalizedString({"en": "test discount"}), code="1337"
+            name=types.LocalizedString({"en": "test discount"}),
+            code="1337",
+            cart_discounts=[],
         )
     )
 
@@ -25,12 +27,16 @@ def test_discount_code_get_by_id(client):
 def test_discount_code_query(client):
     client.discount_codes.create(
         types.DiscountCodeDraft(
-            name=types.LocalizedString({"en:": "test discount"}), code="1337"
+            name=types.LocalizedString({"en:": "test discount"}),
+            code="1337",
+            cart_discounts=[],
         )
     )
     client.discount_codes.create(
         types.DiscountCodeDraft(
-            name=types.LocalizedString({"en:": "test discount"}), code="1338"
+            name=types.LocalizedString({"en:": "test discount"}),
+            code="1338",
+            cart_discounts=[],
         )
     )
 
@@ -51,6 +57,7 @@ def test_discount_code_update(client):
             name=types.LocalizedString(en="en-discount_code"),
             code="1337",
             is_active=True,
+            cart_discounts=[],
         )
     )
     assert discount_code.code == "1337"

--- a/tests/test_service_extensions.py
+++ b/tests/test_service_extensions.py
@@ -2,12 +2,26 @@ from commercetools import types
 
 
 def test_extension_create(client):
-    extension = client.extensions.create(types.ExtensionDraft())
+    extension = client.extensions.create(
+        types.ExtensionDraft(
+            destination=types.ExtensionAWSLambdaDestination(
+                arn="arn:", access_key="access", access_secret="secret"
+            ),
+            triggers=[],
+        )
+    )
     assert extension.id
 
 
 def test_extension_get_by_id(client):
-    extension = client.extensions.create(types.ExtensionDraft())
+    extension = client.extensions.create(
+        types.ExtensionDraft(
+            destination=types.ExtensionAWSLambdaDestination(
+                arn="arn:", access_key="access", access_secret="secret"
+            ),
+            triggers=[],
+        )
+    )
     assert extension.id
 
     extension = client.extensions.get_by_id(extension.id)

--- a/tests/test_service_inventory.py
+++ b/tests/test_service_inventory.py
@@ -2,14 +2,18 @@ from commercetools import types
 
 
 def test_inventory_create(client):
-    inventory = client.inventory.create(types.InventoryEntryDraft(sku="1", quantity_on_stock=10))
+    inventory = client.inventory.create(
+        types.InventoryEntryDraft(sku="1", quantity_on_stock=10)
+    )
 
     assert inventory.id
     assert inventory.quantity_on_stock == 10
 
 
 def test_inventory_get_by_id(client):
-    inventory = client.inventory.create(types.InventoryEntryDraft(sku="1", quantity_on_stock=10))
+    inventory = client.inventory.create(
+        types.InventoryEntryDraft(sku="1", quantity_on_stock=10)
+    )
 
     assert inventory.id
     assert inventory.quantity_on_stock == 10
@@ -20,7 +24,9 @@ def test_inventory_get_by_id(client):
 
 
 def test_inventory_update_by_id(client):
-    inventory = client.inventory.create(types.InventoryEntryDraft(sku="1", quantity_on_stock=10))
+    inventory = client.inventory.create(
+        types.InventoryEntryDraft(sku="1", quantity_on_stock=10)
+    )
 
     assert inventory.id
     assert inventory.quantity_on_stock == 10

--- a/tests/test_service_inventory.py
+++ b/tests/test_service_inventory.py
@@ -2,14 +2,14 @@ from commercetools import types
 
 
 def test_inventory_create(client):
-    inventory = client.inventory.create(types.InventoryEntryDraft(quantity_on_stock=10))
+    inventory = client.inventory.create(types.InventoryEntryDraft(sku="1", quantity_on_stock=10))
 
     assert inventory.id
     assert inventory.quantity_on_stock == 10
 
 
 def test_inventory_get_by_id(client):
-    inventory = client.inventory.create(types.InventoryEntryDraft(quantity_on_stock=10))
+    inventory = client.inventory.create(types.InventoryEntryDraft(sku="1", quantity_on_stock=10))
 
     assert inventory.id
     assert inventory.quantity_on_stock == 10
@@ -20,7 +20,7 @@ def test_inventory_get_by_id(client):
 
 
 def test_inventory_update_by_id(client):
-    inventory = client.inventory.create(types.InventoryEntryDraft(quantity_on_stock=10))
+    inventory = client.inventory.create(types.InventoryEntryDraft(sku="1", quantity_on_stock=10))
 
     assert inventory.id
     assert inventory.quantity_on_stock == 10

--- a/tests/test_service_order.py
+++ b/tests/test_service_order.py
@@ -6,9 +6,7 @@ from commercetools import types
 def test_orders_get_by_id(client):
     cart = client.carts.create(types.CartDraft(currency="EUR"))
     order = client.orders.create(
-        types.OrderFromCartDraft(
-            id=cart.id, version=1, order_number="test-order"
-        ),
+        types.OrderFromCartDraft(id=cart.id, version=1, order_number="test-order")
     )
 
     assert order.id
@@ -21,9 +19,7 @@ def test_orders_query(client):
 
     cart = client.carts.create(types.CartDraft(currency="EUR"))
     order = client.orders.create(
-        types.OrderFromCartDraft(
-            id=cart.id, version=1, order_number="test-order"
-        ),
+        types.OrderFromCartDraft(id=cart.id, version=1, order_number="test-order")
     )
 
     results = client.orders.query()

--- a/tests/test_service_order.py
+++ b/tests/test_service_order.py
@@ -4,7 +4,12 @@ from commercetools import types
 
 
 def test_orders_get_by_id(client):
-    order = client.orders.create(types.OrderFromCartDraft(order_number="test-order"))
+    cart = client.carts.create(types.CartDraft(currency="EUR"))
+    order = client.orders.create(
+        types.OrderFromCartDraft(
+            id=cart.id, version=1, order_number="test-order"
+        ),
+    )
 
     assert order.id
     assert order.order_number == "test-order"
@@ -14,7 +19,12 @@ def test_orders_query(client):
     results = client.orders.query()
     assert results.total == 0
 
-    client.orders.create(types.OrderFromCartDraft(order_number="test-order"))
+    cart = client.carts.create(types.CartDraft(currency="EUR"))
+    order = client.orders.create(
+        types.OrderFromCartDraft(
+            id=cart.id, version=1, order_number="test-order"
+        ),
+    )
 
     results = client.orders.query()
     assert results.total == 1
@@ -96,20 +106,27 @@ def get_test_order():
         id="20ad6c92-fe04-4983-877e-5f5f80b5e37b",
         version=10,
         created_at=datetime.datetime.now(datetime.timezone.utc),
+        last_modified_at=datetime.datetime.now(datetime.timezone.utc),
         last_message_sequence_number=8,
         order_number="test-number",
         customer_email="d.weterings@labdigital.nl",
         anonymous_id="a706a9bf-4cd5-4bd0-b35d-b2373fb0c15e",
         locale="en",
-        total_price=types.CentPrecisionMoney(cent_amount=2000, currency_code="GBP"),
+        total_price=types.CentPrecisionMoney(
+            cent_amount=2000, currency_code="GBP", fraction_digits=2
+        ),
         taxed_price=types.TaxedPrice(
-            total_net=types.CentPrecisionMoney(cent_amount=1666, currency_code="GBP"),
-            total_gross=types.CentPrecisionMoney(cent_amount=2000, currency_code="GBP"),
+            total_net=types.CentPrecisionMoney(
+                cent_amount=1666, currency_code="GBP", fraction_digits=2
+            ),
+            total_gross=types.CentPrecisionMoney(
+                cent_amount=2000, currency_code="GBP", fraction_digits=2
+            ),
             tax_portions=[
                 types.TaxPortion(
                     rate=0.2,
                     amount=types.CentPrecisionMoney(
-                        cent_amount=334, currency_code="GBP"
+                        cent_amount=334, currency_code="GBP", fraction_digits=2
                     ),
                     name="GB",
                 )
@@ -141,8 +158,7 @@ def get_test_order():
                 id="8olFiIwX",
             ),
             tax_category=types.TaxCategoryReference(
-                type_id=types.ReferenceTypeId.TAX_CATEGORY,
-                id="5e564356-d367-4718-a0bb-6a17c3b1fdeb",
+                id="5e564356-d367-4718-a0bb-6a17c3b1fdeb"
             ),
             shipping_method=types.ShippingMethodReference(
                 id="b0e88c41-8553-4904-a2d5-a096c5f6f09f"
@@ -177,7 +193,7 @@ def get_test_order():
                         types.Price(
                             id="fb424988-79b3-4418-8730-9f324025a13c",
                             value=types.CentPrecisionMoney(
-                                cent_amount=1000, currency_code="GBP"
+                                cent_amount=1000, currency_code="GBP", fraction_digits=2
                             ),
                         )
                     ],
@@ -185,7 +201,7 @@ def get_test_order():
                 price=types.Price(
                     id="fb424988-79b3-4418-8730-9f324025a13c",
                     value=types.CentPrecisionMoney(
-                        cent_amount=1000, currency_code="GBP"
+                        cent_amount=1000, currency_code="GBP", fraction_digits=2
                     ),
                 ),
                 quantity=1,
@@ -204,9 +220,10 @@ def get_test_order():
                         ),
                     )
                 ],
+                discounted_price_per_quantity=[],
                 price_mode=types.LineItemPriceMode.PLATFORM,
                 total_price=types.CentPrecisionMoney(
-                    cent_amount=1000, currency_code="GBP"
+                    cent_amount=1000, currency_code="GBP", fraction_digits=2
                 ),
                 taxed_price=types.TaxedItemPrice(
                     total_net=types.CentPrecisionMoney(
@@ -219,17 +236,19 @@ def get_test_order():
                 line_item_mode=types.LineItemMode.STANDARD,
             )
         ],
+        custom_line_items=[],
         cart=types.CartReference(id="some cart id"),
         payment_info=types.PaymentInfo(
             payments=[types.PaymentReference(id="a433f3f8-5e27-406e-b2b0-d4a1f64592c4")]
         ),
         custom=types.CustomFields(
+            type=types.TypeReference(id="dummy"),
             fields=types.FieldContainer(
                 {
                     "sentEmails": ["order_email_confirmed"],
                     "shipwireServiceLevelCode": "GD",
                 }
-            )
+            ),
         ),
         shipping_address=types.Address(
             first_name="David",
@@ -249,5 +268,7 @@ def get_test_order():
             city="Utrecht",
             country="GB",
         ),
+        sync_info=[],
+        refused_gifts=[],
     )
     return order

--- a/tests/test_service_payment.py
+++ b/tests/test_service_payment.py
@@ -2,6 +2,22 @@ from commercetools import types
 
 
 def test_payments_get_by_id(client):
+    custom_type = client.types.create(
+        types.TypeDraft(
+            name=types.LocalizedString(en="myType"),
+            key="payment-info",
+            resource_type_ids=[types.ResourceTypeId.PAYMENT_INTERFACE_INTERACTION],
+            field_definitions=[
+                types.FieldDefinition(
+                    type=types.CustomFieldStringType(),
+                    name="operations",
+                    label=types.LocalizedString(en="Operation"),
+                    required=False,
+                )
+            ],
+        )
+    )
+
     payment = client.payments.create(
         types.PaymentDraft(
             key="test-payment",
@@ -19,6 +35,7 @@ def test_payments_get_by_id(client):
             ],
             interface_interactions=[
                 types.CustomFieldsDraft(
+                    type=types.TypeResourceIdentifier(id=custom_type.id),
                     fields=types.FieldContainer(
                         {
                             "operations": "CANCEL,CAPTURE,REFUND",
@@ -33,7 +50,7 @@ def test_payments_get_by_id(client):
                             "event_code": "AUTHORISATION",
                             "merchant_account_code": "TestMerchant",
                         }
-                    )
+                    ),
                 )
             ],
         )
@@ -44,6 +61,22 @@ def test_payments_get_by_id(client):
 
 
 def test_update_actions(client):
+    custom_type = client.types.create(
+        types.TypeDraft(
+            name=types.LocalizedString(en="myType"),
+            key="payment-info",
+            resource_type_ids=[types.ResourceTypeId.PAYMENT_INTERFACE_INTERACTION],
+            field_definitions=[
+                types.FieldDefinition(
+                    type=types.CustomFieldStringType(),
+                    name="operations",
+                    label=types.LocalizedString(en="Operation"),
+                    required=False,
+                )
+            ],
+        )
+    )
+
     payment = client.payments.create(
         types.PaymentDraft(
             key="test-payment",
@@ -68,6 +101,7 @@ def test_update_actions(client):
         payment.version,
         actions=[
             types.PaymentAddInterfaceInteractionAction(
+                type=types.TypeResourceIdentifier(id=custom_type.id),
                 fields=types.FieldContainer({"pspRef": "1337"})
             ),
             types.PaymentChangeTransactionInteractionIdAction(

--- a/tests/test_service_payment.py
+++ b/tests/test_service_payment.py
@@ -102,7 +102,7 @@ def test_update_actions(client):
         actions=[
             types.PaymentAddInterfaceInteractionAction(
                 type=types.TypeResourceIdentifier(id=custom_type.id),
-                fields=types.FieldContainer({"pspRef": "1337"})
+                fields=types.FieldContainer({"pspRef": "1337"}),
             ),
             types.PaymentChangeTransactionInteractionIdAction(
                 transaction_id=existing_transaction.id, interaction_id="1337"

--- a/tests/test_service_product_discounts.py
+++ b/tests/test_service_product_discounts.py
@@ -3,7 +3,13 @@ from commercetools import types
 
 def test_product_discount_get_by_id(client):
     product_discount = client.product_discounts.create(
-        types.ProductDiscountDraft(name=types.LocalizedString(nl="test-discount"))
+        types.ProductDiscountDraft(
+            name=types.LocalizedString(nl="test-discount"),
+            predicate="",
+            value=types.ProductDiscountValueRelativeDraft(permyriad=10),
+            is_active=True,
+            sort_order="",
+        )
     )
 
     assert product_discount.id

--- a/tests/test_service_product_projections.py
+++ b/tests/test_service_product_projections.py
@@ -5,10 +5,20 @@ from commercetools import types
 
 
 def test_product_projections_get_by_id(client):
+    variant = types.ProductVariantDraft()
     product_create = client.products.create(
-        types.ProductDraft(key="test-product1", publish=False)
+        types.ProductDraft(
+            key="test-product",
+            product_type=types.ProductTypeResourceIdentifier(key="dummy"),
+            name=types.LocalizedString(en=f"my-product"),
+            slug=types.LocalizedString(en=f"my-product"),
+            master_variant=variant,
+            variants=[variant],
+            publish=False,
+        )
     )
-    product = client.product_projections.get_by_id(product_create.id)
+
+    product = client.product_projections.get_by_id(product_create.id, staged=True)
     assert product.id == product_create.id
     assert product.key == product_create.key
 
@@ -19,10 +29,19 @@ def test_product_projections_get_by_id_not_found(client):
 
 
 def test_product_projections_get_by_key(client):
+    variant = types.ProductVariantDraft()
     product_create = client.products.create(
-        types.ProductDraft(key="test-product1", publish=False)
+        types.ProductDraft(
+            key="test-product",
+            product_type=types.ProductTypeResourceIdentifier(key="dummy"),
+            name=types.LocalizedString(en=f"my-product"),
+            slug=types.LocalizedString(en=f"my-product"),
+            master_variant=variant,
+            variants=[variant],
+            publish=False,
+        )
     )
-    product = client.product_projections.get_by_key(product_create.key)
+    product = client.product_projections.get_by_key(product_create.key, staged=True)
     assert product.id == product_create.id
     assert product.key == product_create.key
 
@@ -34,8 +53,31 @@ def test_product_projections_get_by_key_not_found(client):
 
 def test_product_projections_query(client):
     for key in ["product-1", "product-2"]:
-        client.products.create(types.ProductDraft(key=key, publish=True))
-    client.products.create(types.ProductDraft(key="product-3", publish=False))
+        variant = types.ProductVariantDraft()
+        client.products.create(
+            types.ProductDraft(
+                key=key,
+                product_type=types.ProductTypeResourceIdentifier(key="dummy"),
+                name=types.LocalizedString(en=key),
+                slug=types.LocalizedString(en=key),
+                master_variant=variant,
+                variants=[variant],
+                publish=True,
+            )
+        )
+
+    key = "product-3"
+    client.products.create(
+        types.ProductDraft(
+            key=key,
+            product_type=types.ProductTypeResourceIdentifier(key="dummy"),
+            name=types.LocalizedString(en=key),
+            slug=types.LocalizedString(en=key),
+            master_variant=variant,
+            variants=[variant],
+            publish=False,
+        )
+    )
 
     # single sort query
     result = client.product_projections.query(

--- a/tests/test_service_product_types.py
+++ b/tests/test_service_product_types.py
@@ -7,7 +7,9 @@ from commercetools import types
 
 def test_product_types_get_by_id(client):
     product_type = client.product_types.create(
-        types.ProductTypeDraft(key="test-product-type")
+        types.ProductTypeDraft(
+            key="test-product-type", name="test", description="something"
+        )
     )
 
     assert product_type.id
@@ -23,7 +25,9 @@ def test_product_types_get_by_id(client):
 
 def test_product_types_get_by_key(client):
     product_type = client.product_types.create(
-        types.ProductTypeDraft(key="test-product-type")
+        types.ProductTypeDraft(
+            key="test-product-type", name="test", description="something"
+        )
     )
 
     assert product_type.id
@@ -38,8 +42,16 @@ def test_product_types_get_by_key(client):
 
 
 def test_product_type_query(client):
-    client.product_types.create(types.ProductTypeDraft(key="test-product-type1"))
-    client.product_types.create(types.ProductTypeDraft(key="test-product-type2"))
+    product_type = client.product_types.create(
+        types.ProductTypeDraft(
+            key="test-product-type1", name="test-1", description="something"
+        )
+    )
+    product_type = client.product_types.create(
+        types.ProductTypeDraft(
+            key="test-product-type2", name="test-2", description="something"
+        )
+    )
 
     # single sort query
     result = client.product_types.query(sort="id asc")
@@ -59,7 +71,9 @@ def test_product_update(client):
     TODO: See if this is worth testing since we're using a mocking backend
     """
     product_type = client.product_types.create(
-        types.ProductTypeDraft(key="test-product-type", name="Test Product Type")
+        types.ProductTypeDraft(
+            key="test-product-type", name="test", description="something"
+        )
     )
 
     assert product_type.id

--- a/tests/test_service_products.py
+++ b/tests/test_service_products.py
@@ -11,8 +11,16 @@ def test_products_create(client):
     custom_type = client.types.create(
         types.TypeDraft(
             name=types.LocalizedString(en="myType"),
+            key="my-type",
             resource_type_ids=[types.ResourceTypeId.ASSET],
-            field_definitions=[types.FieldDefinition(name="foo")],
+            field_definitions=[
+                types.FieldDefinition(
+                    name="foo",
+                    type=types.CustomFieldStringType(),
+                    label=types.LocalizedString(en="foo"),
+                    required=False,
+                )
+            ],
         )
     )
     assert custom_type.id
@@ -20,13 +28,18 @@ def test_products_create(client):
     draft = types.ProductDraft(
         key="test-product",
         publish=True,
+        name=types.LocalizedString(en=f"my-product"),
+        slug=types.LocalizedString(en=f"my-product"),
+        product_type=types.ProductTypeResourceIdentifier(key="dummy"),
         master_variant=types.ProductVariantDraft(
             assets=[
                 types.AssetDraft(
+                    sources=[],
+                    name=types.LocalizedString(en="something"),
                     custom=types.CustomFieldsDraft(
                         type=types.TypeResourceIdentifier(id=custom_type.id),
                         fields=types.FieldContainer(foo="bar"),
-                    )
+                    ),
                 )
             ],
             prices=[
@@ -46,7 +59,15 @@ def test_products_create(client):
 
 
 def test_products_get_by_id(client):
-    product = client.products.create(types.ProductDraft(key="test-product"))
+    product = client.products.create(
+        types.ProductDraft(
+            key="test-product",
+            product_type=types.ProductTypeResourceIdentifier(key="dummy"),
+            name=types.LocalizedString(en="my-product"),
+            slug=types.LocalizedString(en="my-product"),
+            publish=True,
+        )
+    )
 
     assert product.id
     assert product.key == "test-product"
@@ -60,7 +81,15 @@ def test_products_get_by_id(client):
 
 
 def test_products_get_by_key(client):
-    product = client.products.create(types.ProductDraft(key="test-product"))
+    product = client.products.create(
+        types.ProductDraft(
+            key="test-product",
+            product_type=types.ProductTypeResourceIdentifier(key="dummy"),
+            name=types.LocalizedString(en="my-product"),
+            slug=types.LocalizedString(en="my-product"),
+            publish=True,
+        )
+    )
 
     assert product.id
     assert product.key == "test-product"
@@ -74,8 +103,24 @@ def test_products_get_by_key(client):
 
 
 def test_product_query(client):
-    client.products.create(types.ProductDraft(key="test-product1"))
-    client.products.create(types.ProductDraft(key="test-product2"))
+    client.products.create(
+        types.ProductDraft(
+            key=f"product-1",
+            product_type=types.ProductTypeResourceIdentifier(key="dummy"),
+            name=types.LocalizedString(en=f"my-product-1"),
+            slug=types.LocalizedString(en=f"my-product-1"),
+            publish=True,
+        )
+    )
+    client.products.create(
+        types.ProductDraft(
+            key=f"product-2",
+            product_type=types.ProductTypeResourceIdentifier(key="dummy"),
+            name=types.LocalizedString(en=f"my-product-2"),
+            slug=types.LocalizedString(en=f"my-product-2"),
+            publish=True,
+        )
+    )
 
     # single sort query
     result = client.products.query(sort="id asc", limit=2)
@@ -92,6 +137,9 @@ def test_product_query_where(client):
     client.products.create(
         types.ProductDraft(
             key="test-product1",
+            name=types.LocalizedString(en=f"my-product-1"),
+            slug=types.LocalizedString(en=f"my-product-1"),
+            product_type=types.ProductTypeResourceIdentifier(key="dummy"),
             master_variant=types.ProductVariantDraft(
                 prices=[
                     types.PriceDraft(
@@ -107,6 +155,9 @@ def test_product_query_where(client):
     client.products.create(
         types.ProductDraft(
             key="test-product-2",
+            name=types.LocalizedString(en=f"my-product-1"),
+            slug=types.LocalizedString(en=f"my-product-1"),
+            product_type=types.ProductTypeResourceIdentifier(key="dummy"),
             master_variant=types.ProductVariantDraft(
                 prices=[
                     types.PriceDraft(
@@ -119,7 +170,14 @@ def test_product_query_where(client):
             ),
         )
     )
-    client.products.create(types.ProductDraft(key="test-product2"))
+    client.products.create(
+        types.ProductDraft(
+            key="test-product2",
+            name=types.LocalizedString(en=f"my-product-1"),
+            slug=types.LocalizedString(en=f"my-product-1"),
+            product_type=types.ProductTypeResourceIdentifier(key="dummy"),
+        )
+    )
 
     result = client.products.query(
         where="masterData(staged(masterVariant(prices(country='NL'))))"
@@ -149,6 +207,9 @@ def test_product_update(client):
     product = client.products.create(
         types.ProductDraft(
             key="test-product",
+            name=types.LocalizedString(en=f"my-product-1"),
+            slug=types.LocalizedString(en=f"my-product-1"),
+            product_type=types.ProductTypeResourceIdentifier(key="dummy"),
             master_variant=types.ProductVariantDraft(sku="1", key="1"),
         )
     )
@@ -204,6 +265,9 @@ def test_product_update_add_change_price_staged(client):
     product = client.products.create(
         types.ProductDraft(
             key="test-product",
+            name=types.LocalizedString(en=f"my-product-1"),
+            slug=types.LocalizedString(en=f"my-product-1"),
+            product_type=types.ProductTypeResourceIdentifier(key="dummy"),
             master_variant=types.ProductVariantDraft(sku="1", key="1"),
         )
     )
@@ -251,6 +315,9 @@ def test_product_update_add_price_current(client):
     product = client.products.create(
         types.ProductDraft(
             key="test-product",
+            name=types.LocalizedString(en=f"my-product-1"),
+            slug=types.LocalizedString(en=f"my-product-1"),
+            product_type=types.ProductTypeResourceIdentifier(key="dummy"),
             master_variant=types.ProductVariantDraft(sku="1", key="1"),
             publish=True,
         )

--- a/tests/test_service_shipping_methods.py
+++ b/tests/test_service_shipping_methods.py
@@ -7,7 +7,11 @@ from commercetools import types
 def test_shipping_method_get_by_id(client):
     shipping_method = client.shipping_methods.create(
         types.ShippingMethodDraft(
-            key="test-shipping-method", name="test shipping method"
+            key="test-shipping-method",
+            name="test shipping method",
+            tax_category=types.TaxCategoryResourceIdentifier(id="dummy"),
+            zone_rates=[],
+            is_default=False,
         )
     )
 
@@ -26,12 +30,20 @@ def test_shipping_method_get_by_id(client):
 def test_shipping_method_query(client):
     client.shipping_methods.create(
         types.ShippingMethodDraft(
-            key="test-shipping_method1", name="test shipping method1"
+            key="test-shipping_method1",
+            name="test shipping method1",
+            tax_category=types.TaxCategoryResourceIdentifier(id="dummy"),
+            zone_rates=[],
+            is_default=False,
         )
     )
     client.shipping_methods.create(
         types.ShippingMethodDraft(
-            key="test-shipping_method2", name="test shipping method2"
+            key="test-shipping_method2",
+            name="test shipping method2",
+            tax_category=types.TaxCategoryResourceIdentifier(id="dummy"),
+            zone_rates=[],
+            is_default=False,
         )
     )
 
@@ -54,7 +66,11 @@ def test_shipping_method_update(client):
     """
     shipping_method = client.shipping_methods.create(
         types.ShippingMethodDraft(
-            key="test-shipping-method", name="test shipping method"
+            key="test-shipping-method",
+            name="test shipping method",
+            tax_category=types.TaxCategoryResourceIdentifier(id="dummy"),
+            zone_rates=[],
+            is_default=False,
         )
     )
     assert shipping_method.key == "test-shipping-method"

--- a/tests/test_service_shopping_lists.py
+++ b/tests/test_service_shopping_lists.py
@@ -7,6 +7,8 @@ def test_get_by_id(client):
             master_variant=types.ProductVariantDraft(sku="123"),
             publish=True,
             name=types.LocalizedString(nl="Test product"),
+            slug=types.LocalizedString(en=f"my-product"),
+            product_type=types.ProductTypeResourceIdentifier(key="dummy"),
         )
     )
 
@@ -34,6 +36,8 @@ def test_get_by_key(client):
             master_variant=types.ProductVariantDraft(sku="123"),
             publish=True,
             name=types.LocalizedString(nl="Test product"),
+            slug=types.LocalizedString(en="my-product"),
+            product_type=types.ProductTypeResourceIdentifier(key="dummy"),
         )
     )
 

--- a/tests/test_service_tax_category.py
+++ b/tests/test_service_tax_category.py
@@ -2,14 +2,18 @@ from commercetools import types
 
 
 def test_tax_category_create(client):
-    tax_category = client.tax_categories.create(types.TaxCategoryDraft(name="Hoog"))
+    tax_category = client.tax_categories.create(
+        types.TaxCategoryDraft(name="Hoog", rates=[])
+    )
 
     assert tax_category.id
     assert tax_category.name == "Hoog"
 
 
 def test_tax_category_get_by_id(client):
-    tax_category = client.tax_categories.create(types.TaxCategoryDraft(name="Hoog"))
+    tax_category = client.tax_categories.create(
+        types.TaxCategoryDraft(name="Hoog", rates=[])
+    )
 
     assert tax_category.id
     assert tax_category.name == "Hoog"
@@ -20,7 +24,9 @@ def test_tax_category_get_by_id(client):
 
 
 def test_tax_category_update_by_id(client):
-    tax_category = client.tax_categories.create(types.TaxCategoryDraft(name="Hoog"))
+    tax_category = client.tax_categories.create(
+        types.TaxCategoryDraft(name="Hoog", rates=[])
+    )
 
     assert tax_category.id
     assert tax_category.name == "Hoog"

--- a/tests/test_testing_headers.py
+++ b/tests/test_testing_headers.py
@@ -4,7 +4,14 @@ from commercetools import CommercetoolsError, types
 
 
 def test_correlation_id_is_set_in_exception(client):
-    product = client.products.create(types.ProductDraft(key="test-product"))
+    product = client.products.create(
+        types.ProductDraft(
+            key="test-product",
+            name=types.LocalizedString(en=f"my-product"),
+            slug=types.LocalizedString(en=f"my-product"),
+            product_type=types.ProductTypeResourceIdentifier(key="dummy"),
+        )
+    )
 
     product = client.products.update_by_id(
         id=product.id,

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -27,4 +27,3 @@ def test_equality():
         product_type=types.ProductTypeResourceIdentifier(key="dummy"),
     )
     assert obj_1 == obj_2
-

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,20 +1,35 @@
 from commercetools import types
 
 
-def test_equality():
-    obj_1 = types.ProductDraft(slug="test-1")
-    obj_2 = types.ProductDraft(slug="test-2")
-
+def test_non_equality():
+    obj_1 = types.ProductDraft(
+        slug=types.LocalizedString(en="test-2"),
+        name=types.LocalizedString(en="test-1"),
+        product_type=types.ProductTypeResourceIdentifier(key="dummy"),
+    )
+    obj_2 = types.ProductDraft(
+        slug=types.LocalizedString(en="test-1"),
+        name=types.LocalizedString(en="test-1"),
+        product_type=types.ProductTypeResourceIdentifier(key="dummy"),
+    )
     assert obj_1 != obj_2
-
-    obj_1 = types.ProductDraft(slug="test-1")
-    obj_2 = types.ProductDraft(slug="test-1")
-    assert obj_1 == obj_2
 
 
 def test_gt_lt():
     obj_1 = types.ProductDraft(slug="test-1", name="foo")
     obj_2 = types.ProductDraft(slug="test-1", name="bar")
+def test_equality():
+    obj_1 = types.ProductDraft(
+        slug=types.LocalizedString(en="test-1"),
+        name=types.LocalizedString(en="test-1"),
+        product_type=types.ProductTypeResourceIdentifier(key="dummy"),
+    )
+    obj_2 = types.ProductDraft(
+        slug=types.LocalizedString(en="test-1"),
+        name=types.LocalizedString(en="test-1"),
+        product_type=types.ProductTypeResourceIdentifier(key="dummy"),
+    )
+    assert obj_1 == obj_2
 
     assert obj_1 > obj_2
     assert not obj_1 < obj_2

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -15,9 +15,6 @@ def test_non_equality():
     assert obj_1 != obj_2
 
 
-def test_gt_lt():
-    obj_1 = types.ProductDraft(slug="test-1", name="foo")
-    obj_2 = types.ProductDraft(slug="test-1", name="bar")
 def test_equality():
     obj_1 = types.ProductDraft(
         slug=types.LocalizedString(en="test-1"),
@@ -31,5 +28,3 @@ def test_equality():
     )
     assert obj_1 == obj_2
 
-    assert obj_1 > obj_2
-    assert not obj_1 < obj_2


### PR DESCRIPTION
Previously all properties were marked as either optional or required
based on the raml specification. The __init__ method of the types were
however always optional since the default value of None was defined.

This commit re-orders the keyword arguments and removes default values
for required values. This means that all values which are required
should be specified when creating the instance.

Note that this is a backwards incompatible change


TODO:
 - [x] Update test suite
 - [ ] Write changelog :-)