### PR TITLE
Add missing actions for CT Provider

### DIFF
--- a/src/commercetools/testing/cart_discounts.py
+++ b/src/commercetools/testing/cart_discounts.py
@@ -70,7 +70,7 @@ class CartDiscountsBackend(ServiceBackend):
     ):
         # real API always increments version, so always apply new value.
         new = copy.deepcopy(obj)
-        new["valid_from"] = action.valid_from.isoformat()
+        new["validFrom"] = action.valid_from.isoformat()
         return new
 
     def set_valid_until(
@@ -78,7 +78,7 @@ class CartDiscountsBackend(ServiceBackend):
     ):
         # real API always increments version, so always apply new value.
         new = copy.deepcopy(obj)
-        new["valid_until"] = action.valid_until.isoformat()
+        new["validUntil"] = action.valid_until.isoformat()
         return new
 
     _actions = {

--- a/src/commercetools/testing/cart_discounts.py
+++ b/src/commercetools/testing/cart_discounts.py
@@ -72,4 +72,6 @@ class CartDiscountsBackend(ServiceBackend):
         "setName": update_attribute("name", "name"),
         "setDescription": update_attribute("description", "description"),
         "setCartPredicate": update_attribute("cartPredicate", "cart_predicate"),
+        "setValidFrom": update_attribute("valid_from", "valid_from"),
+        "setValidUntil": update_attribute("valid_until", "valid_until")
     }

--- a/src/commercetools/testing/cart_discounts.py
+++ b/src/commercetools/testing/cart_discounts.py
@@ -1,3 +1,4 @@
+import copy
 import datetime
 import typing
 import uuid
@@ -64,6 +65,22 @@ class CartDiscountsBackend(ServiceBackend):
             ("^(?P<id>[^/]+)$", "DELETE", self.delete_by_id),
         ]
 
+    def set_valid_from(
+            self, obj, action: models.CartDiscountSetValidFromAction
+    ):
+        # real API always increments version, so always apply new value.
+        new = copy.deepcopy(obj)
+        new["valid_from"] = action.valid_from.isoformat()
+        return new
+
+    def set_valid_until(
+            self, obj, action: models.CartDiscountSetValidUntilAction
+    ):
+        # real API always increments version, so always apply new value.
+        new = copy.deepcopy(obj)
+        new["valid_until"] = action.valid_until.isoformat()
+        return new
+
     _actions = {
         "setKey": update_attribute("key", "key"),
         "changeSortOrder": update_attribute("sortOrder", "sort_order"),
@@ -72,6 +89,6 @@ class CartDiscountsBackend(ServiceBackend):
         "setName": update_attribute("name", "name"),
         "setDescription": update_attribute("description", "description"),
         "setCartPredicate": update_attribute("cartPredicate", "cart_predicate"),
-        "setValidFrom": update_attribute("valid_from", "valid_from"),
-        "setValidUntil": update_attribute("valid_until", "valid_until")
+        "setValidFrom": set_valid_from,
+        "setValidUntil": set_valid_until
     }

--- a/src/commercetools/testing/cart_discounts.py
+++ b/src/commercetools/testing/cart_discounts.py
@@ -65,17 +65,13 @@ class CartDiscountsBackend(ServiceBackend):
             ("^(?P<id>[^/]+)$", "DELETE", self.delete_by_id),
         ]
 
-    def set_valid_from(
-            self, obj, action: models.CartDiscountSetValidFromAction
-    ):
+    def set_valid_from(self, obj, action: models.CartDiscountSetValidFromAction):
         # real API always increments version, so always apply new value.
         new = copy.deepcopy(obj)
         new["validFrom"] = action.valid_from.isoformat()
         return new
 
-    def set_valid_until(
-            self, obj, action: models.CartDiscountSetValidUntilAction
-    ):
+    def set_valid_until(self, obj, action: models.CartDiscountSetValidUntilAction):
         # real API always increments version, so always apply new value.
         new = copy.deepcopy(obj)
         new["validUntil"] = action.valid_until.isoformat()
@@ -90,5 +86,5 @@ class CartDiscountsBackend(ServiceBackend):
         "setDescription": update_attribute("description", "description"),
         "setCartPredicate": update_attribute("cartPredicate", "cart_predicate"),
         "setValidFrom": set_valid_from,
-        "setValidUntil": set_valid_until
+        "setValidUntil": set_valid_until,
     }

--- a/src/commercetools/testing/cart_discounts.py
+++ b/src/commercetools/testing/cart_discounts.py
@@ -12,7 +12,8 @@ from commercetools.platform.models._schemas.cart_discount import (
 )
 from commercetools.testing import utils
 from commercetools.testing.abstract import BaseModel, ServiceBackend
-from commercetools.testing.utils import update_attribute, update_enum_attribute
+from commercetools.testing.utils import update_attribute, update_enum_attribute, \
+    update_datetime_attribute
 
 
 class CartDiscountsModel(BaseModel):
