### PR TITLE
feat: support in syntax for single values

### DIFF
--- a/src/commercetools/testing/predicates.py
+++ b/src/commercetools/testing/predicates.py
@@ -514,6 +514,10 @@ class PredicateFilter:
             if operator_value == "in":
                 return op(value, obj)
 
+        # allow comparing single values with 'in' syntax
+        if operator_value == "in" and not isinstance(value, list):
+            return op([value], obj)
+
         return op(obj, value)
 
     def case_insensitive_get(sef, dict, key, default=None):

--- a/tests/test_service_order.py
+++ b/tests/test_service_order.py
@@ -268,3 +268,12 @@ def get_test_order():
         refused_gifts=[],
     )
     return order
+
+
+def test_where_query_state(commercetools_api, client):
+    order = get_test_order()
+    commercetools_api.orders.add_existing(order)
+
+    result = client.orders.query(where='orderState in ("Open")')
+
+    assert result.results[0].id == order.id


### PR DESCRIPTION
Commercetools API supports this as well, so we should emulate it. See test for example syntax.