### PR TITLE
allow passing custom HTTP adapter to BaseClient

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -1,6 +1,13 @@
 name: Python Tests
 
-on: [push]
+on:
+  # This should run the workflow for all non-forked pushes
+  push:
+  pull_request:
+    branches:
+    # This should run the workflow for forked PRs
+    - '**:**'
+
 
 jobs:
 

--- a/tests/platform/test_client.py
+++ b/tests/platform/test_client.py
@@ -2,6 +2,7 @@ import time
 import uuid
 
 import pytest
+from requests_mock.adapter import Adapter
 
 from commercetools import CommercetoolsError
 from commercetools.client import Client
@@ -69,6 +70,24 @@ def test_cache_token(commercetools_api):
     assert len(commercetools_api.requests_mock.request_history) == 1
 
 
+def test_allows_passing_custom_http_adapter():
+    my_adapter = Adapter()
+    my_adapter.register_uri(
+        "POST",
+        "https://auth.sphere.io/oauth/token",
+        json=dict(access_token="my_mock_access_token"),
+    )
+    Client(
+        client_id="unittest",
+        client_secret="none",
+        project_key="test",
+        url="https://api.sphere.io",
+        token_url="https://auth.sphere.io/oauth/token",
+        http_adapter=my_adapter,
+    )
+    assert len(my_adapter.request_history) == 1
+
+
 def test_resource_update_conflict(old_client):
     """Test the return value of the update methods.
 
@@ -124,7 +143,7 @@ def test_resource_update_conflict(old_client):
 
 
 def test_resource_delete_conflict(old_client):
-    """Test the return value of the update methods.
+    """Test the return value of the delete methods.
 
     It doesn't test the actual update itself.
     TODO: See if this is worth testing since we're using a mocking backend

--- a/tests/platform/test_client.py
+++ b/tests/platform/test_client.py
@@ -145,7 +145,7 @@ def test_resource_update_conflict(old_client):
 def test_resource_delete_conflict(old_client):
     """Test the return value of the delete methods.
 
-    It doesn't test the actual update itself.
+    It doesn't test the actual delete itself.
     TODO: See if this is worth testing since we're using a mocking backend
     """
     product = old_client.products.create(


### PR DESCRIPTION
This PR allows users of the SDK to initialize `Client` with a custom `http_adapter` instance. This is useful for setting appropriate timeouts, different retry configuration, and perhaps even for testing.

Our particular use case for this is for setting timeouts, we've noticed CT can sporadically take 10+ seconds for no good reason, and usually gunicorn will timeout and have to kill the worker. It's much preferable to have the timeout set at the request level so gunicorn can just 500 the request and our users can try again