@@ -65,18 +66,6 @@ class CartDiscountsBackend(ServiceBackend):
             ("^(?P<id>[^/]+)$", "DELETE", self.delete_by_id),
         ]
 
-    def set_valid_from(self, obj, action: models.CartDiscountSetValidFromAction):
-        # real API always increments version, so always apply new value.
-        new = copy.deepcopy(obj)
-        new["validFrom"] = action.valid_from.isoformat()
-        return new
-
-    def set_valid_until(self, obj, action: models.CartDiscountSetValidUntilAction):
-        # real API always increments version, so always apply new value.
-        new = copy.deepcopy(obj)
-        new["validUntil"] = action.valid_until.isoformat()
-        return new
-
     _actions = {
         "setKey": update_attribute("key", "key"),
         "changeSortOrder": update_attribute("sortOrder", "sort_order"),
@@ -85,6 +74,6 @@ class CartDiscountsBackend(ServiceBackend):
         "setName": update_attribute("name", "name"),
         "setDescription": update_attribute("description", "description"),
         "setCartPredicate": update_attribute("cartPredicate", "cart_predicate"),
-        "setValidFrom": set_valid_from,
-        "setValidUntil": set_valid_until,
+        "setValidFrom": update_datetime_attribute("validFrom", "valid_from"),
+        "setValidUntil": update_datetime_attribute("validUntil", "valid_until"),
     }

--- a/src/commercetools/testing/cart_discounts.py
+++ b/src/commercetools/testing/cart_discounts.py
@@ -12,8 +12,11 @@ from commercetools.platform.models._schemas.cart_discount import (
 )
 from commercetools.testing import utils
 from commercetools.testing.abstract import BaseModel, ServiceBackend
-from commercetools.testing.utils import update_attribute, update_enum_attribute, \
-    update_datetime_attribute
+from commercetools.testing.utils import (
+    update_attribute,
+    update_datetime_attribute,
+    update_enum_attribute,
+)
 
 
 class CartDiscountsModel(BaseModel):

--- a/src/commercetools/testing/discount_codes.py
+++ b/src/commercetools/testing/discount_codes.py
@@ -67,4 +67,6 @@ class DiscountCodesBackend(ServiceBackend):
         "setMaxApplicationsPerCustomer": update_attribute(
             "maxApplicationsPerCustomer", "max_applications_per_customer"
         ),
+        "setValidFrom": update_attribute("valid_from", "valid_from"),
+        "setValidUntil": update_attribute("valid_until", "valid_until")
     }

--- a/src/commercetools/testing/discount_codes.py
+++ b/src/commercetools/testing/discount_codes.py
@@ -64,7 +64,7 @@ class DiscountCodesBackend(ServiceBackend):
     ):
         # real API always increments version, so always apply new value.
         new = copy.deepcopy(obj)
-        new["valid_from"] = action.valid_from.isoformat()
+        new["validFrom"] = action.valid_from.isoformat()
         return new
 
     def set_valid_until(
@@ -72,7 +72,7 @@ class DiscountCodesBackend(ServiceBackend):
     ):
         # real API always increments version, so always apply new value.
         new = copy.deepcopy(obj)
-        new["valid_until"] = action.valid_until.isoformat()
+        new["validUntil"] = action.valid_until.isoformat()
         return new
 
     def change_cart_discounts(
@@ -80,7 +80,7 @@ class DiscountCodesBackend(ServiceBackend):
     ):
         # real API always increments version, so always apply new value.
         new = copy.deepcopy(obj)
-        new["cart_discounts"] = [cart_discount.serialize() for cart_discount in action.cart_discounts]
+        new["cartDiscounts"] = [cart_discount.serialize() for cart_discount in action.cart_discounts]
         return new
 
     _actions = {

--- a/src/commercetools/testing/discount_codes.py
+++ b/src/commercetools/testing/discount_codes.py
@@ -59,28 +59,26 @@ class DiscountCodesBackend(ServiceBackend):
             ("^(?P<id>[^/]+)$", "POST", self.update_by_id),
         ]
 
-    def set_valid_from(
-            self, obj, action: models.DiscountCodeSetValidFromAction
-    ):
+    def set_valid_from(self, obj, action: models.DiscountCodeSetValidFromAction):
         # real API always increments version, so always apply new value.
         new = copy.deepcopy(obj)
         new["validFrom"] = action.valid_from.isoformat()
         return new
 
-    def set_valid_until(
-            self, obj, action: models.DiscountCodeSetValidUntilAction
-    ):
+    def set_valid_until(self, obj, action: models.DiscountCodeSetValidUntilAction):
         # real API always increments version, so always apply new value.
         new = copy.deepcopy(obj)
         new["validUntil"] = action.valid_until.isoformat()
         return new
 
     def change_cart_discounts(
-            self, obj, action: models.DiscountCodeChangeCartDiscountsAction
+        self, obj, action: models.DiscountCodeChangeCartDiscountsAction
     ):
         # real API always increments version, so always apply new value.
         new = copy.deepcopy(obj)
-        new["cartDiscounts"] = [cart_discount.serialize() for cart_discount in action.cart_discounts]
+        new["cartDiscounts"] = [
+            cart_discount.serialize() for cart_discount in action.cart_discounts
+        ]
         return new
 
     _actions = {
@@ -94,5 +92,5 @@ class DiscountCodesBackend(ServiceBackend):
         ),
         "setValidFrom": set_valid_from,
         "setValidUntil": set_valid_until,
-        "changeCartDiscounts": change_cart_discounts
+        "changeCartDiscounts": change_cart_discounts,
     }

--- a/src/commercetools/testing/discount_codes.py
+++ b/src/commercetools/testing/discount_codes.py
@@ -12,7 +12,8 @@ from commercetools.platform.models._schemas.discount_code import (
 )
 from commercetools.testing import utils
 from commercetools.testing.abstract import BaseModel, ServiceBackend
-from commercetools.testing.utils import update_attribute
+from commercetools.testing.utils import update_attribute, update_datetime_attribute, \
+    update_nested_object_attribute
 
 
 class DiscountCodesModel(BaseModel):
@@ -59,28 +60,6 @@ class DiscountCodesBackend(ServiceBackend):
             ("^(?P<id>[^/]+)$", "POST", self.update_by_id),
         ]
 
-    def set_valid_from(self, obj, action: models.DiscountCodeSetValidFromAction):
-        # real API always increments version, so always apply new value.
-        new = copy.deepcopy(obj)
-        new["validFrom"] = action.valid_from.isoformat()
-        return new
-
-    def set_valid_until(self, obj, action: models.DiscountCodeSetValidUntilAction):
-        # real API always increments version, so always apply new value.
-        new = copy.deepcopy(obj)
-        new["validUntil"] = action.valid_until.isoformat()
-        return new
-
-    def change_cart_discounts(
-        self, obj, action: models.DiscountCodeChangeCartDiscountsAction
-    ):
-        # real API always increments version, so always apply new value.
-        new = copy.deepcopy(obj)
-        new["cartDiscounts"] = [
-            cart_discount.serialize() for cart_discount in action.cart_discounts
-        ]
-        return new
-
     _actions = {
         "changeIsActive": update_attribute("isActive", "is_active"),
         "setName": update_attribute("name", "name"),
@@ -90,7 +69,7 @@ class DiscountCodesBackend(ServiceBackend):
         "setMaxApplicationsPerCustomer": update_attribute(
             "maxApplicationsPerCustomer", "max_applications_per_customer"
         ),
-        "setValidFrom": set_valid_from,
-        "setValidUntil": set_valid_until,
-        "changeCartDiscounts": change_cart_discounts,
+        "setValidFrom": update_datetime_attribute("validFrom", "valid_from"),
+        "setValidUntil": update_datetime_attribute("validUntil", "valid_until"),
+        "changeCartDiscounts": update_nested_object_attribute("cartDiscounts", "cart_discounts"),
     }

--- a/src/commercetools/testing/discount_codes.py
+++ b/src/commercetools/testing/discount_codes.py
@@ -1,3 +1,4 @@
+import copy
 import datetime
 import typing
 import uuid
@@ -58,6 +59,30 @@ class DiscountCodesBackend(ServiceBackend):
             ("^(?P<id>[^/]+)$", "POST", self.update_by_id),
         ]
 
+    def set_valid_from(
+            self, obj, action: models.DiscountCodeSetValidFromAction
+    ):
+        # real API always increments version, so always apply new value.
+        new = copy.deepcopy(obj)
+        new["valid_from"] = action.valid_from.isoformat()
+        return new
+
+    def set_valid_until(
+            self, obj, action: models.DiscountCodeSetValidUntilAction
+    ):
+        # real API always increments version, so always apply new value.
+        new = copy.deepcopy(obj)
+        new["valid_until"] = action.valid_until.isoformat()
+        return new
+
+    def change_cart_discounts(
+            self, obj, action: models.DiscountCodeChangeCartDiscountsAction
+    ):
+        # real API always increments version, so always apply new value.
+        new = copy.deepcopy(obj)
+        new["cart_discounts"] = [cart_discount.serialize() for cart_discount in action.cart_discounts]
+        return new
+
     _actions = {
         "changeIsActive": update_attribute("isActive", "is_active"),
         "setName": update_attribute("name", "name"),
@@ -67,6 +92,7 @@ class DiscountCodesBackend(ServiceBackend):
         "setMaxApplicationsPerCustomer": update_attribute(
             "maxApplicationsPerCustomer", "max_applications_per_customer"
         ),
-        "setValidFrom": update_attribute("valid_from", "valid_from"),
-        "setValidUntil": update_attribute("valid_until", "valid_until")
+        "setValidFrom": set_valid_from,
+        "setValidUntil": set_valid_until,
+        "changeCartDiscounts": change_cart_discounts
     }

--- a/src/commercetools/testing/discount_codes.py
+++ b/src/commercetools/testing/discount_codes.py
@@ -12,8 +12,11 @@ from commercetools.platform.models._schemas.discount_code import (
 )
 from commercetools.testing import utils
 from commercetools.testing.abstract import BaseModel, ServiceBackend
-from commercetools.testing.utils import update_attribute, update_datetime_attribute, \
-    update_nested_object_attribute
+from commercetools.testing.utils import (
+    update_attribute,
+    update_datetime_attribute,
+    update_nested_object_attribute,
+)
 
 
 class DiscountCodesModel(BaseModel):
@@ -71,5 +74,7 @@ class DiscountCodesBackend(ServiceBackend):
         ),
         "setValidFrom": update_datetime_attribute("validFrom", "valid_from"),
         "setValidUntil": update_datetime_attribute("validUntil", "valid_until"),
-        "changeCartDiscounts": update_nested_object_attribute("cartDiscounts", "cart_discounts"),
+        "changeCartDiscounts": update_nested_object_attribute(
+            "cartDiscounts", "cart_discounts"
+        ),
     }

--- a/src/commercetools/testing/extensions.py
+++ b/src/commercetools/testing/extensions.py
@@ -1,3 +1,4 @@
+import copy
 import datetime
 import typing
 import uuid
@@ -51,6 +52,14 @@ class ExtensionsBackend(ServiceBackend):
             ("^key=(?P<key>[^/]+)$", "DELETE", self.delete_by_key),
         ]
 
+    def change_triggers(
+            self, obj, action: models.ExtensionChangeTriggersAction
+    ):
+        # real API always increments version, so always apply new value.
+        new = copy.deepcopy(obj)
+        new["triggers"] = [trigger.serialize() for trigger in action.triggers]
+        return new
+
     _actions = {
-        "changeTriggers": update_attribute("triggers", "triggers"),
+        "changeTriggers": change_triggers,
     }

--- a/src/commercetools/testing/extensions.py
+++ b/src/commercetools/testing/extensions.py
@@ -10,6 +10,7 @@ from commercetools.platform.models._schemas.extension import (
     ExtensionUpdateSchema,
 )
 from commercetools.testing.abstract import BaseModel, ServiceBackend
+from commercetools.testing.utils import update_attribute
 
 
 class ExtensionsModel(BaseModel):
@@ -49,3 +50,7 @@ class ExtensionsBackend(ServiceBackend):
             ("^(?P<id>[^/]+)$", "DELETE", self.delete_by_id),
             ("^key=(?P<key>[^/]+)$", "DELETE", self.delete_by_key),
         ]
+
+    _actions = {
+        "changeTriggers": update_attribute("triggers", "triggers"),
+    }

--- a/src/commercetools/testing/extensions.py
+++ b/src/commercetools/testing/extensions.py
@@ -52,9 +52,7 @@ class ExtensionsBackend(ServiceBackend):
             ("^key=(?P<key>[^/]+)$", "DELETE", self.delete_by_key),
         ]
 
-    def change_triggers(
-            self, obj, action: models.ExtensionChangeTriggersAction
-    ):
+    def change_triggers(self, obj, action: models.ExtensionChangeTriggersAction):
         # real API always increments version, so always apply new value.
         new = copy.deepcopy(obj)
         new["triggers"] = [trigger.serialize() for trigger in action.triggers]

--- a/src/commercetools/testing/extensions.py
+++ b/src/commercetools/testing/extensions.py
@@ -11,7 +11,7 @@ from commercetools.platform.models._schemas.extension import (
     ExtensionUpdateSchema,
 )
 from commercetools.testing.abstract import BaseModel, ServiceBackend
-from commercetools.testing.utils import update_attribute
+from commercetools.testing.utils import update_attribute, update_nested_object_attribute
 
 
 class ExtensionsModel(BaseModel):
@@ -59,5 +59,5 @@ class ExtensionsBackend(ServiceBackend):
         return new
 
     _actions = {
-        "changeTriggers": change_triggers,
+        "changeTriggers": update_nested_object_attribute("triggers", "triggers"),
     }

--- a/src/commercetools/testing/extensions.py
+++ b/src/commercetools/testing/extensions.py
@@ -52,12 +52,6 @@ class ExtensionsBackend(ServiceBackend):
             ("^key=(?P<key>[^/]+)$", "DELETE", self.delete_by_key),
         ]
 
-    def change_triggers(self, obj, action: models.ExtensionChangeTriggersAction):
-        # real API always increments version, so always apply new value.
-        new = copy.deepcopy(obj)
-        new["triggers"] = [trigger.serialize() for trigger in action.triggers]
-        return new
-
     _actions = {
         "changeTriggers": update_nested_object_attribute("triggers", "triggers"),
     }

--- a/src/commercetools/testing/utils.py
+++ b/src/commercetools/testing/utils.py
@@ -137,10 +137,12 @@ def update_nested_object_attribute(dst: str, src: str):
         if not isinstance(values, list):
             raise TypeError(f"Unsupported nested object type: f{type(values)}")
 
-        if obj.get(dst) != values:
+        items = [item.serialize() for item in values]
+        if items != obj.get(dst):
             new = copy.deepcopy(obj)
-            new[dst] = [item.serialize() for item in values]
+            new[dst] = items
             return new
+
         return obj
 
     return updater

--- a/src/commercetools/testing/utils.py
+++ b/src/commercetools/testing/utils.py
@@ -121,7 +121,7 @@ def update_datetime_attribute(dst: str, src: str):
         if not isinstance(value, datetime):
             raise TypeError(f"Unsupported datetime object type: f{type(value)}")
 
-        if obj.get(dst) != value:
+        if obj.get(dst) != value.isoformat():
             new = copy.deepcopy(obj)
             new[dst] = value.isoformat()
             return new
@@ -134,7 +134,7 @@ def update_nested_object_attribute(dst: str, src: str):
     def updater(self, obj, action):
         values = getattr(action, src)
 
-        if not isinstance(values, typing.List):
+        if not isinstance(values, list):
             raise TypeError(f"Unsupported nested object type: f{type(values)}")
 
         if obj.get(dst) != values:

--- a/src/commercetools/testing/utils.py
+++ b/src/commercetools/testing/utils.py
@@ -145,6 +145,7 @@ def update_nested_object_attribute(dst: str, src: str):
 
     return updater
 
+
 def update_enum_attribute(dst: str, src: str):
     def updater(self, obj, action):
         value = getattr(action, src).value

--- a/src/commercetools/testing/utils.py
+++ b/src/commercetools/testing/utils.py
@@ -3,6 +3,7 @@ import importlib
 import json
 import typing
 import uuid
+from datetime import datetime
 
 from marshmallow import Schema
 from requests_mock import create_response
@@ -112,6 +113,37 @@ def update_attribute(dst: str, src: str):
 
     return updater
 
+
+def update_datetime_attribute(dst: str, src: str):
+    def updater(self, obj, action):
+        value = getattr(action, src)
+
+        if not isinstance(value, datetime):
+            raise TypeError(f"Unsupported datetime object type: f{type(value)}")
+
+        if obj.get(dst) != value:
+            new = copy.deepcopy(obj)
+            new[dst] = value.isoformat()
+            return new
+        return obj
+
+    return updater
+
+
+def update_nested_object_attribute(dst: str, src: str):
+    def updater(self, obj, action):
+        values = getattr(action, src)
+
+        if not isinstance(values, typing.List):
+            raise TypeError(f"Unsupported nested object type: f{type(values)}")
+
+        if obj.get(dst) != values:
+            new = copy.deepcopy(obj)
+            new[dst] = [item.serialize() for item in values]
+            return new
+        return obj
+
+    return updater
 
 def update_enum_attribute(dst: str, src: str):
     def updater(self, obj, action):

--- a/tests/platform/test_service_cart_discounts.py
+++ b/tests/platform/test_service_cart_discounts.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 import pytest
 from requests.exceptions import HTTPError
 
@@ -90,3 +92,49 @@ def test_cart_discount_update(old_client):
     )
 
     assert cart_discount.is_active is False
+
+
+@pytest.mark.freeze_time("2021-03-01 12:34:56")
+def test_cart_discount_set_valid_from(old_client):
+    cart_discount = old_client.cart_discounts.create(
+        models.CartDiscountDraft(
+            name=models.LocalizedString(en="en-cart_discount"),
+            value=models.CartDiscountValueRelative(permyriad=10),
+            is_active=True,
+            cart_predicate="",
+            sort_order="",
+            requires_discount_code=False,
+        )
+    )
+    assert cart_discount.id
+
+    cart_discount = old_client.cart_discounts.update_by_id(
+        id=cart_discount.id,
+        version=cart_discount.version,
+        actions=[models.CartDiscountSetValidFromAction(valid_from=datetime.now())],
+    )
+
+    assert cart_discount.valid_from == datetime.now()
+
+
+@pytest.mark.freeze_time("2021-03-01 12:34:56")
+def test_cart_discount_set_valid_until(old_client):
+    cart_discount = old_client.cart_discounts.create(
+        models.CartDiscountDraft(
+            name=models.LocalizedString(en="en-cart_discount"),
+            value=models.CartDiscountValueRelative(permyriad=10),
+            is_active=True,
+            cart_predicate="",
+            sort_order="",
+            requires_discount_code=False,
+        )
+    )
+    assert cart_discount.id
+
+    cart_discount = old_client.cart_discounts.update_by_id(
+        id=cart_discount.id,
+        version=cart_discount.version,
+        actions=[models.CartDiscountSetValidUntilAction(valid_until=datetime.now())],
+    )
+
+    assert cart_discount.valid_until == datetime.now()

--- a/tests/platform/test_service_cart_discounts.py
+++ b/tests/platform/test_service_cart_discounts.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 
 import pytest
+from freezegun import freeze_time
 from requests.exceptions import HTTPError
 
 from commercetools.platform import models
@@ -94,7 +95,7 @@ def test_cart_discount_update(old_client):
     assert cart_discount.is_active is False
 
 
-@pytest.mark.freeze_time("2021-03-01 12:34:56")
+@freeze_time("2021-03-01 12:34:56")
 def test_cart_discount_set_valid_from(old_client):
     cart_discount = old_client.cart_discounts.create(
         models.CartDiscountDraft(
@@ -118,7 +119,7 @@ def test_cart_discount_set_valid_from(old_client):
     assert cart_discount.valid_from == datetime.now()
 
 
-@pytest.mark.freeze_time("2021-03-01 12:34:56")
+@freeze_time("2021-03-01 12:34:56")
 def test_cart_discount_set_valid_until(old_client):
     cart_discount = old_client.cart_discounts.create(
         models.CartDiscountDraft(

--- a/tests/platform/test_service_cart_discounts.py
+++ b/tests/platform/test_service_cart_discounts.py
@@ -107,6 +107,7 @@ def test_cart_discount_set_valid_from(old_client):
         )
     )
     assert cart_discount.id
+    assert cart_discount.valid_from is None
 
     cart_discount = old_client.cart_discounts.update_by_id(
         id=cart_discount.id,
@@ -130,6 +131,7 @@ def test_cart_discount_set_valid_until(old_client):
         )
     )
     assert cart_discount.id
+    assert cart_discount.valid_until is None
 
     cart_discount = old_client.cart_discounts.update_by_id(
         id=cart_discount.id,

--- a/tests/platform/test_service_cart_discounts.py
+++ b/tests/platform/test_service_cart_discounts.py
@@ -114,7 +114,7 @@ def test_cart_discount_set_valid_from(old_client):
         actions=[models.CartDiscountSetValidFromAction(valid_from=datetime.now())],
     )
 
-    assert cart_discount.valid_from == datetime.now()
+    assert cart_discount.valid_from == datetime.now().isoformat()
 
 
 @pytest.mark.freeze_time("2021-03-01 12:34:56")
@@ -137,4 +137,4 @@ def test_cart_discount_set_valid_until(old_client):
         actions=[models.CartDiscountSetValidUntilAction(valid_until=datetime.now())],
     )
 
-    assert cart_discount.valid_until == datetime.now()
+    assert cart_discount.valid_until == datetime.now().isoformat()

--- a/tests/platform/test_service_cart_discounts.py
+++ b/tests/platform/test_service_cart_discounts.py
@@ -114,7 +114,7 @@ def test_cart_discount_set_valid_from(old_client):
         actions=[models.CartDiscountSetValidFromAction(valid_from=datetime.now())],
     )
 
-    assert cart_discount.valid_from == datetime.now().isoformat()
+    assert cart_discount.valid_from == datetime.now()
 
 
 @pytest.mark.freeze_time("2021-03-01 12:34:56")
@@ -137,4 +137,4 @@ def test_cart_discount_set_valid_until(old_client):
         actions=[models.CartDiscountSetValidUntilAction(valid_until=datetime.now())],
     )
 
-    assert cart_discount.valid_until == datetime.now().isoformat()
+    assert cart_discount.valid_until == datetime.now()

--- a/tests/platform/test_service_discount_codes.py
+++ b/tests/platform/test_service_discount_codes.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 import pytest
 from requests.exceptions import HTTPError
 
@@ -69,3 +71,47 @@ def test_discount_code_update(old_client):
     )
 
     assert discount_code.is_active is False
+
+
+@pytest.mark.freeze_time("2021-03-01 12:34:56")
+def test_discount_code_set_valid_from(old_client):
+    discount_code = old_client.discount_codes.create(
+        models.DiscountCodeDraft(
+            name=models.LocalizedString(en="en-discount_code"),
+            code="1337",
+            is_active=True,
+            cart_discounts=[],
+        )
+    )
+    assert discount_code.id
+    assert discount_code.valid_from is None
+
+    discount_code = old_client.discount_codes.update_by_id(
+        id=discount_code.id,
+        version=discount_code.version,
+        actions=[models.DiscountCodeSetValidFromAction(valid_from=datetime.now())],
+    )
+
+    assert discount_code.valid_from == datetime.now()
+
+
+@pytest.mark.freeze_time("2021-03-01 12:34:56")
+def test_discount_code_set_valid_until(old_client):
+    discount_code = old_client.discount_codes.create(
+        models.DiscountCodeDraft(
+            name=models.LocalizedString(en="en-discount_code"),
+            code="1337",
+            is_active=True,
+            cart_discounts=[],
+        )
+    )
+    assert discount_code.id
+    assert discount_code.valid_until is None
+
+    discount_code = old_client.discount_codes.update_by_id(
+        id=discount_code.id,
+        version=discount_code.version,
+        actions=[models.DiscountCodeSetValidUntilAction(valid_until=datetime.now())],
+    )
+
+    assert discount_code.valid_until == datetime.now()

--- a/tests/platform/test_service_discount_codes.py
+++ b/tests/platform/test_service_discount_codes.py
@@ -144,10 +144,16 @@ def test_discount_code_change_cart_discounts(old_client):
     discount_code = old_client.discount_codes.update_by_id(
         id=discount_code.id,
         version=discount_code.version,
-        actions=[models.DiscountCodeChangeCartDiscountsAction(
-            cart_discounts=[models.CartDiscountResourceIdentifier(id=cart_discount.id)]
-        )],
+        actions=[
+            models.DiscountCodeChangeCartDiscountsAction(
+                cart_discounts=[
+                    models.CartDiscountResourceIdentifier(id=cart_discount.id)
+                ]
+            )
+        ],
     )
 
     assert discount_code.version == 2
-    assert discount_code.cart_discounts == [models.CartDiscountReference(id=cart_discount.id)]
+    assert discount_code.cart_discounts == [
+        models.CartDiscountReference(id=cart_discount.id)
+    ]

--- a/tests/platform/test_service_discount_codes.py
+++ b/tests/platform/test_service_discount_codes.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 
 import pytest
+from freezegun import freeze_time
 from requests.exceptions import HTTPError
 
 from commercetools.platform import models
@@ -73,7 +74,7 @@ def test_discount_code_update(old_client):
     assert discount_code.is_active is False
 
 
-@pytest.mark.freeze_time("2021-03-01 12:34:56")
+@freeze_time("2021-03-01 12:34:56")
 def test_discount_code_set_valid_from(old_client):
     discount_code = old_client.discount_codes.create(
         models.DiscountCodeDraft(
@@ -95,7 +96,7 @@ def test_discount_code_set_valid_from(old_client):
     assert discount_code.valid_from == datetime.now()
 
 
-@pytest.mark.freeze_time("2021-03-01 12:34:56")
+@freeze_time("2021-03-01 12:34:56")
 def test_discount_code_set_valid_until(old_client):
     discount_code = old_client.discount_codes.create(
         models.DiscountCodeDraft(

--- a/tests/platform/test_service_discount_codes.py
+++ b/tests/platform/test_service_discount_codes.py
@@ -73,7 +73,7 @@ def test_discount_code_update(old_client):
     assert discount_code.is_active is False
 
 
-@pytest.mark.freeze_time("2021-03-01")
+@pytest.mark.freeze_time("2021-03-01 12:34:56")
 def test_discount_code_set_valid_from(old_client):
     discount_code = old_client.discount_codes.create(
         models.DiscountCodeDraft(
@@ -95,7 +95,7 @@ def test_discount_code_set_valid_from(old_client):
     assert discount_code.valid_from == datetime.now()
 
 
-@pytest.mark.freeze_time("2021-03-01")
+@pytest.mark.freeze_time("2021-03-01 12:34:56")
 def test_discount_code_set_valid_until(old_client):
     discount_code = old_client.discount_codes.create(
         models.DiscountCodeDraft(
@@ -115,7 +115,7 @@ def test_discount_code_set_valid_until(old_client):
     )
 
     assert discount_code.version == 2
-    assert discount_code.valid_until == datetime.now().isoformat()
+    assert discount_code.valid_until == datetime.now()
 
 
 def test_discount_code_change_cart_discounts(old_client):
@@ -150,4 +150,4 @@ def test_discount_code_change_cart_discounts(old_client):
     )
 
     assert discount_code.version == 2
-    assert discount_code.cart_discounts == cart_discount
+    assert discount_code.cart_discounts == [models.CartDiscountReference(id=cart_discount.id)]

--- a/tests/platform/test_service_discount_codes.py
+++ b/tests/platform/test_service_discount_codes.py
@@ -73,7 +73,7 @@ def test_discount_code_update(old_client):
     assert discount_code.is_active is False
 
 
-@pytest.mark.freeze_time("2021-03-01 12:34:56")
+@pytest.mark.freeze_time("2021-03-01")
 def test_discount_code_set_valid_from(old_client):
     discount_code = old_client.discount_codes.create(
         models.DiscountCodeDraft(
@@ -95,7 +95,7 @@ def test_discount_code_set_valid_from(old_client):
     assert discount_code.valid_from == datetime.now()
 
 
-@pytest.mark.freeze_time("2021-03-01 12:34:56")
+@pytest.mark.freeze_time("2021-03-01")
 def test_discount_code_set_valid_until(old_client):
     discount_code = old_client.discount_codes.create(
         models.DiscountCodeDraft(
@@ -114,4 +114,40 @@ def test_discount_code_set_valid_until(old_client):
         actions=[models.DiscountCodeSetValidUntilAction(valid_until=datetime.now())],
     )
 
-    assert discount_code.valid_until == datetime.now()
+    assert discount_code.version == 2
+    assert discount_code.valid_until == datetime.now().isoformat()
+
+
+def test_discount_code_change_cart_discounts(old_client):
+    discount_code = old_client.discount_codes.create(
+        models.DiscountCodeDraft(
+            name=models.LocalizedString(en="en-discount_code"),
+            code="1337",
+            is_active=True,
+            cart_discounts=[],
+        )
+    )
+    assert discount_code.id
+    assert discount_code.cart_discounts == []
+
+    cart_discount = old_client.cart_discounts.create(
+        models.CartDiscountDraft(
+            name=models.LocalizedString(en="cart-discount-test"),
+            value=models.CartDiscountValueDraft(type="absolute"),
+            cart_predicate="sku",
+            sort_order="1",
+            requires_discount_code=True,
+        )
+    )
+    assert cart_discount.id
+
+    discount_code = old_client.discount_codes.update_by_id(
+        id=discount_code.id,
+        version=discount_code.version,
+        actions=[models.DiscountCodeChangeCartDiscountsAction(
+            cart_discounts=[models.CartDiscountResourceIdentifier(id=cart_discount.id)]
+        )],
+    )
+
+    assert discount_code.version == 2
+    assert discount_code.cart_discounts == cart_discount

--- a/tests/platform/test_service_extensions.py
+++ b/tests/platform/test_service_extensions.py
@@ -26,3 +26,31 @@ def test_extension_get_by_id(old_client):
 
     extension = old_client.extensions.get_by_id(extension.id)
     assert extension.id
+
+
+def test_extension_update_change_triggers(old_client):
+    extension = old_client.extensions.create(models.ExtensionDraft(
+            destination=models.ExtensionAWSLambdaDestination(
+                arn="arn:", access_key="access", access_secret="secret"
+            ),
+            triggers=[],
+        )
+    )
+    assert extension.id
+    assert extension.triggers == []
+
+    extension = old_client.extensions.update_by_id(
+        id=extension.id,
+        version=extension.version,
+        actions=[
+            models.ExtensionChangeTriggersAction(
+                triggers=[models.ExtensionTrigger(
+                    resource_type_id=models.ExtensionResourceTypeId.CART,
+                    actions=[models.ExtensionAction.CREATE, models.ExtensionAction.UPDATE]
+                )]
+        )
+    ])
+    assert extension.triggers == [models.ExtensionTrigger(
+                resource_type_id=models.ExtensionResourceTypeId.CART,
+                actions=[models.ExtensionAction.CREATE, models.ExtensionAction.UPDATE]
+            )]

--- a/tests/platform/test_service_extensions.py
+++ b/tests/platform/test_service_extensions.py
@@ -29,7 +29,8 @@ def test_extension_get_by_id(old_client):
 
 
 def test_extension_update_change_triggers(old_client):
-    extension = old_client.extensions.create(models.ExtensionDraft(
+    extension = old_client.extensions.create(
+        models.ExtensionDraft(
             destination=models.ExtensionAWSLambdaDestination(
                 arn="arn:", access_key="access", access_secret="secret"
             ),
@@ -44,13 +45,21 @@ def test_extension_update_change_triggers(old_client):
         version=extension.version,
         actions=[
             models.ExtensionChangeTriggersAction(
-                triggers=[models.ExtensionTrigger(
-                    resource_type_id=models.ExtensionResourceTypeId.CART,
-                    actions=[models.ExtensionAction.CREATE, models.ExtensionAction.UPDATE]
-                )]
+                triggers=[
+                    models.ExtensionTrigger(
+                        resource_type_id=models.ExtensionResourceTypeId.CART,
+                        actions=[
+                            models.ExtensionAction.CREATE,
+                            models.ExtensionAction.UPDATE,
+                        ],
+                    )
+                ]
+            )
+        ],
+    )
+    assert extension.triggers == [
+        models.ExtensionTrigger(
+            resource_type_id=models.ExtensionResourceTypeId.CART,
+            actions=[models.ExtensionAction.CREATE, models.ExtensionAction.UPDATE],
         )
-    ])
-    assert extension.triggers == [models.ExtensionTrigger(
-                resource_type_id=models.ExtensionResourceTypeId.CART,
-                actions=[models.ExtensionAction.CREATE, models.ExtensionAction.UPDATE]
-            )]
+    ]

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -1,6 +1,7 @@
 import pytest
 
 from commercetools import paginators
+from commercetools.contrib.pytest import ct_platform_client
 from commercetools.platform import models
 from commercetools.platform.client import Client
 from commercetools.platform.client.by_project_key_request_builder import (

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -1,7 +1,6 @@
 import pytest
 
 from commercetools import paginators
-from commercetools.contrib.pytest import ct_platform_client
 from commercetools.platform import models
 from commercetools.platform.client import Client
 from commercetools.platform.client.by_project_key_request_builder import (


### PR DESCRIPTION
Some actions are missing from the mocking backend which hinders proper mock testing for the commercetools terraform provider

* Add setalidFrom and setValidUntil actions for CartDiscounts and DiscountCodes
* Add changeCartDiscounts action for Discount Code 
* Add changeTriggers for API extensions